### PR TITLE
fix: switch receive address to P2TR for wallet consistency

### DIFF
--- a/internal/lndrpc/queries.go
+++ b/internal/lndrpc/queries.go
@@ -349,7 +349,7 @@ func (c *Client) GetNewAddress() (*OnChainAddress, error) {
 	defer cancel()
 
 	resp, err := rpc.NewAddress(ctx, &lnrpc.NewAddressRequest{
-		Type: lnrpc.AddressType_WITNESS_PUBKEY_HASH,
+		Type: lnrpc.AddressType_TAPROOT_PUBKEY,
 	})
 	if err != nil {
 		c.handleError(err)

--- a/internal/welcome/inputs.go
+++ b/internal/welcome/inputs.go
@@ -162,7 +162,7 @@ func newSyncthingIDInput() textinput.Model {
 
 func newOnChainAddrInput() textinput.Model {
 	ti := textinput.New()
-	ti.Placeholder = "bc1q..."
+	ti.Placeholder = "bc1p..."
 	ti.CharLimit = 90
 	ti.SetWidth(62)
 	ti.Validate = validateOnChainAddr


### PR DESCRIPTION
Production testing on LND v0.20.0-beta confirmed that all internally generated addresses (SendCoins change, cooperative close delivery, sweeper outputs) use P2TR. Receive addresses should match to eliminate change-detection fingerprints on outgoing transactions. Aligns with LND's migration toward P2TR across all wallet operations.

Update send address placeholder to match (bc1q → bc1p).