### PR TITLE
fix: unconfirmed UTXO spending, in-flight UX consistency, deprecations

### DIFF
--- a/internal/installer/lndhub.go
+++ b/internal/installer/lndhub.go
@@ -113,6 +113,12 @@ func createLndHubDatabase(dbPassword string) error {
 	return nil
 }
 
+// ── Git ─────────────────────────────────────────────────
+
+func installGit() error {
+	return system.SudoRun("apt-get", "install", "-y", "-qq", "git")
+}
+
 // ── Build from source ────────────────────────────────────
 
 // lndhubBuildDir holds the temp directory used across clone/build/install.

--- a/internal/installer/setup.go
+++ b/internal/installer/setup.go
@@ -483,6 +483,8 @@ func LndHubInstallSteps(
 			Fn: func() error {
 				return createLndHubDatabase(dbPassword)
 			}},
+		{Name: "Installing git",
+			Fn: installGit},
 		{Name: "Cloning lndhub.go v" + lndhubVersion,
 			Fn: cloneLndHub},
 		{Name: "Building lndhub (from source)",

--- a/internal/lndrpc/invoices.go
+++ b/internal/lndrpc/invoices.go
@@ -253,7 +253,7 @@ func (c *Client) ListPayments(limit uint64) ([]PaymentEntry, error) {
 			AmountSats:     pay.GetValueSat(),
 			FeeSats:        pay.GetFeeSat(),
 			Status:         pay.GetStatus().String(),
-			CreationDate:   pay.GetCreationDate(),
+			CreationDate:   pay.GetCreationTimeNs() / 1_000_000_000,
 			Preimage:       pay.GetPaymentPreimage(),
 			PaymentRequest: pay.GetPaymentRequest(),
 			IsIncoming:     false,

--- a/internal/lndrpc/onchain.go
+++ b/internal/lndrpc/onchain.go
@@ -141,10 +141,12 @@ func (c *Client) SendCoins(
 	defer cancel()
 
 	req := &lnrpc.SendCoinsRequest{
-		Addr:        address,
-		Amount:      amountSats,
-		SatPerVbyte: uint64(satPerVbyte),
-		SendAll:     sendAll,
+		Addr:             address,
+		Amount:           amountSats,
+		SatPerVbyte:      uint64(satPerVbyte),
+		SendAll:          sendAll,
+		MinConfs:         0,
+		SpendUnconfirmed: true,
 	}
 
 	// Coin control: restrict inputs to selected UTXOs

--- a/internal/lndrpc/queries.go
+++ b/internal/lndrpc/queries.go
@@ -453,8 +453,8 @@ func (c *Client) OpenChannel(pubkey string, localAmount int64, private bool, tap
 		NodePubkey:         pubkeyBytes,
 		LocalFundingAmount: localAmount,
 		Private:            private,
-		MinConfs:           1,
-		SpendUnconfirmed:   false,
+		MinConfs:           0,
+		SpendUnconfirmed:   true,
 		ScidAlias:          private,
 	}
 	if taproot {

--- a/internal/welcome/screen_channels_open.go
+++ b/internal/welcome/screen_channels_open.go
@@ -148,7 +148,7 @@ func (s *ChannelOpenScreen) View(w, h int) string {
 	case coStepConfirm:
 		return s.viewConfirm(w, h)
 	case coStepOpening:
-		return s.viewOpening(w)
+		return s.viewOpening(w, h)
 	case coStepResult:
 		return s.viewResult(w)
 	}
@@ -165,7 +165,7 @@ func (s *ChannelOpenScreen) HelpBindings() []key.Binding {
 		return actionButtonBindings(
 			s.confirmBtnIdx, s.ctx.HasTabs)
 	case coStepOpening:
-		return waitingBindings()
+		return inFlightBindings()
 	case coStepResult:
 		return resultBindings(s.ctx.HasTabs)
 	}
@@ -697,9 +697,7 @@ func (s *ChannelOpenScreen) backToInput() {
 func (s *ChannelOpenScreen) handleOpeningKey(
 	keyStr string,
 ) (Screen, tea.Cmd) {
-	if keyStr == "ctrl+c" {
-		return s, tea.Quit
-	}
+	// Fund-moving operation in progress — block all keys.
 	return s, nil
 }
 
@@ -765,6 +763,9 @@ func (s *ChannelOpenScreen) handleOpenResult(
 		s.error = ""
 	}
 	s.step = coStepResult
+	if msg.err == nil {
+		return s, emitRefreshStatus
+	}
 	return s, nil
 }
 
@@ -1241,7 +1242,7 @@ func (s *ChannelOpenScreen) viewConfirm(
 }
 
 func (s *ChannelOpenScreen) viewOpening(
-	w int,
+	w, h int,
 ) string {
 	p := newPane(w)
 	p.title(theme.Header, "Opening Channel...")
@@ -1250,7 +1251,8 @@ func (s *ChannelOpenScreen) viewOpening(
 	p.blank()
 	p.dim("May take up to 2 minutes over Tor.")
 	p.dim("Do not close the terminal.")
-	return p.render()
+	return p.renderWithBottomButtons(
+		[]string{"Opening..."}, 0, false, h)
 }
 
 func (s *ChannelOpenScreen) viewResult(

--- a/internal/welcome/screen_install_progress.go
+++ b/internal/welcome/screen_install_progress.go
@@ -7,6 +7,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/ripsline/virtual-private-node/internal/installer"
+	"github.com/ripsline/virtual-private-node/internal/logger"
 	"github.com/ripsline/virtual-private-node/internal/theme"
 )
 
@@ -113,6 +114,9 @@ func (s *InstallProgressScreen) HandleMsg(
 			s.steps[msg.index].Err = msg.err
 			s.failed = true
 			s.done = true
+			logger.Install("step %d/%d failed: %s: %v",
+				msg.index+1, len(s.steps),
+				s.steps[msg.index].Name, msg.err)
 			if s.onFail != nil {
 				return s, s.onFail()
 			}
@@ -164,9 +168,8 @@ func (s *InstallProgressScreen) View(
 
 		if step.Status == installer.StepFailed &&
 			step.Err != nil {
-			p.line(" " + theme.Warn.Render(
-				fmt.Sprintf("    Error: %v",
-					step.Err)))
+			p.warnWrap(fmt.Sprintf(
+				"    Error: %v", step.Err))
 		}
 	}
 
@@ -185,8 +188,9 @@ func (s *InstallProgressScreen) View(
 			s.ctx.ContentFocused, h)
 	}
 
-	p.dim("Installing... please wait")
-	return p.render()
+	p.dim("Do not close the terminal.")
+	return p.renderWithBottomButtons(
+		[]string{"Installing..."}, 0, false, h)
 }
 
 // ── HelpBindings ────────────────────────────────────────
@@ -195,5 +199,5 @@ func (s *InstallProgressScreen) HelpBindings() []key.Binding {
 	if s.done {
 		return resultBindings(s.ctx.HasTabs)
 	}
-	return waitingBindings()
+	return inFlightBindings()
 }

--- a/internal/welcome/update.go
+++ b/internal/welcome/update.go
@@ -767,6 +767,9 @@ func (m Model) previewSection(
 	sec int,
 ) (tea.Model, tea.Cmd) {
 	switch sec {
+	case secChannels:
+		return m,
+			fetchStatus(m.cfg, m.lndClient)
 	case secWallet:
 		return m,
 			fetchPaymentHistoryCmd(m.lndClient)


### PR DESCRIPTION
In-flight screens:
- Block ctrl+c during channel open (missed in #7)
- Add Opening... and Installing... bottom buttons to match send/close screens (Broadcasting.../Sending.../Closing...)
- Swap helpbar to inFlightBindings on channel open + install progress
- Wrap install errors with warnWrap for full visibility
- Log install step failures to /var/log/rlvpn.log

Unconfirmed UTXOs (#51):
- Set MinConfs: 0, SpendUnconfirmed: true on SendCoins and OpenChannel, matching Sparrow wallet behavior

Channel open refresh:
- Emit refreshStatusMsg on successful channel open so pending channel appears on channels home immediately
- Add secChannels to previewSection so sidebar navigation triggers a status refresh

Deprecation cleanup (#54):
- Replace pay.GetCreationDate() with GetCreationTimeNs() / 1e9

LndHub fix:
- Add git as install dependency before clone step