### PR TITLE
bootstrap: always generate a fresh password on every run

### DIFF
--- a/virtual-private-node.sh
+++ b/virtual-private-node.sh
@@ -242,18 +242,23 @@ download() {
 }
 
 # ── Create admin user ───────────────────────────────────────
+#
+# A fresh random password is generated on every run. On a
+# re-run after a partial failure, this replaces the existing
+# password so the final summary always prints a usable one.
+
+set +o pipefail
+PASSWORD=$(LC_ALL=C tr -dc 'A-Za-z0-9' < /dev/urandom | head -c 25)
+set -o pipefail
+if [ ${#PASSWORD} -lt 25 ]; then
+    echo "ERROR: Failed to generate secure password."
+    exit 1
+fi
 
 if id "$ADMIN_USER" &>/dev/null; then
-    echo "  User $ADMIN_USER already exists, skipping."
-    PASSWORD="(unchanged)"
+    echo "$ADMIN_USER:$PASSWORD" | chpasswd
+    echo "  ✓ User $ADMIN_USER exists — password reset"
 else
-    set +o pipefail
-    PASSWORD=$(LC_ALL=C tr -dc 'A-Za-z0-9' < /dev/urandom | head -c 25)
-    set -o pipefail
-    if [ ${#PASSWORD} -lt 25 ]; then
-        echo "ERROR: Failed to generate secure password."
-        exit 1
-    fi
     adduser --disabled-password --gecos "Virtual Private Node" "$ADMIN_USER"
     echo "$ADMIN_USER:$PASSWORD" | chpasswd
     echo "  ✓ Created user $ADMIN_USER"


### PR DESCRIPTION
Previously, re-running the bootstrap after a partial failure would print Password: (unchanged) in the final summary because the existing-user branch set PASSWORD to a literal placeholder instead of resetting the password. Users who didn't scroll up to catch the original password on the first run (which crashed before printing the summary) had no recoverable way to log in as ripsline without key auth.

Move password generation out of the if/else so it runs on every invocation. On a fresh run, the generated password is applied to the new user via chpasswd as before. On a re-run, the existing user's password is reset to the new value via the same chpasswd call. The final summary always prints a usable password, and key auth (when a key was copied) is unaffected.