### PR TITLE
fix: right-arrow phantom increment on pre-wallet home screens

### DIFF
--- a/internal/welcome/screen_channels_home.go
+++ b/internal/welcome/screen_channels_home.go
@@ -73,6 +73,8 @@ func (s *ChannelsHomeScreen) HandleKey(
 		return s, emitFocusSidebar
 	case "right":
 		if s.focusZone == chanHomeZoneButtons &&
+			s.ctx.Cfg.HasLND() &&
+			s.ctx.Cfg.WalletExists() &&
 			s.btnIdx < 2 {
 			s.btnIdx++
 		}

--- a/internal/welcome/screen_offchain_home.go
+++ b/internal/welcome/screen_offchain_home.go
@@ -64,6 +64,8 @@ func (s *WalletHomeScreen) HandleKey(
 		return s, emitFocusSidebar
 	case "right":
 		if s.focusZone == walletHomeZoneButtons &&
+			s.ctx.Cfg.HasLND() &&
+			s.ctx.Cfg.WalletExists() &&
 			s.btnIdx < 2 {
 			s.btnIdx++
 		}

--- a/internal/welcome/screen_onchain_home.go
+++ b/internal/welcome/screen_onchain_home.go
@@ -140,7 +140,9 @@ func (s *OnChainHomeScreen) handleRight() (
 ) {
 	switch s.focusZone {
 	case ocHomeZoneButtons:
-		if s.btnIdx < 1 {
+		if s.ctx.Cfg.HasLND() &&
+			s.ctx.Cfg.WalletExists() &&
+			s.btnIdx < 1 {
 			s.btnIdx++
 		}
 	case ocHomeZoneUtxos:


### PR DESCRIPTION
All three section home screens (Channels, Wallet, On-Chain) allowed btnIdx to increment via right-arrow in the pre-wallet state, where only the single Create Wallet button is rendered. The View gates on HasLND/WalletExists to choose between single-button and multi-button layout, but HandleKey had no matching gate — btnIdx moved to positions that only exist in the multi-button layout, requiring extra left presses to reach sidebar.

Add HasLND() && WalletExists() guard to the right-arrow increment condition on all three screens.