### PR TITLE
fix: route peer alias in payment history + background pkg update

### DIFF
--- a/internal/lndrpc/invoices.go
+++ b/internal/lndrpc/invoices.go
@@ -274,6 +274,10 @@ func (c *Client) ListPayments(limit uint64) ([]PaymentEntry, error) {
 				break // use first successful route
 			}
 		}
+		for i := range entry.Hops {
+			entry.Hops[i].Alias = c.getPeerAlias(
+				entry.Hops[i].PubKey)
+		}
 
 		// Decode payment request for memo
 		if entry.PaymentRequest != "" && c.rpc() != nil {

--- a/internal/lndrpc/payments.go
+++ b/internal/lndrpc/payments.go
@@ -132,13 +132,3 @@ func (c *Client) WaitForInvoiceSettlement(
 	}
 	return inv, nil
 }
-
-// ResolveRouteAliases fills in the Alias field for each hop.
-func (c *Client) ResolveRouteAliases(hops []RouteHop) []RouteHop {
-	for i := range hops {
-		if hops[i].Alias == "" {
-			hops[i].Alias = c.getPeerAlias(hops[i].PubKey)
-		}
-	}
-	return hops
-}

--- a/internal/welcome/cmds.go
+++ b/internal/welcome/cmds.go
@@ -535,18 +535,24 @@ func runUpdatePackagesCmd() tea.Cmd {
 	//     skipping the pink dpkg prompt
 	// This matches the bootstrap script's Phase 1
 	// upgrade command exactly.
-	c := exec.Command("bash", "-c",
-		"sudo DEBIAN_FRONTEND=noninteractive "+
-			"NEEDRESTART_MODE=a "+
-			"apt-get update -qq && "+
-			"sudo DEBIAN_FRONTEND=noninteractive "+
-			"NEEDRESTART_MODE=a "+
-			"apt-get upgrade -y -qq "+
-			"-o Dpkg::Options::=--force-confdef "+
-			"-o Dpkg::Options::=--force-confold")
-	return tea.ExecProcess(c, func(err error) tea.Msg {
-		return svcActionDoneMsg{}
-	})
+	return func() tea.Msg {
+		logger.Install("Update packages started")
+		err := system.SudoRun("bash", "-c",
+			"DEBIAN_FRONTEND=noninteractive "+
+				"NEEDRESTART_MODE=a "+
+				"apt-get update -qq && "+
+				"DEBIAN_FRONTEND=noninteractive "+
+				"NEEDRESTART_MODE=a "+
+				"apt-get upgrade -y -qq "+
+				"-o Dpkg::Options::=--force-confdef "+
+				"-o Dpkg::Options::=--force-confold")
+		if err != nil {
+			logger.Install("Update packages failed: %v", err)
+		} else {
+			logger.Install("Update packages completed")
+		}
+		return pkgUpdateDoneMsg{}
+	}
 }
 
 func runRebootCmd() tea.Cmd {

--- a/internal/welcome/model.go
+++ b/internal/welcome/model.go
@@ -99,6 +99,7 @@ type feeTier struct {
 }
 
 type svcActionDoneMsg struct{}
+type pkgUpdateDoneMsg struct{}
 type tickMsg time.Time
 type latestVersionMsg string
 

--- a/internal/welcome/screen_system_home.go
+++ b/internal/welcome/screen_system_home.go
@@ -53,7 +53,8 @@ type SystemHomeScreen struct {
 	sysConfirm string // "Update packages", "Reboot"
 
 	// Background service action in progress
-	svcPending string // "restarting...", "stopping...", "starting..."
+	svcPending  string // "restarting...", "stopping...", "starting..."
+	pkgUpdating bool   // true while apt-get runs in background
 }
 
 func NewSystemHomeScreen(
@@ -216,7 +217,9 @@ func (s *SystemHomeScreen) HandleKey(
 			s.btnIdx < len(actions) {
 			switch actions[s.btnIdx] {
 			case sysBtnUpdatePkg:
-				s.sysConfirm = "Update packages"
+				if !s.pkgUpdating {
+					s.sysConfirm = "Update packages"
+				}
 			case sysBtnSSHKeys:
 				screen := NewSSHKeysScreen(s.ctx)
 				return s, func() tea.Msg {
@@ -278,6 +281,7 @@ func (s *SystemHomeScreen) handleSysConfirm(
 		if action == "Reboot" {
 			return s, runRebootCmd()
 		}
+		s.pkgUpdating = true
 		return s, runUpdatePackagesCmd()
 	}
 	return s, nil
@@ -289,6 +293,8 @@ func (s *SystemHomeScreen) HandleMsg(
 	switch msg.(type) {
 	case svcActionDoneMsg:
 		s.svcPending = ""
+	case pkgUpdateDoneMsg:
+		s.pkgUpdating = false
 	}
 	return s, nil
 }
@@ -720,6 +726,9 @@ func (s *SystemHomeScreen) buttonLabels() []string {
 	labels := make([]string, len(actions))
 	for i, a := range actions {
 		labels[i] = sysBtnLabel[a]
+		if a == sysBtnUpdatePkg && s.pkgUpdating {
+			labels[i] = "Updating..."
+		}
 	}
 	return labels
 }

--- a/internal/welcome/update.go
+++ b/internal/welcome/update.go
@@ -260,6 +260,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case svcActionDoneMsg:
 		m.routeToSectionScreen(secSystem, msg)
 		return m, fetchStatus(m.cfg, m.lndClient)
+	case pkgUpdateDoneMsg:
+		m.routeToSectionScreen(secSystem, msg)
+		return m, fetchStatus(m.cfg, m.lndClient)
 	case statusMsg:
 		m.fetchInFlight = false
 		m.status = &msg


### PR DESCRIPTION
Resolve peer aliases on historical payment hops in ListPayments(), matching SendPayment() pattern. Remove unused ResolveRouteAliases().

Convert Update Packages from tea.ExecProcess (TUI suspension) to background tea.Cmd via system.SudoRun. Button shows Updating... while running, blocks re-press. Dedicated pkgUpdateDoneMsg avoids race with svcActionDoneMsg. Log start/completion/failure to rlvpn.log.