### PR TITLE
feature: channel open coin control

### DIFF
--- a/internal/lndrpc/client_test.go
+++ b/internal/lndrpc/client_test.go
@@ -78,7 +78,7 @@ func TestNilClientSafety(t *testing.T) {
 	if err := c.ConnectPeer("a", "b"); err == nil {
 		t.Error("should error")
 	}
-	if _, err := c.OpenChannel("a", 100000, false, false); err == nil {
+	if _, err := c.OpenChannel("a", 100000, false, false, nil, false, 0); err == nil {
 		t.Error("should error")
 	}
 }

--- a/internal/lndrpc/queries.go
+++ b/internal/lndrpc/queries.go
@@ -453,13 +453,15 @@ func (c *Client) OpenChannel(pubkey string, localAmount int64, private bool, tap
 	defer cancel()
 
 	req := &lnrpc.OpenChannelRequest{
-		NodePubkey:         pubkeyBytes,
-		LocalFundingAmount: localAmount,
-		Private:            private,
-		MinConfs:           0,
-		SpendUnconfirmed:   true,
-		ScidAlias:          private,
-		FundMax:            fundMax,
+		NodePubkey:       pubkeyBytes,
+		Private:          private,
+		MinConfs:         0,
+		SpendUnconfirmed: true,
+		ScidAlias:        private,
+		FundMax:          fundMax,
+	}
+	if !fundMax {
+		req.LocalFundingAmount = localAmount
 	}
 	if taproot {
 		req.CommitmentType = lnrpc.CommitmentType_SIMPLE_TAPROOT

--- a/internal/lndrpc/queries.go
+++ b/internal/lndrpc/queries.go
@@ -434,8 +434,11 @@ func (c *Client) WaitForPeer(pubkey string, timeout time.Duration) error {
 
 // OpenChannel opens a channel to a peer. This is a fund-moving operation.
 // The caller MUST verify the peer is connected and show a confirmation
-// dialog before calling this.
-func (c *Client) OpenChannel(pubkey string, localAmount int64, private bool, taproot bool) (*ChannelOpenResult, error) {
+// dialog before calling this. When outpoints is non-empty, only those
+// UTXOs are used to fund the channel (coin control). When fundMax is
+// true, the entire selected balance (minus fees) funds the channel,
+// producing no change output.
+func (c *Client) OpenChannel(pubkey string, localAmount int64, private bool, taproot bool, outpoints []string, fundMax bool, satPerVbyte uint64) (*ChannelOpenResult, error) {
 	rpc := c.rpc()
 	if rpc == nil {
 		return nil, errNotConnected
@@ -456,10 +459,35 @@ func (c *Client) OpenChannel(pubkey string, localAmount int64, private bool, tap
 		MinConfs:           0,
 		SpendUnconfirmed:   true,
 		ScidAlias:          private,
+		FundMax:            fundMax,
 	}
 	if taproot {
 		req.CommitmentType = lnrpc.CommitmentType_SIMPLE_TAPROOT
 	}
+	if satPerVbyte > 0 {
+		req.SatPerVbyte = satPerVbyte
+	}
+
+	// Coin control: restrict inputs to selected UTXOs
+	for _, op := range outpoints {
+		parts := strings.SplitN(op, ":", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		txid := parts[0]
+		var idx uint32
+		for _, c := range parts[1] {
+			if c >= '0' && c <= '9' {
+				idx = idx*10 + uint32(c-'0')
+			}
+		}
+		req.Outpoints = append(req.Outpoints,
+			&lnrpc.OutPoint{
+				TxidStr:     txid,
+				OutputIndex: idx,
+			})
+	}
+
 	resp, err := rpc.OpenChannelSync(ctx, req)
 	if err != nil {
 		c.handleError(err)

--- a/internal/welcome/amount_input.go
+++ b/internal/welcome/amount_input.go
@@ -53,7 +53,6 @@ func NewAmountInput() AmountInput {
 	// Update() by filtering the keystroke. A Validate hook
 	// would reject "22,542" because it contains a comma.
 	applyInputStyles(&ti)
-	ti.Focus()
 	return AmountInput{ti: ti}
 }
 

--- a/internal/welcome/cmds.go
+++ b/internal/welcome/cmds.go
@@ -85,6 +85,8 @@ func removeSyncthingDeviceCmd(
 func openChannelCmd(
 	client *lndrpc.Client, pubkey, host string,
 	amount int64, private bool, taproot bool,
+	outpoints []string, fundMax bool,
+	satPerVbyte uint64,
 ) tea.Cmd {
 	return func() tea.Msg {
 		if client == nil {
@@ -105,7 +107,8 @@ func openChannelCmd(
 					"could not connect: %v", err)}
 		}
 		result, err := client.OpenChannel(
-			pubkey, amount, private, taproot)
+			pubkey, amount, private, taproot,
+			outpoints, fundMax, satPerVbyte)
 		if err != nil {
 			return channelOpenResultMsg{err: err}
 		}

--- a/internal/welcome/inputs.go
+++ b/internal/welcome/inputs.go
@@ -97,8 +97,6 @@ func newRecvMemoInput() textinput.Model {
 	ti.Validate = validatePrintableASCII
 	ti.Prompt = "  "
 	applyInputStyles(&ti)
-	// Starts blurred — amount field is focused first
-	ti.Blur()
 	return ti
 }
 
@@ -122,7 +120,6 @@ func newChanHostInput() textinput.Model {
 	ti.Validate = validateHostChars
 	ti.Prompt = "  "
 	applyInputStyles(&ti)
-	ti.Blur()
 	return ti
 }
 
@@ -158,7 +155,6 @@ func newOCSendLabelInput() textinput.Model {
 	ti.Validate = validatePrintableASCII
 	ti.Prompt = "  "
 	applyInputStyles(&ti)
-	ti.Blur()
 	return ti
 }
 

--- a/internal/welcome/inputs.go
+++ b/internal/welcome/inputs.go
@@ -41,16 +41,6 @@ func validateHostChars(s string) error {
 	return nil
 }
 
-func validateHubName(s string) error {
-	for _, ch := range s {
-		if !((ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') ||
-			(ch >= '0' && ch <= '9') || ch == ' ' || ch == '-') {
-			return errInvalidChar{}
-		}
-	}
-	return nil
-}
-
 func validateSyncthingID(s string) error {
 	for _, ch := range s {
 		upper := ch
@@ -136,18 +126,6 @@ func newChanHostInput() textinput.Model {
 	return ti
 }
 
-func newHubNameInput() textinput.Model {
-	ti := textinput.New()
-	ti.Placeholder = "account name"
-	ti.CharLimit = 30
-	ti.SetWidth(30)
-	ti.Validate = validateHubName
-	ti.Prompt = "  "
-	applyInputStyles(&ti)
-	ti.Focus()
-	return ti
-}
-
 func newSyncthingIDInput() textinput.Model {
 	ti := textinput.New()
 	ti.Placeholder = "XXXXXXX-XXXXXXX-XXXXXXX-XXXXXXX-XXXXXXX-XXXXXXX-XXXXXXX-XXXXXXX"
@@ -191,7 +169,6 @@ func NewFeeInput() AmountInput {
 	ti.SetWidth(12)
 	ti.Prompt = "  "
 	applyInputStyles(&ti)
-	ti.Focus()
 	return AmountInput{ti: ti}
 }
 

--- a/internal/welcome/keybinds.go
+++ b/internal/welcome/keybinds.go
@@ -32,7 +32,6 @@ var (
 	kUpTabBar         = bind("↑", "tab bar", "up")
 	kShiftTabBar      = bind("⇧tab", "tab bar", "shift+tab")
 	kUpShiftTabBar    = bind("↑/⇧tab", "tab bar", "up", "shift+tab")
-	kShiftTabBack     = bind("⇧tab", "back", "shift+tab")
 	kShiftTabButtons  = bind("⇧tab", "buttons", "shift+tab")
 	kShiftTabInput    = bind("⇧tab", "input", "shift+tab")
 	kTabNext          = bind("tab", "next", "tab")

--- a/internal/welcome/nav.go
+++ b/internal/welcome/nav.go
@@ -194,15 +194,11 @@ func (n NavSidebar) BlockRows(
 			if r == titleRow {
 				styled := style.Render(label)
 				if isCursor {
-					markerStyle := theme.NavActive
-					if !isActive {
-						markerStyle = theme.NavCursor
-					}
 					// Center "▸ Label" as a single unit
 					// so the cursor doesn't push the
 					// label off-center relative to
 					// non-cursor rows.
-					combined := markerStyle.Render("▸") +
+					combined := theme.NavActive.Render("▸") +
 						" " + styled
 					rows = append(rows,
 						cellBase.Render(combined))

--- a/internal/welcome/pane_builder.go
+++ b/internal/welcome/pane_builder.go
@@ -221,10 +221,9 @@ func (p *paneBuilder) success(
 func (p *paneBuilder) input(
 	label string, view string, focused bool,
 ) *paneBuilder {
-	labelStyle := theme.Label
+	labelStyle := theme.Header
 	marker := " "
 	if focused {
-		labelStyle = theme.NavActive
 		marker = theme.NavActive.Render("▸")
 	}
 	p.lines = append(p.lines,

--- a/internal/welcome/screen_addon_syncthing.go
+++ b/internal/welcome/screen_addon_syncthing.go
@@ -259,7 +259,7 @@ func (s *SyncthingDetailScreen) View(
 
 			marker := " "
 			if isSelected {
-				marker = "▸"
+				marker = theme.NavActive.Render("▸")
 				cursorLine = tableStart + i
 				midLines = append(midLines,
 					marker+

--- a/internal/welcome/screen_addon_syncthing_pair.go
+++ b/internal/welcome/screen_addon_syncthing_pair.go
@@ -132,14 +132,14 @@ func (s *SyncthingPairScreen) inputBindings() []key.Binding {
 		binds = append(binds,
 			bind("enter", "pair", "enter"),
 			kTabButtons, kSidebar)
+		if s.ctx.HasTabs {
+			binds = append(binds, kShiftTabBar)
+		}
 	} else {
 		binds = append(binds, kEnter)
 		binds = append(binds, buttonNav(s.btnIdx)...)
 		binds = append(binds, kShiftTabInput,
 			kBack)
-	}
-	if s.ctx.HasTabs {
-		binds = append(binds, kShiftTabBar)
 	}
 	binds = append(binds, kQuit)
 	return binds

--- a/internal/welcome/screen_addon_syncthing_pair.go
+++ b/internal/welcome/screen_addon_syncthing_pair.go
@@ -408,10 +408,9 @@ func (s *SyncthingPairScreen) viewInput(
 	// Input
 	inputFocused := isFocused &&
 		s.focusZone == syncPairZoneInput
-	labelStyle := theme.Label
+	labelStyle := theme.Header
 	marker := " "
 	if inputFocused {
-		labelStyle = theme.NavActive
 		marker = theme.NavActive.Render("▸")
 	}
 	lines = append(lines,

--- a/internal/welcome/screen_channels_close.go
+++ b/internal/welcome/screen_channels_close.go
@@ -496,10 +496,10 @@ func (s *ChannelCloseScreen) viewType(
 		coopPrefix = "●"
 		coopStyle = theme.Action
 	}
-	p.line(fmt.Sprintf(" %s %s",
+	p.line(fmt.Sprintf("%s %s",
 		coopPrefix,
 		coopStyle.Render("Cooperative close")))
-	p.line("   " + theme.Dim.Render(
+	p.line("  " + theme.Dim.Render(
 		"Requires peer online. Funds available"+
 			" immediately."))
 	p.blank()
@@ -513,10 +513,10 @@ func (s *ChannelCloseScreen) viewType(
 		forcePrefix = "●"
 		forceStyle = theme.Warning
 	}
-	p.line(fmt.Sprintf(" %s %s",
+	p.line(fmt.Sprintf("%s %s",
 		forcePrefix,
 		forceStyle.Render("Force close")))
-	p.line("   " + theme.Dim.Render(
+	p.line("  " + theme.Dim.Render(
 		"Unilateral. Funds locked ~2 weeks."))
 
 	return p.renderWithBottomButtons(

--- a/internal/welcome/screen_channels_close.go
+++ b/internal/welcome/screen_channels_close.go
@@ -691,7 +691,8 @@ func (s *ChannelCloseScreen) confirmBindings() []key.Binding {
 		binds = append(binds,
 			kLeftRightButtons, kEnter)
 		if !s.force {
-			binds = append(binds, kShiftTabBack)
+			binds = append(binds,
+				bind("⇧tab", "fee", "shift+tab"))
 		} else {
 			binds = append(binds, kSidebar)
 			if s.ctx.HasTabs {

--- a/internal/welcome/screen_channels_close.go
+++ b/internal/welcome/screen_channels_close.go
@@ -490,7 +490,7 @@ func (s *ChannelCloseScreen) viewType(
 	coopPrefix := " "
 	coopStyle := theme.Value
 	if onOptions && s.typeIdx == 0 {
-		coopPrefix = "▸"
+		coopPrefix = theme.NavActive.Render("▸")
 		coopStyle = theme.Action
 	} else if onButtons && s.typeIdx == 0 {
 		coopPrefix = "●"
@@ -507,7 +507,7 @@ func (s *ChannelCloseScreen) viewType(
 	forcePrefix := " "
 	forceStyle := theme.Value
 	if onOptions && s.typeIdx == 1 {
-		forcePrefix = "▸"
+		forcePrefix = theme.NavActive.Render("▸")
 		forceStyle = theme.Warning
 	} else if onButtons && s.typeIdx == 1 {
 		forcePrefix = "●"

--- a/internal/welcome/screen_channels_close.go
+++ b/internal/welcome/screen_channels_close.go
@@ -267,6 +267,7 @@ func (s *ChannelCloseScreen) handleTypeBtnKey(
 				s.feeInput.SetSats(
 					int64(s.feeTiers[0].SatPerVB))
 			}
+			s.feeInput.Focus()
 			s.focusZone = closeZoneFee
 		} else {
 			s.focusZone = closeZoneButtons

--- a/internal/welcome/screen_channels_history.go
+++ b/internal/welcome/screen_channels_history.go
@@ -184,7 +184,7 @@ func (s *ChannelHistoryScreen) View(
 
 		marker := " "
 		if isSelected {
-			marker = "▸"
+			marker = theme.NavActive.Render("▸")
 			midLines = append(midLines,
 				marker+
 					selStyle.Render(peerStr)+

--- a/internal/welcome/screen_channels_home.go
+++ b/internal/welcome/screen_channels_home.go
@@ -463,7 +463,7 @@ func (s *ChannelsHomeScreen) View(
 			marker := " "
 			nameStyle := theme.Value
 			if isSelected {
-				marker = "▸"
+				marker = theme.NavActive.Render("▸")
 				nameStyle = theme.NavActive
 			}
 			namePad := pad(name, nameW)

--- a/internal/welcome/screen_channels_open.go
+++ b/internal/welcome/screen_channels_open.go
@@ -128,11 +128,6 @@ func NewChannelOpenScreen(
 		customBtnIdx: 1,
 		utxoSelected: make(map[int]bool),
 	}
-	// Blur inputs that aren't active on initial render.
-	// Focus is granted by zone navigation handlers when
-	// the user reaches each input.
-	s.amountInput.Blur()
-	s.feeInput.Blur()
 	return s
 }
 
@@ -748,7 +743,6 @@ func (s *ChannelOpenScreen) clearForm() *ChannelOpenScreen {
 		s.feeInput.SetSats(
 			int64(s.feeTiers[0].SatPerVB))
 	}
-	s.feeInput.Blur()
 	s.private = true
 	s.taproot = true
 	s.toggleIdx = 0

--- a/internal/welcome/screen_channels_open.go
+++ b/internal/welcome/screen_channels_open.go
@@ -2,12 +2,12 @@ package welcome
 
 import (
 	"fmt"
-	"strings"
 
 	"charm.land/bubbles/v2/key"
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/ripsline/virtual-private-node/internal/lndrpc"
 	"github.com/ripsline/virtual-private-node/internal/theme"
 )
 
@@ -16,11 +16,12 @@ import (
 type chanOpenStep int
 
 const (
-	coStepInput      chanOpenStep = iota // peer + amount + toggles + buttons
-	coStepCustomPeer                     // pubkey + host fields + Go Back/Continue
-	coStepConfirm                        // summary + Go Back / Confirm
-	coStepOpening                        // in-flight
-	coStepResult                         // success or error
+	coStepInput       chanOpenStep = iota // peer + amount + fee + toggles + buttons
+	coStepCustomPeer                      // pubkey + host fields + Go Back/Continue
+	coStepCoinControl                     // UTXO table + Go Back / Confirm
+	coStepConfirm                         // summary + Go Back / Confirm
+	coStepOpening                         // in-flight
+	coStepResult                          // success or error
 )
 
 // ── Focus zones for coStepInput ────────────────────────
@@ -28,8 +29,9 @@ const (
 const (
 	coZonePeers   = 0
 	coZoneAmounts = 1
-	coZoneToggles = 2
-	coZoneButtons = 3
+	coZoneFee     = 2
+	coZoneToggles = 3
+	coZoneButtons = 4
 )
 
 // ── Focus zones for coStepCustomPeer ───────────────────
@@ -38,6 +40,13 @@ const (
 	coCustomZonePubkey  = 0
 	coCustomZoneHost    = 1
 	coCustomZoneButtons = 2
+)
+
+// ── Focus zones for coStepCoinControl ─────────────────
+
+const (
+	coCCZoneList    = 0
+	coCCZoneButtons = 1
 )
 
 // ── ChannelOpenScreen ──────────────────────────────────
@@ -58,14 +67,30 @@ type ChannelOpenScreen struct {
 	customBtnIdx int
 
 	// Amount selection
-	amountPreset int
-	amountInput  AmountInput
-	amount       int64
+	amountIdx   int // 0=coin control btn, 1=amount
+	amountInput AmountInput
+	amount      int64
+	fundMax     bool
+
+	// Fee rate
+	feeInput AmountInput
+	feeTiers [4]feeTier
 
 	// Toggles
 	private   bool
 	taproot   bool
 	toggleIdx int
+
+	// UTXO selection (coin control)
+	utxos             []lndrpc.UTXO
+	txs               []lndrpc.OnChainTx
+	utxoSelected      map[int]bool
+	utxoSelectedTotal int64
+	utxoOutpoints     []string
+	utxoCursor        int
+	utxoFetched       bool // lazy fetch guard
+	ccZone            int  // sub-step focus zone
+	ccBtnIdx          int  // sub-step button index
 
 	// Selection state (✓ indicators)
 	peerConfirmed   bool
@@ -94,19 +119,24 @@ func NewChannelOpenScreen(
 		step:         coStepInput,
 		peerList:     channelOpenPeers(),
 		amountInput:  NewAmountInput(),
+		feeInput:     NewFeeInput(),
 		private:      true,
 		taproot:      false,
 		btnIdx:       1,
 		pubkeyInput:  newChanPubkeyInput(),
 		hostInput:    newChanHostInput(),
 		customBtnIdx: 1,
+		utxoSelected: make(map[int]bool),
 	}
 }
 
 // ── Screen interface ────────────────────────────────────
 
 func (s *ChannelOpenScreen) Init() tea.Cmd {
-	return nil
+	return tea.Batch(
+		fetchChannelUtxosCmd(s.ctx.LndClient),
+		fetchChannelTxsCmd(s.ctx.LndClient),
+		fetchFeeTiersCmd(s.ctx.Cfg))
 }
 
 func (s *ChannelOpenScreen) HandleKey(
@@ -117,6 +147,8 @@ func (s *ChannelOpenScreen) HandleKey(
 		return s.handleInputKey(keyStr, msg)
 	case coStepCustomPeer:
 		return s.handleCustomPeerKey(keyStr, msg)
+	case coStepCoinControl:
+		return s.handleCoinControlKey(keyStr)
 	case coStepConfirm:
 		return s.handleConfirmKey(keyStr)
 	case coStepOpening:
@@ -131,10 +163,24 @@ func (s *ChannelOpenScreen) HandleMsg(
 	msg tea.Msg,
 ) (Screen, tea.Cmd) {
 	switch msg := msg.(type) {
+	case tabActivatedMsg:
+		// Always refetch on tab re-focus so data
+		// reflects any changes since last viewed,
+		// matching channel history's pattern.
+		return s, tea.Batch(
+			fetchChannelUtxosCmd(s.ctx.LndClient),
+			fetchChannelTxsCmd(s.ctx.LndClient),
+			fetchFeeTiersCmd(s.ctx.Cfg))
 	case tea.PasteMsg:
 		return s.handlePaste(msg)
 	case channelOpenResultMsg:
 		return s.handleOpenResult(msg)
+	case coUtxoListMsg:
+		return s.handleUtxoList(msg)
+	case coTxListMsg:
+		return s.handleTxList(msg)
+	case feeTiersMsg:
+		return s.handleFeeTiers(msg)
 	}
 	return s, nil
 }
@@ -145,6 +191,8 @@ func (s *ChannelOpenScreen) View(w, h int) string {
 		return s.viewInput(w, h)
 	case coStepCustomPeer:
 		return s.viewCustomPeer(w, h)
+	case coStepCoinControl:
+		return s.viewCoinControl(w, h)
 	case coStepConfirm:
 		return s.viewConfirm(w, h)
 	case coStepOpening:
@@ -161,6 +209,8 @@ func (s *ChannelOpenScreen) HelpBindings() []key.Binding {
 		return s.inputBindings()
 	case coStepCustomPeer:
 		return s.customPeerBindings()
+	case coStepCoinControl:
+		return s.coinControlBindings()
 	case coStepConfirm:
 		return actionButtonBindings(
 			s.confirmBtnIdx, s.ctx.HasTabs)
@@ -182,6 +232,8 @@ func (s *ChannelOpenScreen) handleInputKey(
 		return s.handlePeerListKey(keyStr)
 	case coZoneAmounts:
 		return s.handleAmountListKey(keyStr, msg)
+	case coZoneFee:
+		return s.handleFeeZoneKey(keyStr, msg)
 	case coZoneToggles:
 		return s.handleToggleKey(keyStr)
 	case coZoneButtons:
@@ -212,7 +264,6 @@ func (s *ChannelOpenScreen) handlePeerListKey(
 			s.peerIdx++
 			s.peerConfirmed = false
 		} else {
-			// Bottom of peer list: cross to amounts
 			s.focusZone = coZoneAmounts
 		}
 		return s, nil
@@ -247,7 +298,6 @@ func (s *ChannelOpenScreen) handlePeerListKey(
 		// Curated peer: confirm + advance
 		s.peerConfirmed = true
 		s.focusZone = coZoneAmounts
-		s.amountPreset = 0
 		return s, nil
 	case "backspace":
 		return s, emitFocusParent
@@ -258,102 +308,106 @@ func (s *ChannelOpenScreen) handlePeerListKey(
 func (s *ChannelOpenScreen) handleAmountListKey(
 	keyStr string, msg tea.KeyPressMsg,
 ) (Screen, tea.Cmd) {
-	isCustom := s.amountPreset == len(amountPresets)-1
+	onCoinCtrl := s.amountIdx == 0
+	editing := s.amountIdx == 1 &&
+		s.amountInput.Focused()
 	switch keyStr {
 	case "ctrl+c":
 		return s, tea.Quit
 	case "left":
-		if isCustom &&
-			!s.amountInput.Empty() {
+		if editing && !s.amountInput.Empty() {
 			cmd := s.amountInput.Update(tea.Msg(msg))
 			return s, cmd
 		}
 		return s, emitFocusSidebar
 	case "right":
-		if isCustom {
+		if editing {
 			cmd := s.amountInput.Update(tea.Msg(msg))
 			return s, cmd
 		}
 		return s, nil
 	case "up":
-		if isCustom {
-			// On custom row: move to previous preset
-			s.amountPreset--
-			s.amountConfirmed = false
-			s.amountInput.Blur()
-		} else if s.amountPreset > 0 {
-			s.amountPreset--
-			s.amountConfirmed = false
-		} else {
-			// Top of amount list: cross to peers.
-			// Land on the last peer row — the user is
-			// coming from below and this is the closest
-			// row to where they were.
+		if onCoinCtrl {
 			s.enterPeersBackward()
-			s.peerIdx = len(s.peerList)
+		} else {
+			// Amount → coin control
+			if editing {
+				s.amountInput.Blur()
+			}
+			s.amountIdx = 0
 		}
 		return s, nil
 	case "down":
-		if !isCustom &&
-			s.amountPreset < len(amountPresets)-1 {
-			s.amountPreset++
-			s.amountConfirmed = false
-			if s.amountPreset == len(amountPresets)-1 {
+		if onCoinCtrl {
+			// Coin control → amount
+			s.amountIdx = 1
+			if !s.amountConfirmed {
 				s.amountInput.Focus()
 			}
 			return s, nil
 		}
-		// Bottom of amount list: cross to toggles.
-		// Custom mode auto-confirms on the way out —
-		// typing a value and moving away should use
-		// that value. Invalid → error and stay.
-		if isCustom {
-			if !s.confirmCustomAmountAndAdvance(
-				coZoneToggles) {
+		// Amount: advance to fee
+		if editing && !s.amountInput.Empty() {
+			if !s.confirmAmountAndAdvance() {
 				return s, nil
 			}
 			return s, nil
 		}
-		s.focusZone = coZoneToggles
-		s.toggleIdx = 0
+		if editing {
+			s.amountInput.Blur()
+		}
+		s.focusZone = coZoneFee
+		s.feeInput.Focus()
 		return s, nil
 	case "tab":
-		if isCustom {
-			if !s.confirmCustomAmountAndAdvance(
-				coZoneToggles) {
+		if editing && !s.amountInput.Empty() {
+			if !s.confirmAmountAndAdvance() {
 				return s, nil
 			}
 			return s, nil
 		}
-		s.focusZone = coZoneToggles
-		s.toggleIdx = 0
+		if editing {
+			s.amountInput.Blur()
+		}
+		s.focusZone = coZoneFee
+		s.feeInput.Focus()
 		return s, nil
 	case "shift+tab":
-		if isCustom {
+		if editing {
 			s.amountInput.Blur()
 		}
 		s.enterPeersBackward()
 		return s, nil
 	case "backspace":
-		if isCustom {
+		if editing {
 			cmd := s.amountInput.Update(tea.Msg(msg))
 			return s, cmd
 		}
 		return s, emitFocusParent
 	case "enter":
-		if isCustom {
-			if !s.confirmCustomAmountAndAdvance(
-				coZoneToggles) {
+		if onCoinCtrl {
+			// Open coin control sub-step
+			s.ccZone = coCCZoneList
+			s.ccBtnIdx = 1
+			s.error = ""
+			s.step = coStepCoinControl
+			return s, nil
+		}
+		if s.amountConfirmed && !editing {
+			// Unlock editing on auto-confirmed amount
+			s.amountConfirmed = false
+			s.amountInput.Focus()
+			return s, nil
+		}
+		if editing {
+			if !s.confirmAmountAndAdvance() {
 				return s, nil
 			}
 			return s, nil
 		}
-		s.amountConfirmed = true
-		s.focusZone = coZoneToggles
-		s.toggleIdx = 0
 		return s, nil
 	}
-	if isCustom {
+	if editing {
 		cmd := s.amountInput.Update(tea.Msg(msg))
 		return s, cmd
 	}
@@ -382,7 +436,7 @@ func (s *ChannelOpenScreen) handleToggleKey(
 		if s.toggleIdx > 0 {
 			s.toggleIdx--
 		} else {
-			s.enterAmountsBackward()
+			s.enterFeeBackward()
 		}
 		return s, nil
 	case "down":
@@ -396,7 +450,7 @@ func (s *ChannelOpenScreen) handleToggleKey(
 		s.focusZone = coZoneButtons
 		return s, nil
 	case "shift+tab":
-		s.enterAmountsBackward()
+		s.enterFeeBackward()
 		return s, nil
 	case "enter":
 		switch s.toggleIdx {
@@ -452,277 +506,56 @@ func (s *ChannelOpenScreen) handleButtonKey(
 	return s, nil
 }
 
-// ── Custom peer step ───────────────────────────────────
+// ── Fee zone key handling ─────────────────────────────
 
-func (s *ChannelOpenScreen) handleCustomPeerKey(
-	keyStr string, msg tea.KeyPressMsg,
-) (Screen, tea.Cmd) {
-	switch s.customZone {
-	case coCustomZonePubkey:
-		return s.handleCustomPubkeyKey(keyStr, msg)
-	case coCustomZoneHost:
-		return s.handleCustomHostKey(keyStr, msg)
-	case coCustomZoneButtons:
-		return s.handleCustomButtonKey(keyStr)
-	}
-	return s, nil
-}
-
-func (s *ChannelOpenScreen) handleCustomPubkeyKey(
+func (s *ChannelOpenScreen) handleFeeZoneKey(
 	keyStr string, msg tea.KeyPressMsg,
 ) (Screen, tea.Cmd) {
 	switch keyStr {
 	case "ctrl+c":
 		return s, tea.Quit
 	case "left":
-		if s.pubkeyInput.Value() != "" {
-			var cmd tea.Cmd
-			s.pubkeyInput, cmd =
-				s.pubkeyInput.Update(tea.Msg(msg))
+		if !s.feeInput.Empty() {
+			cmd := s.feeInput.Update(tea.Msg(msg))
 			return s, cmd
 		}
 		return s, emitFocusSidebar
 	case "right":
-		if s.pubkeyInput.Value() != "" {
-			var cmd tea.Cmd
-			s.pubkeyInput, cmd =
-				s.pubkeyInput.Update(tea.Msg(msg))
+		if !s.feeInput.Empty() {
+			cmd := s.feeInput.Update(tea.Msg(msg))
 			return s, cmd
 		}
 		return s, nil
 	case "up":
-		if s.ctx.HasTabs {
-			return s, emitFocusTabBar
-		}
+		s.feeInput.Blur()
+		s.enterAmountsBackward()
 		return s, nil
 	case "down":
-		s.pubkeyInput.Blur()
-		s.hostInput.Focus()
-		s.customZone = coCustomZoneHost
+		s.feeInput.Blur()
+		s.focusZone = coZoneToggles
+		s.toggleIdx = 0
 		return s, nil
 	case "tab":
-		s.pubkeyInput.Blur()
-		s.hostInput.Focus()
-		s.customZone = coCustomZoneHost
+		s.feeInput.Blur()
+		s.focusZone = coZoneToggles
+		s.toggleIdx = 0
 		return s, nil
 	case "shift+tab":
-		if s.ctx.HasTabs {
-			return s, emitFocusTabBar
-		}
+		s.feeInput.Blur()
+		s.enterAmountsBackward()
 		return s, nil
 	case "backspace":
-		var cmd tea.Cmd
-		s.pubkeyInput, cmd =
-			s.pubkeyInput.Update(tea.Msg(msg))
+		cmd := s.feeInput.Update(tea.Msg(msg))
 		return s, cmd
 	case "enter":
-		s.pubkeyInput.Blur()
-		s.hostInput.Focus()
-		s.customZone = coCustomZoneHost
+		s.feeInput.Blur()
+		s.focusZone = coZoneToggles
+		s.toggleIdx = 0
 		return s, nil
 	default:
-		var cmd tea.Cmd
-		s.pubkeyInput, cmd =
-			s.pubkeyInput.Update(tea.Msg(msg))
+		cmd := s.feeInput.Update(tea.Msg(msg))
 		return s, cmd
 	}
-}
-
-func (s *ChannelOpenScreen) handleCustomHostKey(
-	keyStr string, msg tea.KeyPressMsg,
-) (Screen, tea.Cmd) {
-	switch keyStr {
-	case "ctrl+c":
-		return s, tea.Quit
-	case "left":
-		if s.hostInput.Value() != "" {
-			var cmd tea.Cmd
-			s.hostInput, cmd =
-				s.hostInput.Update(tea.Msg(msg))
-			return s, cmd
-		}
-		return s, emitFocusSidebar
-	case "right":
-		if s.hostInput.Value() != "" {
-			var cmd tea.Cmd
-			s.hostInput, cmd =
-				s.hostInput.Update(tea.Msg(msg))
-			return s, cmd
-		}
-		return s, nil
-	case "up":
-		s.hostInput.Blur()
-		s.pubkeyInput.Focus()
-		s.customZone = coCustomZonePubkey
-		return s, nil
-	case "down":
-		s.hostInput.Blur()
-		s.customZone = coCustomZoneButtons
-		return s, nil
-	case "tab":
-		s.hostInput.Blur()
-		s.customZone = coCustomZoneButtons
-		return s, nil
-	case "shift+tab":
-		s.hostInput.Blur()
-		s.pubkeyInput.Focus()
-		s.customZone = coCustomZonePubkey
-		return s, nil
-	case "backspace":
-		var cmd tea.Cmd
-		s.hostInput, cmd =
-			s.hostInput.Update(tea.Msg(msg))
-		return s, cmd
-	case "enter":
-		s.hostInput.Blur()
-		s.customZone = coCustomZoneButtons
-		return s, nil
-	default:
-		var cmd tea.Cmd
-		s.hostInput, cmd =
-			s.hostInput.Update(tea.Msg(msg))
-		return s, cmd
-	}
-}
-
-func (s *ChannelOpenScreen) handleCustomButtonKey(
-	keyStr string,
-) (Screen, tea.Cmd) {
-	switch keyStr {
-	case "ctrl+c":
-		return s, tea.Quit
-	case "left":
-		if s.customBtnIdx > 0 {
-			s.customBtnIdx--
-		} else {
-			return s, emitFocusSidebar
-		}
-		return s, nil
-	case "right":
-		if s.customBtnIdx < 1 {
-			s.customBtnIdx++
-		}
-		return s, nil
-	case "up":
-		s.customZone = coCustomZoneHost
-		s.hostInput.Focus()
-		return s, nil
-	case "tab":
-		return s, nil
-	case "shift+tab":
-		s.customZone = coCustomZoneHost
-		s.hostInput.Focus()
-		return s, nil
-	case "enter":
-		switch s.customBtnIdx {
-		case 0: // Go Back
-			s.error = ""
-			s.step = coStepInput
-			return s, nil
-		case 1: // Continue
-			return s.submitCustomPeer()
-		}
-		return s, nil
-	case "backspace":
-		s.error = ""
-		s.step = coStepInput
-		return s, nil
-	}
-	return s, nil
-}
-
-// ── Confirm step ───────────────────────────────────────
-
-func (s *ChannelOpenScreen) handleConfirmKey(
-	keyStr string,
-) (Screen, tea.Cmd) {
-	switch keyStr {
-	case "ctrl+c":
-		return s, tea.Quit
-	case "left":
-		if s.confirmBtnIdx > 0 {
-			s.confirmBtnIdx--
-		} else {
-			return s, emitFocusSidebar
-		}
-		return s, nil
-	case "right":
-		if s.confirmBtnIdx < 1 {
-			s.confirmBtnIdx++
-		}
-		return s, nil
-	case "up":
-		if s.ctx.HasTabs {
-			return s, emitFocusTabBar
-		}
-		return s, nil
-	case "backspace":
-		s.backToInput()
-		return s, nil
-	case "enter":
-		switch s.confirmBtnIdx {
-		case 0: // Go Back
-			s.backToInput()
-			return s, nil
-		case 1: // Confirm
-			if s.inFlight {
-				return s, nil
-			}
-			s.inFlight = true
-			s.error = ""
-			s.step = coStepOpening
-			return s, openChannelCmd(
-				s.ctx.LndClient,
-				s.selectedPubkey(),
-				s.selectedHost(),
-				s.amount,
-				s.private,
-				s.taproot,
-			)
-		}
-	}
-	return s, nil
-}
-
-func (s *ChannelOpenScreen) backToInput() {
-	s.step = coStepInput
-	s.error = ""
-	s.confirmBtnIdx = 0
-	s.focusZone = coZoneButtons
-	s.btnIdx = 1
-}
-
-// ── Opening step ───────────────────────────────────────
-
-func (s *ChannelOpenScreen) handleOpeningKey(
-	keyStr string,
-) (Screen, tea.Cmd) {
-	// Fund-moving operation in progress — block all keys.
-	return s, nil
-}
-
-// ── Result step ────────────────────────────────────────
-
-func (s *ChannelOpenScreen) handleResultKey(
-	keyStr string,
-) (Screen, tea.Cmd) {
-	switch keyStr {
-	case "ctrl+c":
-		return s, tea.Quit
-	case "enter":
-		return s, tea.Batch(
-			emitCloseTab,
-			emitRefreshStatus)
-	case "left":
-		return s, emitFocusSidebar
-	case "up", "shift+tab":
-		if s.ctx.HasTabs {
-			return s, emitFocusTabBar
-		}
-	case "backspace":
-		return s, emitFocusParent
-	}
-	return s, nil
 }
 
 // ── Paste handling ─────────────────────────────────────
@@ -743,8 +576,14 @@ func (s *ChannelOpenScreen) handlePaste(
 	}
 	if s.step == coStepInput &&
 		s.focusZone == coZoneAmounts &&
-		s.amountPreset == len(amountPresets)-1 {
+		s.amountIdx == 1 &&
+		s.amountInput.Focused() {
 		cmd := s.amountInput.Update(msg)
+		return s, cmd
+	}
+	if s.step == coStepInput &&
+		s.focusZone == coZoneFee {
+		cmd := s.feeInput.Update(msg)
 		return s, cmd
 	}
 	return s, nil
@@ -765,6 +604,22 @@ func (s *ChannelOpenScreen) handleOpenResult(
 	s.step = coStepResult
 	if msg.err == nil {
 		return s, emitRefreshStatus
+	}
+	return s, nil
+}
+
+func (s *ChannelOpenScreen) handleFeeTiers(
+	msg feeTiersMsg,
+) (Screen, tea.Cmd) {
+	if msg.err != nil {
+		return s, nil
+	}
+	s.feeTiers = msg.tiers
+	// Pre-fill fee input if still empty
+	if s.feeInput.Empty() &&
+		msg.tiers[0].SatPerVB > 0 {
+		s.feeInput.SetSats(
+			int64(msg.tiers[0].SatPerVB))
 	}
 	return s, nil
 }
@@ -790,15 +645,10 @@ func (s *ChannelOpenScreen) validateCustomAmount() (int64, string) {
 	return n, ""
 }
 
-// confirmCustomAmountAndAdvance validates the custom
-// amount, commits it to s.amount, and moves focus to the
-// given zone. On validation failure, sets the error and
-// returns false without changing focus. Called from the
-// three forward-navigation handlers (enter, down, tab)
-// when the user is on the custom amount row.
-func (s *ChannelOpenScreen) confirmCustomAmountAndAdvance(
-	toZone int,
-) bool {
+// confirmAmountAndAdvance validates the amount input,
+// commits it, detects FundMax, and advances to fee zone.
+// Returns false on validation failure.
+func (s *ChannelOpenScreen) confirmAmountAndAdvance() bool {
 	n, errMsg := s.validateCustomAmount()
 	if errMsg != "" {
 		s.error = errMsg
@@ -806,12 +656,13 @@ func (s *ChannelOpenScreen) confirmCustomAmountAndAdvance(
 	}
 	s.error = ""
 	s.amount = n
+	// FundMax when amount matches selected UTXO total
+	s.fundMax = len(s.utxoSelected) > 0 &&
+		n == s.utxoSelectedTotal
 	s.amountConfirmed = true
 	s.amountInput.Blur()
-	s.focusZone = toZone
-	if toZone == coZoneToggles {
-		s.toggleIdx = 0
-	}
+	s.focusZone = coZoneFee
+	s.feeInput.Focus()
 	return true
 }
 
@@ -841,18 +692,24 @@ func (s *ChannelOpenScreen) enterPeersBackward() {
 }
 
 // enterAmountsBackward: focus returned to amounts from
-// the toggles zone. Decommits the amount. If on the
-// Custom row, refocuses the input so the cursor is
-// visible for immediate editing. The entered value
-// (if any) is preserved in s.amountInput.
+// the fee zone. Decommits the amount but preserves the
+// value in the input for review/editing. If there's a
+// committed amount, populates the AmountInput so the
+// user can arrow left/right through the number.
 func (s *ChannelOpenScreen) enterAmountsBackward() {
 	s.focusZone = coZoneAmounts
 	s.amountConfirmed = false
 	s.error = ""
-	isCustom := s.amountPreset == len(amountPresets)-1
-	if isCustom {
-		s.amountInput.Focus()
-	}
+	s.amountIdx = 1
+	s.amountInput.Focus()
+}
+
+// enterFeeBackward: focus returned to fee from the
+// toggles zone. Refocuses the fee input for editing.
+func (s *ChannelOpenScreen) enterFeeBackward() {
+	s.focusZone = coZoneFee
+	s.feeInput.Focus()
+	s.error = ""
 }
 
 // enterTogglesBackward: focus returned to toggles from
@@ -872,12 +729,25 @@ func (s *ChannelOpenScreen) clearForm() *ChannelOpenScreen {
 	s.customPubkey = ""
 	s.customHost = ""
 	s.customAlias = ""
-	s.amountPreset = 0
+	s.amountIdx = 0
 	s.amountConfirmed = false
 	s.amountInput.Clear()
+	s.amount = 0
+	s.fundMax = false
+	s.feeInput = NewFeeInput()
+	if s.feeTiers[0].SatPerVB > 0 {
+		s.feeInput.SetSats(
+			int64(s.feeTiers[0].SatPerVB))
+	}
 	s.private = true
 	s.taproot = false
 	s.toggleIdx = 0
+	s.utxoSelected = make(map[int]bool)
+	s.utxoSelectedTotal = 0
+	s.utxoOutpoints = nil
+	s.utxoCursor = 0
+	s.utxoFetched = false
+	s.txs = nil
 	s.focusZone = coZonePeers
 	s.btnIdx = 1
 	s.error = ""
@@ -905,54 +775,51 @@ func (s *ChannelOpenScreen) submitOpenChannel() (
 	}
 
 	// Validate amount value
-	isCustom :=
-		s.amountPreset == len(amountPresets)-1
-	if isCustom {
+	if !s.fundMax {
 		n, errMsg := s.validateCustomAmount()
 		if errMsg != "" {
 			s.error = errMsg
 			return s, nil
 		}
 		s.amount = n
-	} else {
-		s.amount = amountPresets[s.amountPreset]
+	}
+
+	// Effective total for coin control checks
+	var effectiveTotal int64
+	if len(s.utxoSelected) > 0 {
+		effectiveTotal = s.utxoSelectedTotal
+	} else if s.ctx.Status != nil &&
+		s.ctx.Status.lndBalance != "" {
+		effectiveTotal = parseBalance(
+			s.ctx.Status.lndBalance)
+	}
+
+	// FundMax minimum check
+	if s.fundMax && effectiveTotal > 0 &&
+		effectiveTotal < 20000 {
+		s.error = "min 20,000 sats"
+		return s, nil
+	}
+
+	// Custom amount vs selected UTXOs check
+	feeRate := s.feeInput.Sats()
+	if !s.fundMax && len(s.utxoSelected) > 0 {
+		numInputs := len(s.utxoSelected)
+		if numInputs < 1 {
+			numInputs = 1
+		}
+		estFee := estimateSimpleFee(
+			numInputs, 2, feeRate)
+		if s.amount+estFee > effectiveTotal {
+			s.error = "not enough for amount " +
+				"and on-chain fee"
+			return s, nil
+		}
 	}
 
 	s.error = ""
 	s.confirmBtnIdx = 1
 	s.step = coStepConfirm
-	return s, nil
-}
-
-func (s *ChannelOpenScreen) submitCustomPeer() (
-	Screen, tea.Cmd,
-) {
-	pubkey := strings.TrimSpace(
-		s.pubkeyInput.Value())
-	host := strings.TrimSpace(
-		s.hostInput.Value())
-	if pubkey == "" {
-		s.error = "Pubkey is required"
-		return s, nil
-	}
-	if len(pubkey) != 66 {
-		s.error = "Pubkey must be 66 hex chars"
-		return s, nil
-	}
-	if host == "" {
-		s.error = "Host required"
-		return s, nil
-	}
-	s.customPubkey = pubkey
-	s.customHost = host
-	s.customAlias = pubkey[:16] + "..."
-	s.error = ""
-	// Return to input with custom peer confirmed
-	s.peerIdx = len(s.peerList)
-	s.peerConfirmed = true
-	s.step = coStepInput
-	s.focusZone = coZoneAmounts
-	s.amountPreset = 0
 	return s, nil
 }
 
@@ -1007,7 +874,7 @@ func (s *ChannelOpenScreen) viewInput(
 			parseBalance(s.ctx.Status.lndBalance)) +
 			" sats"
 	}
-	p.field("On-chain: ", balText)
+	p.field("On-Chain Balance: ", balText)
 	p.blank()
 
 	isFocused := s.ctx.ContentFocused
@@ -1071,37 +938,101 @@ func (s *ChannelOpenScreen) viewInput(
 		customStyle.Render(customLabel)))
 	p.blank()
 
-	// ── Amount presets ──
+	// ── Channel size: coin control + amount ──
 	p.line(" " + theme.Header.Render("Channel size:"))
-	for i, amt := range amountPresets {
-		prefix := " "
-		style := theme.Value
-		isCursor := isFocused &&
-			s.focusZone == coZoneAmounts &&
-			s.amountPreset == i
-		isConfirmed := s.amountConfirmed &&
-			s.amountPreset == i
-		if isCursor {
-			prefix = "▸"
-			style = theme.Action
+
+	amtFocused := isFocused &&
+		s.focusZone == coZoneAmounts
+
+	// Coin control button
+	ccPrefix := " "
+	ccStyle := theme.Value
+	if amtFocused && s.amountIdx == 0 {
+		ccPrefix = "▸"
+		ccStyle = theme.Action
+	}
+	var ccLabel string
+	if len(s.utxoSelected) > 0 {
+		ccLabel = fmt.Sprintf(
+			"[Coin control: %d UTXO (%s sats)]",
+			len(s.utxoSelected),
+			formatSats(s.utxoSelectedTotal))
+	} else {
+		ccLabel = "[Coin control]"
+	}
+	p.line(fmt.Sprintf(" %s %s",
+		ccPrefix, ccStyle.Render(ccLabel)))
+
+	// Amount line
+	amtPrefix := " "
+	amtStyle := theme.Value
+	amtCursor := amtFocused && s.amountIdx == 1
+	if amtCursor {
+		amtPrefix = "▸"
+		amtStyle = theme.Action
+	}
+	if s.amountConfirmed {
+		amtPrefix = "✓"
+		amtStyle = theme.Action
+	}
+
+	hasCoinCtrl := len(s.utxoSelected) > 0
+	if s.amountConfirmed && !s.amountInput.Focused() {
+		// Auto-confirmed or committed state
+		annotation := ""
+		if hasCoinCtrl &&
+			s.amount == s.utxoSelectedTotal {
+			annotation = theme.Dim.Render(
+				"  full UTXO, no change")
 		}
-		if isConfirmed {
-			prefix = "✓"
-			style = theme.Action
+		p.line(fmt.Sprintf(" %s %s%s",
+			amtPrefix,
+			amtStyle.Render(
+				formatSats(s.amount)+" sats"),
+			annotation))
+	} else {
+		// Editing state with input field
+		inputW := w - 14
+		if inputW > 20 {
+			inputW = 20
 		}
-		if amt == 0 && s.amountPreset == i {
-			p.line(fmt.Sprintf(" %s %s",
-				prefix, style.Render("Custom:")))
-			inputW := w - 6
-			if inputW > 20 {
-				inputW = 20
+		s.amountInput.SetWidth(inputW)
+		amtLine := fmt.Sprintf(" %s %s %s",
+			amtPrefix,
+			amtStyle.Render("Amount:"),
+			s.amountInput.View())
+		// Change annotation
+		if hasCoinCtrl && !s.amountInput.Empty() {
+			typed := s.amountInput.Sats()
+			if typed == s.utxoSelectedTotal {
+				amtLine += theme.Dim.Render(
+					"  full UTXO, no change")
+			} else if typed < s.utxoSelectedTotal {
+				change := s.utxoSelectedTotal - typed
+				amtLine += theme.Warning.Render(
+					fmt.Sprintf("  ~%s sats change",
+						formatSats(change)))
 			}
-			s.amountInput.SetWidth(inputW)
-			p.line("   " + s.amountInput.View())
-			continue
 		}
-		p.line(fmt.Sprintf(" %s %s",
-			prefix, style.Render(presetLabel(amt))))
+		p.line(amtLine)
+	}
+	p.blank()
+
+	// ── Fee rate ──
+	feeActive := isFocused &&
+		s.focusZone == coZoneFee
+	feeLabelStyle := theme.Label
+	feeMarker := " "
+	if feeActive {
+		feeLabelStyle = theme.NavActive
+		feeMarker = theme.NavActive.Render("▸")
+	}
+	p.line(" " + feeLabelStyle.Render(
+		"Fee Rate (sat/vB):"))
+	p.line(feeMarker + " " + s.feeInput.View())
+	hints := formatFeeHints(s.feeTiers)
+	if hints != "" {
+		p.line("  " + theme.Dim.Render(hints))
 	}
 	p.blank()
 
@@ -1181,108 +1112,6 @@ func renderToggleSwitch(
 		toggle + " " + rightStyled
 }
 
-func (s *ChannelOpenScreen) viewCustomPeer(
-	w, h int,
-) string {
-	p := newPane(w)
-	p.title(theme.Header, "Custom Peer")
-
-	isFocused := s.ctx.ContentFocused
-
-	p.input("Node Pubkey:",
-		s.pubkeyInput.View(),
-		isFocused &&
-			s.customZone == coCustomZonePubkey)
-	p.blank()
-	p.input("Host (host:port):",
-		s.hostInput.View(),
-		isFocused &&
-			s.customZone == coCustomZoneHost)
-
-	p.appendError(s.error)
-
-	btnFocused := isFocused &&
-		s.customZone == coCustomZoneButtons
-	return p.renderWithBottomButtons(
-		[]string{"Go Back", "Continue"},
-		s.customBtnIdx, btnFocused, h)
-}
-
-func (s *ChannelOpenScreen) viewConfirm(
-	w, h int,
-) string {
-	p := newPane(w)
-	p.title(theme.Warning, "Confirm Channel Open")
-
-	p.field("Peer:    ", s.selectedAlias())
-	p.field("Amount:  ",
-		formatSats(s.amount)+" sats")
-
-	chanType := "public"
-	if s.private {
-		chanType = "private"
-	}
-	if s.taproot {
-		chanType += ", taproot"
-	}
-	p.field("Type:    ", chanType)
-	p.blank()
-
-	p.labelLine("Pubkey:")
-	p.mono(s.selectedPubkey())
-	p.blank()
-	p.warn("Spend " +
-		formatSats(s.amount) + " sats?")
-
-	p.appendError(s.error)
-
-	return p.renderWithBottomButtons(
-		[]string{"Go Back", "Confirm"},
-		s.confirmBtnIdx, s.ctx.ContentFocused, h)
-}
-
-func (s *ChannelOpenScreen) viewOpening(
-	w, h int,
-) string {
-	p := newPane(w)
-	p.title(theme.Header, "Opening Channel...")
-	p.line(" " + theme.Value.Render(
-		"Connecting to peer and broadcasting tx."))
-	p.blank()
-	p.dim("May take up to 2 minutes over Tor.")
-	p.dim("Do not close the terminal.")
-	return p.renderWithBottomButtons(
-		[]string{"Opening..."}, 0, false, h)
-}
-
-func (s *ChannelOpenScreen) viewResult(
-	w int,
-) string {
-	p := newPane(w)
-
-	if s.error != "" {
-		p.title(theme.Warning, "Channel Open Failed")
-		p.warnWrap(s.error)
-	} else {
-		p.title(theme.Success, "Channel Opening")
-		p.line(" " + theme.Value.Render(
-			"Funding tx broadcast successfully."))
-		p.blank()
-		p.field("Peer:   ", s.selectedAlias())
-		p.field("Amount: ",
-			formatSats(s.amount)+" sats")
-		if s.txid != "" {
-			p.blank()
-			p.labelLine("TX ID:")
-			p.monoWrap(s.txid)
-		}
-		p.blank()
-		p.dim("Channel will appear as pending.")
-	}
-
-	return p.render()
-}
-
 // ── Helpbar bindings ───────────────────────────────────
 
 func (s *ChannelOpenScreen) inputBindings() []key.Binding {
@@ -1291,6 +1120,8 @@ func (s *ChannelOpenScreen) inputBindings() []key.Binding {
 		return s.peerListBindings()
 	case coZoneAmounts:
 		return s.amountListBindings()
+	case coZoneFee:
+		return s.feeZoneBindings()
 	case coZoneToggles:
 		return s.toggleBindings()
 	case coZoneButtons:
@@ -1325,43 +1156,20 @@ func (s *ChannelOpenScreen) toggleBindings() []key.Binding {
 	}
 }
 
+func (s *ChannelOpenScreen) feeZoneBindings() []key.Binding {
+	return []key.Binding{
+		kLeftRightCursor, kTabNext, kShiftTabBack,
+		kSidebar, kBack, kQuit,
+	}
+}
+
 func (s *ChannelOpenScreen) buttonBindings() []key.Binding {
 	binds := buttonNav(s.btnIdx)
 	binds = append(binds, kEnter, kShiftTabBack, kBack, kQuit)
 	return binds
 }
 
-func (s *ChannelOpenScreen) customPeerBindings() []key.Binding {
-	switch s.customZone {
-	case coCustomZonePubkey, coCustomZoneHost:
-		return []key.Binding{
-			kLeftRightCursor, kTabNext,
-			kShiftTabBack, kSidebar, kQuit,
-		}
-	case coCustomZoneButtons:
-		binds := buttonNav(s.customBtnIdx)
-		binds = append(binds, kEnter, kShiftTabBack, kBack, kQuit)
-		return binds
-	}
-	return nil
-}
-
 // ── channelOpenPeers ───────────────────────────────────
-
-// amountPresets defines the channel size options.
-// The last entry (0) represents the custom amount option.
-var amountPresets = []int64{
-	100000, 250000, 500000,
-	1000000, 2000000,
-	0, // custom
-}
-
-func presetLabel(sats int64) string {
-	if sats == 0 {
-		return "Custom amount"
-	}
-	return formatSats(sats) + " sats"
-}
 
 func channelOpenPeers() []peerOption {
 	return []peerOption{
@@ -1372,14 +1180,6 @@ func channelOpenPeers() []peerOption {
 			TorOnly:     true,
 			Curated:     true,
 			MinChanSize: 500000,
-		},
-		{
-			Alias:       "ACINQ",
-			Pubkey:      "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f",
-			Host:        "3.33.236.230:9735",
-			TorOnly:     false,
-			Curated:     true,
-			MinChanSize: 400000,
 		},
 		{
 			Alias:       "Zeus",

--- a/internal/welcome/screen_channels_open.go
+++ b/internal/welcome/screen_channels_open.go
@@ -885,7 +885,7 @@ func (s *ChannelOpenScreen) viewInput(
 		isConfirmed := s.peerConfirmed &&
 			s.peerIdx == i
 		if isCursor {
-			prefix = "▸"
+			prefix = theme.NavActive.Render("▸")
 			style = theme.Action
 		}
 		if isConfirmed {
@@ -916,7 +916,7 @@ func (s *ChannelOpenScreen) viewInput(
 	customConfirmed := s.peerConfirmed &&
 		s.peerIdx == len(s.peerList)
 	if customCursor {
-		customPrefix = "▸"
+		customPrefix = theme.NavActive.Render("▸")
 		customStyle = theme.Action
 	}
 	if customConfirmed {
@@ -943,7 +943,7 @@ func (s *ChannelOpenScreen) viewInput(
 	ccPrefix := " "
 	ccStyle := theme.Value
 	if amtFocused && s.amountIdx == 0 {
-		ccPrefix = "▸"
+		ccPrefix = theme.NavActive.Render("▸")
 		ccStyle = theme.Action
 	}
 	var ccLabel string
@@ -963,7 +963,7 @@ func (s *ChannelOpenScreen) viewInput(
 	amtStyle := theme.Value
 	amtCursor := amtFocused && s.amountIdx == 1
 	if amtCursor {
-		amtPrefix = "▸"
+		amtPrefix = theme.NavActive.Render("▸")
 		amtStyle = theme.Action
 	}
 	if s.amountConfirmed {
@@ -1022,7 +1022,7 @@ func (s *ChannelOpenScreen) viewInput(
 	}
 	p.line(" " + theme.Header.Render(
 		"Fee Rate (sat/vB):"))
-	p.line(feeMarker + " " + s.feeInput.View())
+	p.line(" " + feeMarker + " " + s.feeInput.View())
 	hints := formatFeeHints(s.feeTiers)
 	if hints != "" {
 		p.line("  " + theme.Dim.Render(hints))
@@ -1098,7 +1098,7 @@ func renderToggleSwitch(
 
 	prefix := "  "
 	if focused {
-		prefix = " " + theme.Action.Render("▸")
+		prefix = " " + theme.NavActive.Render("▸")
 	}
 
 	return prefix + leftStyled + " " +

--- a/internal/welcome/screen_channels_open.go
+++ b/internal/welcome/screen_channels_open.go
@@ -422,17 +422,7 @@ func (s *ChannelOpenScreen) handleToggleKey(
 	case "ctrl+c":
 		return s, tea.Quit
 	case "left":
-		if s.toggleIdx > 0 {
-			s.toggleIdx--
-		} else {
-			return s, emitFocusSidebar
-		}
-		return s, nil
-	case "right":
-		if s.toggleIdx < 1 {
-			s.toggleIdx++
-		}
-		return s, nil
+		return s, emitFocusSidebar
 	case "up":
 		if s.toggleIdx > 0 {
 			s.toggleIdx--
@@ -499,7 +489,9 @@ func (s *ChannelOpenScreen) handleButtonKey(
 	case "enter":
 		switch s.btnIdx {
 		case 0: // Clear
-			return s.clearForm(), nil
+			return s.clearForm(), tea.Batch(
+				fetchChannelUtxosCmd(s.ctx.LndClient),
+				fetchChannelTxsCmd(s.ctx.LndClient))
 		case 1: // Open Channel
 			return s.submitOpenChannel()
 		}
@@ -903,7 +895,7 @@ func (s *ChannelOpenScreen) viewInput(
 		if peer.Curated {
 			tags += " ★"
 		}
-		p.line(fmt.Sprintf(" %s %s%s",
+		p.line(fmt.Sprintf("%s %s%s",
 			prefix, style.Render(name),
 			theme.Dim.Render(tags)))
 	}
@@ -928,7 +920,7 @@ func (s *ChannelOpenScreen) viewInput(
 		customLabel = fmt.Sprintf("[%s]",
 			s.customAlias)
 	}
-	p.line(fmt.Sprintf(" %s %s",
+	p.line(fmt.Sprintf("%s %s",
 		customPrefix,
 		customStyle.Render(customLabel)))
 	p.blank()
@@ -955,7 +947,7 @@ func (s *ChannelOpenScreen) viewInput(
 	} else {
 		ccLabel = "[Coin control]"
 	}
-	p.line(fmt.Sprintf(" %s %s",
+	p.line(fmt.Sprintf("%s %s",
 		ccPrefix, ccStyle.Render(ccLabel)))
 
 	// Amount line
@@ -980,7 +972,7 @@ func (s *ChannelOpenScreen) viewInput(
 			annotation = theme.Dim.Render(
 				"  full UTXO(s), no change")
 		}
-		p.line(fmt.Sprintf(" %s %s%s",
+		p.line(fmt.Sprintf("%s %s%s",
 			amtPrefix,
 			amtStyle.Render(
 				formatSats(s.amount)+" sats"),
@@ -992,7 +984,7 @@ func (s *ChannelOpenScreen) viewInput(
 			inputW = 20
 		}
 		s.amountInput.SetWidth(inputW)
-		amtLine := fmt.Sprintf(" %s %s %s",
+		amtLine := fmt.Sprintf("%s %s %s",
 			amtPrefix,
 			amtStyle.Render("Amount:"),
 			s.amountInput.View())
@@ -1022,7 +1014,7 @@ func (s *ChannelOpenScreen) viewInput(
 	}
 	p.line(" " + theme.Header.Render(
 		"Fee Rate (sat/vB):"))
-	p.line(" " + feeMarker + " " + s.feeInput.View())
+	p.line(feeMarker + " " + s.feeInput.View())
 	hints := formatFeeHints(s.feeTiers)
 	if hints != "" {
 		p.line("  " + theme.Dim.Render(hints))
@@ -1096,9 +1088,9 @@ func renderToggleSwitch(
 			bracket.Render(" ]")
 	}
 
-	prefix := "  "
+	prefix := " "
 	if focused {
-		prefix = " " + theme.NavActive.Render("▸")
+		prefix = theme.NavActive.Render("▸")
 	}
 
 	return prefix + leftStyled + " " +
@@ -1149,7 +1141,7 @@ func (s *ChannelOpenScreen) toggleBindings() []key.Binding {
 		bind("space", "toggle", "space"),
 		kEnterNext,
 		bind("⇧tab", "fee", "shift+tab"),
-		kBack, kQuit,
+		kSidebar, kBack, kQuit,
 	}
 }
 

--- a/internal/welcome/screen_channels_open.go
+++ b/internal/welcome/screen_channels_open.go
@@ -1129,7 +1129,7 @@ func (s *ChannelOpenScreen) peerListBindings() []key.Binding {
 		kSidebar,
 	}
 	if s.ctx.HasTabs {
-		binds = append(binds, kShiftTabBack)
+		binds = append(binds, kShiftTabBar)
 	}
 	binds = append(binds, kBack, kQuit)
 	return binds
@@ -1137,7 +1137,8 @@ func (s *ChannelOpenScreen) peerListBindings() []key.Binding {
 
 func (s *ChannelOpenScreen) amountListBindings() []key.Binding {
 	return []key.Binding{
-		kUpDownSelect, kTabNext, kShiftTabBack,
+		kUpDownSelect, kTabNext,
+		bind("⇧tab", "peers", "shift+tab"),
 		kEnterConfirm, kSidebar, kBack, kQuit,
 	}
 }
@@ -1146,20 +1147,25 @@ func (s *ChannelOpenScreen) toggleBindings() []key.Binding {
 	return []key.Binding{
 		kUpDownSelect,
 		bind("space", "toggle", "space"),
-		kEnterNext, kShiftTabBack, kBack, kQuit,
+		kEnterNext,
+		bind("⇧tab", "fee", "shift+tab"),
+		kBack, kQuit,
 	}
 }
 
 func (s *ChannelOpenScreen) feeZoneBindings() []key.Binding {
 	return []key.Binding{
-		kLeftRightCursor, kTabNext, kShiftTabBack,
+		kLeftRightCursor, kTabNext,
+		bind("⇧tab", "amount", "shift+tab"),
 		kSidebar, kBack, kQuit,
 	}
 }
 
 func (s *ChannelOpenScreen) buttonBindings() []key.Binding {
 	binds := buttonNav(s.btnIdx)
-	binds = append(binds, kEnter, kShiftTabBack, kBack, kQuit)
+	binds = append(binds, kEnter,
+		bind("⇧tab", "toggles", "shift+tab"),
+		kBack, kQuit)
 	return binds
 }
 

--- a/internal/welcome/screen_channels_open.go
+++ b/internal/welcome/screen_channels_open.go
@@ -114,20 +114,26 @@ type ChannelOpenScreen struct {
 func NewChannelOpenScreen(
 	ctx *ScreenContext,
 ) *ChannelOpenScreen {
-	return &ChannelOpenScreen{
+	s := &ChannelOpenScreen{
 		ctx:          ctx,
 		step:         coStepInput,
 		peerList:     channelOpenPeers(),
 		amountInput:  NewAmountInput(),
 		feeInput:     NewFeeInput(),
 		private:      true,
-		taproot:      false,
+		taproot:      true,
 		btnIdx:       1,
 		pubkeyInput:  newChanPubkeyInput(),
 		hostInput:    newChanHostInput(),
 		customBtnIdx: 1,
 		utxoSelected: make(map[int]bool),
 	}
+	// Blur inputs that aren't active on initial render.
+	// Focus is granted by zone navigation handlers when
+	// the user reaches each input.
+	s.amountInput.Blur()
+	s.feeInput.Blur()
+	return s
 }
 
 // ── Screen interface ────────────────────────────────────
@@ -453,6 +459,9 @@ func (s *ChannelOpenScreen) handleToggleKey(
 		s.enterFeeBackward()
 		return s, nil
 	case "enter":
+		s.focusZone = coZoneButtons
+		return s, nil
+	case "space":
 		switch s.toggleIdx {
 		case 0:
 			s.private = !s.private
@@ -739,8 +748,9 @@ func (s *ChannelOpenScreen) clearForm() *ChannelOpenScreen {
 		s.feeInput.SetSats(
 			int64(s.feeTiers[0].SatPerVB))
 	}
+	s.feeInput.Blur()
 	s.private = true
-	s.taproot = false
+	s.taproot = true
 	s.toggleIdx = 0
 	s.utxoSelected = make(map[int]bool)
 	s.utxoSelectedTotal = 0
@@ -768,6 +778,12 @@ func (s *ChannelOpenScreen) submitOpenChannel() (
 		return s, nil
 	}
 
+	// Mandatory coin control
+	if len(s.utxoSelected) == 0 {
+		s.error = "Select UTXOs in Coin control first"
+		return s, nil
+	}
+
 	// Validate amount confirmed
 	if !s.amountConfirmed {
 		s.error = "Select a channel size first"
@@ -784,35 +800,20 @@ func (s *ChannelOpenScreen) submitOpenChannel() (
 		s.amount = n
 	}
 
-	// Effective total for coin control checks
-	var effectiveTotal int64
-	if len(s.utxoSelected) > 0 {
-		effectiveTotal = s.utxoSelectedTotal
-	} else if s.ctx.Status != nil &&
-		s.ctx.Status.lndBalance != "" {
-		effectiveTotal = parseBalance(
-			s.ctx.Status.lndBalance)
-	}
-
 	// FundMax minimum check
-	if s.fundMax && effectiveTotal > 0 &&
-		effectiveTotal < 20000 {
+	if s.fundMax && s.utxoSelectedTotal < 20000 {
 		s.error = "min 20,000 sats"
 		return s, nil
 	}
 
 	// Custom amount vs selected UTXOs check
 	feeRate := s.feeInput.Sats()
-	if !s.fundMax && len(s.utxoSelected) > 0 {
-		numInputs := len(s.utxoSelected)
-		if numInputs < 1 {
-			numInputs = 1
-		}
+	if !s.fundMax {
 		estFee := estimateSimpleFee(
-			numInputs, 2, feeRate)
-		if s.amount+estFee > effectiveTotal {
-			s.error = "not enough for amount " +
-				"and on-chain fee"
+			len(s.utxoSelected), 2, feeRate)
+		if s.amount+estFee > s.utxoSelectedTotal {
+			s.error = "Amount plus fee exceeds " +
+				"selected UTXOs"
 			return s, nil
 		}
 	}
@@ -983,7 +984,7 @@ func (s *ChannelOpenScreen) viewInput(
 		if hasCoinCtrl &&
 			s.amount == s.utxoSelectedTotal {
 			annotation = theme.Dim.Render(
-				"  full UTXO, no change")
+				"  full UTXO(s), no change")
 		}
 		p.line(fmt.Sprintf(" %s %s%s",
 			amtPrefix,
@@ -1006,7 +1007,7 @@ func (s *ChannelOpenScreen) viewInput(
 			typed := s.amountInput.Sats()
 			if typed == s.utxoSelectedTotal {
 				amtLine += theme.Dim.Render(
-					"  full UTXO, no change")
+					"  full UTXO(s), no change")
 			} else if typed < s.utxoSelectedTotal {
 				change := s.utxoSelectedTotal - typed
 				amtLine += theme.Warning.Render(
@@ -1021,13 +1022,11 @@ func (s *ChannelOpenScreen) viewInput(
 	// ── Fee rate ──
 	feeActive := isFocused &&
 		s.focusZone == coZoneFee
-	feeLabelStyle := theme.Label
 	feeMarker := " "
 	if feeActive {
-		feeLabelStyle = theme.NavActive
 		feeMarker = theme.NavActive.Render("▸")
 	}
-	p.line(" " + feeLabelStyle.Render(
+	p.line(" " + theme.Header.Render(
 		"Fee Rate (sat/vB):"))
 	p.line(feeMarker + " " + s.feeInput.View())
 	hints := formatFeeHints(s.feeTiers)
@@ -1151,8 +1150,9 @@ func (s *ChannelOpenScreen) amountListBindings() []key.Binding {
 
 func (s *ChannelOpenScreen) toggleBindings() []key.Binding {
 	return []key.Binding{
-		bind("←→", "toggle", "left", "right"),
-		kEnterToggle, kTabNext, kShiftTabBack, kBack, kQuit,
+		kUpDownSelect,
+		bind("space", "toggle", "space"),
+		kEnterNext, kShiftTabBack, kBack, kQuit,
 	}
 }
 
@@ -1184,8 +1184,8 @@ func channelOpenPeers() []peerOption {
 		{
 			Alias:       "Zeus",
 			Pubkey:      "031b301307574bbe9b9ac7b79cbe1700e31e544513eae0b5d7497483083f99e581",
-			Host:        "45.79.192.236:9735",
-			TorOnly:     false,
+			Host:        "r46dwvxcdri754hf6n3rwexmc53h5x4natg5g6hidnxfzejm5xrqn2id.onion:9735",
+			TorOnly:     true,
 			Curated:     true,
 			MinChanSize: 150000,
 		},

--- a/internal/welcome/screen_channels_open_confirm.go
+++ b/internal/welcome/screen_channels_open_confirm.go
@@ -119,9 +119,6 @@ func (s *ChannelOpenScreen) viewConfirm(
 	// Estimate fee for display
 	feeRate := s.feeInput.Sats()
 	numInputs := len(s.utxoSelected)
-	if numInputs < 1 {
-		numInputs = 1
-	}
 	numOutputs := 1
 	if !s.fundMax {
 		numOutputs = 2 // channel + change
@@ -130,18 +127,13 @@ func (s *ChannelOpenScreen) viewConfirm(
 		numInputs, numOutputs, feeRate)
 
 	if s.fundMax {
-		if len(s.utxoSelected) > 0 {
-			chanAmt := s.utxoSelectedTotal - estFee
-			if chanAmt < 0 {
-				chanAmt = 0
-			}
-			p.field("Amount:  ",
-				fmt.Sprintf("~%s sats (full UTXO minus fee)",
-					formatSats(chanAmt)))
-		} else {
-			p.field("Amount:  ",
-				"Max (full balance minus fee)")
+		chanAmt := s.utxoSelectedTotal - estFee
+		if chanAmt < 0 {
+			chanAmt = 0
 		}
+		p.field("Amount:  ",
+			fmt.Sprintf("~%s sats (full UTXO(s) minus fee)",
+				formatSats(chanAmt)))
 	} else {
 		p.field("Amount:  ",
 			formatSats(s.amount)+" sats")
@@ -191,7 +183,7 @@ func (s *ChannelOpenScreen) viewConfirm(
 	p.blank()
 
 	if s.fundMax {
-		p.warn("Spend full UTXO amount minus fee?")
+		p.warn("Spend full UTXO(s) amount minus fee?")
 	} else {
 		p.warn("Spend " +
 			formatSats(s.amount) + " sats?")
@@ -237,16 +229,11 @@ func (s *ChannelOpenScreen) viewResult(
 		p.blank()
 		p.field("Peer:   ", s.selectedAlias())
 		if s.fundMax {
-			if len(s.utxoSelected) > 0 {
-				p.field("Amount: ",
-					fmt.Sprintf(
-						"Max (%s sats minus fee)",
-						formatSats(
-							s.utxoSelectedTotal)))
-			} else {
-				p.field("Amount: ",
-					"Max (full balance minus fee)")
-			}
+			p.field("Amount: ",
+				fmt.Sprintf(
+					"Max (%s sats minus fee)",
+					formatSats(
+						s.utxoSelectedTotal)))
 		} else {
 			p.field("Amount: ",
 				formatSats(s.amount)+" sats")

--- a/internal/welcome/screen_channels_open_confirm.go
+++ b/internal/welcome/screen_channels_open_confirm.go
@@ -1,0 +1,264 @@
+package welcome
+
+import (
+	"fmt"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/ripsline/virtual-private-node/internal/theme"
+)
+
+// ── Confirm step ───────────────────────────────────────
+
+func (s *ChannelOpenScreen) handleConfirmKey(
+	keyStr string,
+) (Screen, tea.Cmd) {
+	switch keyStr {
+	case "ctrl+c":
+		return s, tea.Quit
+	case "left":
+		if s.confirmBtnIdx > 0 {
+			s.confirmBtnIdx--
+		} else {
+			return s, emitFocusSidebar
+		}
+		return s, nil
+	case "right":
+		if s.confirmBtnIdx < 1 {
+			s.confirmBtnIdx++
+		}
+		return s, nil
+	case "up":
+		if s.ctx.HasTabs {
+			return s, emitFocusTabBar
+		}
+		return s, nil
+	case "backspace":
+		s.backToInput()
+		return s, nil
+	case "enter":
+		switch s.confirmBtnIdx {
+		case 0: // Go Back
+			s.backToInput()
+			return s, nil
+		case 1: // Confirm
+			if s.inFlight {
+				return s, nil
+			}
+			s.inFlight = true
+			s.error = ""
+			s.step = coStepOpening
+			feeRate := s.feeInput.Sats()
+			return s, openChannelCmd(
+				s.ctx.LndClient,
+				s.selectedPubkey(),
+				s.selectedHost(),
+				s.amount,
+				s.private,
+				s.taproot,
+				s.utxoOutpoints,
+				s.fundMax,
+				uint64(feeRate),
+			)
+		}
+	}
+	return s, nil
+}
+
+func (s *ChannelOpenScreen) backToInput() {
+	s.step = coStepInput
+	s.error = ""
+	s.confirmBtnIdx = 0
+	s.focusZone = coZoneButtons
+	s.btnIdx = 1
+}
+
+// ── Opening step ───────────────────────────────────────
+
+func (s *ChannelOpenScreen) handleOpeningKey(
+	keyStr string,
+) (Screen, tea.Cmd) {
+	// Fund-moving operation in progress — block all keys.
+	return s, nil
+}
+
+// ── Result step ────────────────────────────────────────
+
+func (s *ChannelOpenScreen) handleResultKey(
+	keyStr string,
+) (Screen, tea.Cmd) {
+	switch keyStr {
+	case "ctrl+c":
+		return s, tea.Quit
+	case "enter":
+		return s, tea.Batch(
+			emitCloseTab,
+			emitRefreshStatus)
+	case "left":
+		return s, emitFocusSidebar
+	case "up", "shift+tab":
+		if s.ctx.HasTabs {
+			return s, emitFocusTabBar
+		}
+	case "backspace":
+		return s, emitFocusParent
+	}
+	return s, nil
+}
+
+// ── Confirm view ───────────────────────────────────────
+
+func (s *ChannelOpenScreen) viewConfirm(
+	w, h int,
+) string {
+	p := newPane(w)
+	p.title(theme.Warning, "Confirm Channel Open")
+
+	p.field("Peer:    ", s.selectedAlias())
+
+	// Estimate fee for display
+	feeRate := s.feeInput.Sats()
+	numInputs := len(s.utxoSelected)
+	if numInputs < 1 {
+		numInputs = 1
+	}
+	numOutputs := 1
+	if !s.fundMax {
+		numOutputs = 2 // channel + change
+	}
+	estFee := estimateSimpleFee(
+		numInputs, numOutputs, feeRate)
+
+	if s.fundMax {
+		if len(s.utxoSelected) > 0 {
+			chanAmt := s.utxoSelectedTotal - estFee
+			if chanAmt < 0 {
+				chanAmt = 0
+			}
+			p.field("Amount:  ",
+				fmt.Sprintf("~%s sats (full UTXO minus fee)",
+					formatSats(chanAmt)))
+		} else {
+			p.field("Amount:  ",
+				"Max (full balance minus fee)")
+		}
+	} else {
+		p.field("Amount:  ",
+			formatSats(s.amount)+" sats")
+	}
+
+	chanType := "public"
+	if s.private {
+		chanType = "private"
+	}
+	if s.taproot {
+		chanType += ", taproot"
+	}
+	p.field("Type:    ", chanType)
+
+	if feeRate > 0 {
+		p.field("Fee:     ",
+			fmt.Sprintf("%d sat/vB (~%s sats)",
+				feeRate, formatSats(estFee)))
+	} else {
+		p.field("Fee:     ", "auto (LND default)")
+	}
+
+	if len(s.utxoSelected) > 0 {
+		p.field("UTXOs:   ",
+			fmt.Sprintf("%d selected (%s sats)",
+				len(s.utxoSelected),
+				formatSats(s.utxoSelectedTotal)))
+	}
+
+	// Change warning for custom amount with coin control
+	if !s.fundMax && len(s.utxoSelected) > 0 &&
+		s.amount < s.utxoSelectedTotal {
+		change := s.utxoSelectedTotal -
+			s.amount - estFee
+		if change > 0 {
+			p.field("Change:  ",
+				theme.Warning.Render(
+					fmt.Sprintf("~%s sats",
+						formatSats(change))))
+		}
+	}
+
+	p.blank()
+
+	p.labelLine("Pubkey:")
+	p.mono(s.selectedPubkey())
+	p.blank()
+
+	if s.fundMax {
+		p.warn("Spend full UTXO amount minus fee?")
+	} else {
+		p.warn("Spend " +
+			formatSats(s.amount) + " sats?")
+	}
+
+	p.appendError(s.error)
+
+	return p.renderWithBottomButtons(
+		[]string{"Go Back", "Confirm"},
+		s.confirmBtnIdx, s.ctx.ContentFocused, h)
+}
+
+// ── Opening view ───────────────────────────────────────
+
+func (s *ChannelOpenScreen) viewOpening(
+	w, h int,
+) string {
+	p := newPane(w)
+	p.title(theme.Header, "Opening Channel...")
+	p.line(" " + theme.Value.Render(
+		"Connecting to peer and broadcasting tx."))
+	p.blank()
+	p.dim("May take up to 2 minutes over Tor.")
+	p.dim("Do not close the terminal.")
+	return p.renderWithBottomButtons(
+		[]string{"Opening..."}, 0, false, h)
+}
+
+// ── Result view ────────────────────────────────────────
+
+func (s *ChannelOpenScreen) viewResult(
+	w int,
+) string {
+	p := newPane(w)
+
+	if s.error != "" {
+		p.title(theme.Warning, "Channel Open Failed")
+		p.warnWrap(s.error)
+	} else {
+		p.title(theme.Success, "Channel Opening")
+		p.line(" " + theme.Value.Render(
+			"Funding tx broadcast successfully."))
+		p.blank()
+		p.field("Peer:   ", s.selectedAlias())
+		if s.fundMax {
+			if len(s.utxoSelected) > 0 {
+				p.field("Amount: ",
+					fmt.Sprintf(
+						"Max (%s sats minus fee)",
+						formatSats(
+							s.utxoSelectedTotal)))
+			} else {
+				p.field("Amount: ",
+					"Max (full balance minus fee)")
+			}
+		} else {
+			p.field("Amount: ",
+				formatSats(s.amount)+" sats")
+		}
+		if s.txid != "" {
+			p.blank()
+			p.labelLine("TX ID:")
+			p.monoWrap(s.txid)
+		}
+		p.blank()
+		p.dim("Channel will appear as pending.")
+	}
+
+	return p.render()
+}

--- a/internal/welcome/screen_channels_open_custom.go
+++ b/internal/welcome/screen_channels_open_custom.go
@@ -266,7 +266,7 @@ func (s *ChannelOpenScreen) customPeerBindings() []key.Binding {
 		return binds
 	case coCustomZoneHost:
 		return []key.Binding{
-			kLeftRightCursor, kTabNext,
+			kLeftRightCursor, kTabButtons,
 			bind("⇧tab", "pubkey", "shift+tab"),
 			kSidebar, kQuit,
 		}

--- a/internal/welcome/screen_channels_open_custom.go
+++ b/internal/welcome/screen_channels_open_custom.go
@@ -1,0 +1,268 @@
+package welcome
+
+import (
+	"strings"
+
+	"charm.land/bubbles/v2/key"
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/ripsline/virtual-private-node/internal/theme"
+)
+
+// ── Custom peer step ───────────────────────────────────
+
+func (s *ChannelOpenScreen) handleCustomPeerKey(
+	keyStr string, msg tea.KeyPressMsg,
+) (Screen, tea.Cmd) {
+	switch s.customZone {
+	case coCustomZonePubkey:
+		return s.handleCustomPubkeyKey(keyStr, msg)
+	case coCustomZoneHost:
+		return s.handleCustomHostKey(keyStr, msg)
+	case coCustomZoneButtons:
+		return s.handleCustomButtonKey(keyStr)
+	}
+	return s, nil
+}
+
+func (s *ChannelOpenScreen) handleCustomPubkeyKey(
+	keyStr string, msg tea.KeyPressMsg,
+) (Screen, tea.Cmd) {
+	switch keyStr {
+	case "ctrl+c":
+		return s, tea.Quit
+	case "left":
+		if s.pubkeyInput.Value() != "" {
+			var cmd tea.Cmd
+			s.pubkeyInput, cmd =
+				s.pubkeyInput.Update(tea.Msg(msg))
+			return s, cmd
+		}
+		return s, emitFocusSidebar
+	case "right":
+		if s.pubkeyInput.Value() != "" {
+			var cmd tea.Cmd
+			s.pubkeyInput, cmd =
+				s.pubkeyInput.Update(tea.Msg(msg))
+			return s, cmd
+		}
+		return s, nil
+	case "up":
+		if s.ctx.HasTabs {
+			return s, emitFocusTabBar
+		}
+		return s, nil
+	case "down":
+		s.pubkeyInput.Blur()
+		s.hostInput.Focus()
+		s.customZone = coCustomZoneHost
+		return s, nil
+	case "tab":
+		s.pubkeyInput.Blur()
+		s.hostInput.Focus()
+		s.customZone = coCustomZoneHost
+		return s, nil
+	case "shift+tab":
+		if s.ctx.HasTabs {
+			return s, emitFocusTabBar
+		}
+		return s, nil
+	case "backspace":
+		var cmd tea.Cmd
+		s.pubkeyInput, cmd =
+			s.pubkeyInput.Update(tea.Msg(msg))
+		return s, cmd
+	case "enter":
+		s.pubkeyInput.Blur()
+		s.hostInput.Focus()
+		s.customZone = coCustomZoneHost
+		return s, nil
+	default:
+		var cmd tea.Cmd
+		s.pubkeyInput, cmd =
+			s.pubkeyInput.Update(tea.Msg(msg))
+		return s, cmd
+	}
+}
+
+func (s *ChannelOpenScreen) handleCustomHostKey(
+	keyStr string, msg tea.KeyPressMsg,
+) (Screen, tea.Cmd) {
+	switch keyStr {
+	case "ctrl+c":
+		return s, tea.Quit
+	case "left":
+		if s.hostInput.Value() != "" {
+			var cmd tea.Cmd
+			s.hostInput, cmd =
+				s.hostInput.Update(tea.Msg(msg))
+			return s, cmd
+		}
+		return s, emitFocusSidebar
+	case "right":
+		if s.hostInput.Value() != "" {
+			var cmd tea.Cmd
+			s.hostInput, cmd =
+				s.hostInput.Update(tea.Msg(msg))
+			return s, cmd
+		}
+		return s, nil
+	case "up":
+		s.hostInput.Blur()
+		s.pubkeyInput.Focus()
+		s.customZone = coCustomZonePubkey
+		return s, nil
+	case "down":
+		s.hostInput.Blur()
+		s.customZone = coCustomZoneButtons
+		return s, nil
+	case "tab":
+		s.hostInput.Blur()
+		s.customZone = coCustomZoneButtons
+		return s, nil
+	case "shift+tab":
+		s.hostInput.Blur()
+		s.pubkeyInput.Focus()
+		s.customZone = coCustomZonePubkey
+		return s, nil
+	case "backspace":
+		var cmd tea.Cmd
+		s.hostInput, cmd =
+			s.hostInput.Update(tea.Msg(msg))
+		return s, cmd
+	case "enter":
+		s.hostInput.Blur()
+		s.customZone = coCustomZoneButtons
+		return s, nil
+	default:
+		var cmd tea.Cmd
+		s.hostInput, cmd =
+			s.hostInput.Update(tea.Msg(msg))
+		return s, cmd
+	}
+}
+
+func (s *ChannelOpenScreen) handleCustomButtonKey(
+	keyStr string,
+) (Screen, tea.Cmd) {
+	switch keyStr {
+	case "ctrl+c":
+		return s, tea.Quit
+	case "left":
+		if s.customBtnIdx > 0 {
+			s.customBtnIdx--
+		} else {
+			return s, emitFocusSidebar
+		}
+		return s, nil
+	case "right":
+		if s.customBtnIdx < 1 {
+			s.customBtnIdx++
+		}
+		return s, nil
+	case "up":
+		s.customZone = coCustomZoneHost
+		s.hostInput.Focus()
+		return s, nil
+	case "tab":
+		return s, nil
+	case "shift+tab":
+		s.customZone = coCustomZoneHost
+		s.hostInput.Focus()
+		return s, nil
+	case "enter":
+		switch s.customBtnIdx {
+		case 0: // Go Back
+			s.error = ""
+			s.step = coStepInput
+			return s, nil
+		case 1: // Continue
+			return s.submitCustomPeer()
+		}
+		return s, nil
+	case "backspace":
+		s.error = ""
+		s.step = coStepInput
+		return s, nil
+	}
+	return s, nil
+}
+
+// ── Custom peer form submission ────────────────────────
+
+func (s *ChannelOpenScreen) submitCustomPeer() (
+	Screen, tea.Cmd,
+) {
+	pubkey := strings.TrimSpace(
+		s.pubkeyInput.Value())
+	host := strings.TrimSpace(
+		s.hostInput.Value())
+	if pubkey == "" {
+		s.error = "Pubkey is required"
+		return s, nil
+	}
+	if len(pubkey) != 66 {
+		s.error = "Pubkey must be 66 hex chars"
+		return s, nil
+	}
+	if host == "" {
+		s.error = "Host required"
+		return s, nil
+	}
+	s.customPubkey = pubkey
+	s.customHost = host
+	s.customAlias = pubkey[:16] + "..."
+	s.error = ""
+	// Return to input with custom peer confirmed
+	s.peerIdx = len(s.peerList)
+	s.peerConfirmed = true
+	s.step = coStepInput
+	s.focusZone = coZoneAmounts
+	return s, nil
+}
+
+// ── Custom peer view ───────────────────────────────────
+
+func (s *ChannelOpenScreen) viewCustomPeer(
+	w, h int,
+) string {
+	p := newPane(w)
+	p.title(theme.Header, "Custom Peer")
+
+	isFocused := s.ctx.ContentFocused
+
+	p.input("Node Pubkey:",
+		s.pubkeyInput.View(),
+		isFocused &&
+			s.customZone == coCustomZonePubkey)
+	p.blank()
+	p.input("Host (host:port):",
+		s.hostInput.View(),
+		isFocused &&
+			s.customZone == coCustomZoneHost)
+
+	p.appendError(s.error)
+
+	btnFocused := isFocused &&
+		s.customZone == coCustomZoneButtons
+	return p.renderWithBottomButtons(
+		[]string{"Go Back", "Continue"},
+		s.customBtnIdx, btnFocused, h)
+}
+
+// ── Custom peer helpbar ────────────────────────────────
+
+func (s *ChannelOpenScreen) customPeerBindings() []key.Binding {
+	switch s.customZone {
+	case coCustomZonePubkey, coCustomZoneHost:
+		return []key.Binding{
+			kLeftRightCursor, kTabNext,
+			kShiftTabBack, kSidebar, kQuit,
+		}
+	case coCustomZoneButtons:
+		binds := buttonNav(s.customBtnIdx)
+		binds = append(binds, kEnter, kShiftTabBack, kBack, kQuit)
+		return binds
+	}
+	return nil
+}

--- a/internal/welcome/screen_channels_open_custom.go
+++ b/internal/welcome/screen_channels_open_custom.go
@@ -254,14 +254,27 @@ func (s *ChannelOpenScreen) viewCustomPeer(
 
 func (s *ChannelOpenScreen) customPeerBindings() []key.Binding {
 	switch s.customZone {
-	case coCustomZonePubkey, coCustomZoneHost:
+	case coCustomZonePubkey:
+		binds := []key.Binding{
+			kLeftRightCursor, kTabNext,
+			kSidebar,
+		}
+		if s.ctx.HasTabs {
+			binds = append(binds, kShiftTabBar)
+		}
+		binds = append(binds, kQuit)
+		return binds
+	case coCustomZoneHost:
 		return []key.Binding{
 			kLeftRightCursor, kTabNext,
-			kShiftTabBack, kSidebar, kQuit,
+			bind("⇧tab", "pubkey", "shift+tab"),
+			kSidebar, kQuit,
 		}
 	case coCustomZoneButtons:
 		binds := buttonNav(s.customBtnIdx)
-		binds = append(binds, kEnter, kShiftTabBack, kBack, kQuit)
+		binds = append(binds, kEnter,
+			bind("⇧tab", "host", "shift+tab"),
+			kBack, kQuit)
 		return binds
 	}
 	return nil

--- a/internal/welcome/screen_channels_open_utxos.go
+++ b/internal/welcome/screen_channels_open_utxos.go
@@ -469,7 +469,9 @@ func (s *ChannelOpenScreen) coinControlBindings() []key.Binding {
 	if s.ccZone == coCCZoneButtons {
 		binds := buttonNav(s.ccBtnIdx)
 		binds = append(binds,
-			kEnter, kShiftTabBack, kBack, kQuit)
+			kEnter,
+			bind("⇧tab", "UTXOs", "shift+tab"),
+			kBack, kQuit)
 		return binds
 	}
 	if !s.utxoFetched || len(s.utxos) == 0 {

--- a/internal/welcome/screen_channels_open_utxos.go
+++ b/internal/welcome/screen_channels_open_utxos.go
@@ -425,7 +425,7 @@ func (s *ChannelOpenScreen) viewUtxoTable(
 			marker = "✓"
 		}
 		if isCursor && !isChecked {
-			marker = "▸"
+			marker = theme.NavActive.Render("▸")
 		}
 
 		// Scroll indicator on edge rows

--- a/internal/welcome/screen_channels_open_utxos.go
+++ b/internal/welcome/screen_channels_open_utxos.go
@@ -417,7 +417,7 @@ func (s *ChannelOpenScreen) viewUtxoTable(
 		labelCell := pad(uLabel, labelW)
 		addrCell := pad(addr, addrW)
 		valCell := fmt.Sprintf("%*s",
-			valW, formatSats(u.AmountSats)+" sats")
+			valW, formatSats(u.AmountSats))
 
 		// Marker (1 char, matching on-chain home)
 		marker := " "

--- a/internal/welcome/screen_channels_open_utxos.go
+++ b/internal/welcome/screen_channels_open_utxos.go
@@ -1,0 +1,485 @@
+package welcome
+
+import (
+	"fmt"
+	"strings"
+
+	"charm.land/bubbles/v2/key"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	"github.com/ripsline/virtual-private-node/internal/lndrpc"
+	"github.com/ripsline/virtual-private-node/internal/theme"
+)
+
+// ── UTXO + transaction fetch for channel open ─────────
+// Separate message types so the Model-level utxoListMsg
+// and onChainTxMsg handlers (which populate OnChainContext)
+// are unaffected. Both routed via dispatchToTab(tabOpenChannel)
+// in update.go. Fetched in parallel via tea.Batch,
+// matching the previewSection(secOnChain) pattern.
+
+type coUtxoListMsg struct {
+	utxos []lndrpc.UTXO
+	err   error
+}
+
+type coTxListMsg struct {
+	txs []lndrpc.OnChainTx
+	err error
+}
+
+func fetchChannelUtxosCmd(
+	client *lndrpc.Client,
+) tea.Cmd {
+	return func() tea.Msg {
+		if client == nil {
+			return coUtxoListMsg{err: fmt.Errorf(
+				"LND not connected")}
+		}
+		utxos, err := client.ListUnspent(0, 999999)
+		return coUtxoListMsg{utxos: utxos, err: err}
+	}
+}
+
+func fetchChannelTxsCmd(
+	client *lndrpc.Client,
+) tea.Cmd {
+	return func() tea.Msg {
+		if client == nil {
+			return coTxListMsg{err: fmt.Errorf(
+				"LND not connected")}
+		}
+		txs, err := client.GetTransactions()
+		return coTxListMsg{txs: txs, err: err}
+	}
+}
+
+func (s *ChannelOpenScreen) handleUtxoList(
+	msg coUtxoListMsg,
+) (Screen, tea.Cmd) {
+	if msg.err != nil {
+		s.error = msg.err.Error()
+		return s, nil
+	}
+	s.utxos = msg.utxos
+	s.utxoFetched = true
+	// Prune selections beyond new UTXO range
+	for idx := range s.utxoSelected {
+		if idx >= len(s.utxos) {
+			delete(s.utxoSelected, idx)
+		}
+	}
+	s.recalcUtxoTotal()
+	return s, nil
+}
+
+func (s *ChannelOpenScreen) handleTxList(
+	msg coTxListMsg,
+) (Screen, tea.Cmd) {
+	if msg.err != nil {
+		// Non-fatal: table still works without
+		// date and label columns.
+		return s, nil
+	}
+	s.txs = msg.txs
+	return s, nil
+}
+
+// ── Transaction lookup helpers ────────────────────────
+// Same pattern as on-chain home's utxoDate / utxoTxLabel
+// but reading from the screen's own local tx list.
+
+func (s *ChannelOpenScreen) utxoDate(
+	txid string,
+) string {
+	for _, tx := range s.txs {
+		if tx.Txid == txid {
+			return formatDateShort(tx.Timestamp)
+		}
+	}
+	return "—"
+}
+
+func (s *ChannelOpenScreen) utxoTxLabel(
+	txid string,
+) string {
+	for _, tx := range s.txs {
+		if tx.Txid == txid {
+			return tx.Label
+		}
+	}
+	return ""
+}
+
+// ── Coin control sub-step ─────────────────────────────
+// Opened via enter on the [Coin control] button in the
+// amounts zone. Same sub-step pattern as coStepCustomPeer.
+
+const coUtxoVisibleRows = 10
+
+func (s *ChannelOpenScreen) handleCoinControlKey(
+	keyStr string,
+) (Screen, tea.Cmd) {
+	switch s.ccZone {
+	case coCCZoneList:
+		return s.handleCCListKey(keyStr)
+	case coCCZoneButtons:
+		return s.handleCCButtonKey(keyStr)
+	}
+	return s, nil
+}
+
+func (s *ChannelOpenScreen) handleCCListKey(
+	keyStr string,
+) (Screen, tea.Cmd) {
+	if !s.utxoFetched || len(s.utxos) == 0 {
+		switch keyStr {
+		case "ctrl+c":
+			return s, tea.Quit
+		case "left":
+			return s, emitFocusSidebar
+		case "up", "shift+tab":
+			if s.ctx.HasTabs {
+				return s, emitFocusTabBar
+			}
+			return s, nil
+		case "down", "tab":
+			s.ccZone = coCCZoneButtons
+			return s, nil
+		case "backspace":
+			return s.returnFromCoinControl(false)
+		}
+		return s, nil
+	}
+
+	switch keyStr {
+	case "ctrl+c":
+		return s, tea.Quit
+	case "left":
+		return s, emitFocusSidebar
+	case "up":
+		if s.utxoCursor > 0 {
+			s.utxoCursor--
+		} else if s.ctx.HasTabs {
+			return s, emitFocusTabBar
+		}
+		return s, nil
+	case "down":
+		if s.utxoCursor < len(s.utxos)-1 {
+			s.utxoCursor++
+		} else {
+			s.ccZone = coCCZoneButtons
+		}
+		return s, nil
+	case "tab":
+		s.ccZone = coCCZoneButtons
+		return s, nil
+	case "shift+tab":
+		if s.ctx.HasTabs {
+			return s, emitFocusTabBar
+		}
+		return s, nil
+	case "space", "enter":
+		s.toggleUtxoSelection(s.utxoCursor)
+		return s, nil
+	case "backspace":
+		return s.returnFromCoinControl(false)
+	}
+	return s, nil
+}
+
+func (s *ChannelOpenScreen) handleCCButtonKey(
+	keyStr string,
+) (Screen, tea.Cmd) {
+	switch keyStr {
+	case "ctrl+c":
+		return s, tea.Quit
+	case "left":
+		if s.ccBtnIdx > 0 {
+			s.ccBtnIdx--
+		} else {
+			return s, emitFocusSidebar
+		}
+		return s, nil
+	case "right":
+		if s.ccBtnIdx < 1 {
+			s.ccBtnIdx++
+		}
+		return s, nil
+	case "up", "shift+tab":
+		s.ccZone = coCCZoneList
+		return s, nil
+	case "enter":
+		switch s.ccBtnIdx {
+		case 0: // Go Back
+			return s.returnFromCoinControl(false)
+		case 1: // Confirm
+			return s.returnFromCoinControl(true)
+		}
+		return s, nil
+	case "backspace":
+		return s.returnFromCoinControl(false)
+	}
+	return s, nil
+}
+
+// returnFromCoinControl exits the coin control sub-step.
+// If confirm=true and UTXOs are selected, pre-fills amount
+// with the UTXO total, sets FundMax, auto-confirms, and
+// advances to the fee zone. Otherwise returns to amounts.
+func (s *ChannelOpenScreen) returnFromCoinControl(
+	confirm bool,
+) (Screen, tea.Cmd) {
+	s.step = coStepInput
+	s.error = ""
+
+	if confirm && len(s.utxoSelected) > 0 {
+		// Pre-fill amount, auto-confirm, advance
+		s.amount = s.utxoSelectedTotal
+		s.amountInput.SetSats(s.amount)
+		s.fundMax = true
+		s.amountConfirmed = true
+		s.amountIdx = 1
+		s.amountInput.Blur()
+		s.focusZone = coZoneFee
+		s.feeInput.Focus()
+		return s, nil
+	}
+
+	// No selection or cancelled
+	if len(s.utxoSelected) == 0 {
+		s.amount = 0
+		s.fundMax = false
+		s.amountConfirmed = false
+		s.amountInput.Clear()
+	}
+	s.focusZone = coZoneAmounts
+	s.amountIdx = 0
+	return s, nil
+}
+
+// ── Selection helpers ──────────────────────────────────
+
+func (s *ChannelOpenScreen) toggleUtxoSelection(
+	idx int,
+) {
+	if idx < 0 || idx >= len(s.utxos) {
+		return
+	}
+	if s.utxoSelected[idx] {
+		delete(s.utxoSelected, idx)
+	} else {
+		s.utxoSelected[idx] = true
+	}
+	s.recalcUtxoTotal()
+}
+
+func (s *ChannelOpenScreen) recalcUtxoTotal() {
+	s.utxoSelectedTotal = 0
+	s.utxoOutpoints = nil
+	for idx := range s.utxoSelected {
+		if idx < len(s.utxos) {
+			s.utxoSelectedTotal +=
+				s.utxos[idx].AmountSats
+			s.utxoOutpoints = append(
+				s.utxoOutpoints,
+				fmt.Sprintf("%s:%d",
+					s.utxos[idx].Txid,
+					s.utxos[idx].Vout))
+		}
+	}
+}
+
+// ── Coin control sub-step view ──────────────────────────
+
+func (s *ChannelOpenScreen) viewCoinControl(
+	w, h int,
+) string {
+	p := newPane(w)
+	p.title(theme.Header, "Coin Control")
+
+	// Selection summary
+	if len(s.utxoSelected) > 0 {
+		p.field("Selected: ",
+			fmt.Sprintf("%d UTXO (%s sats)",
+				len(s.utxoSelected),
+				formatSats(s.utxoSelectedTotal)))
+	} else {
+		p.dim(" Select UTXOs for the channel open.")
+	}
+	p.blank()
+
+	focused := s.ctx.ContentFocused &&
+		s.ccZone == coCCZoneList
+	s.viewUtxoTable(p, w, focused)
+
+	p.appendError(s.error)
+
+	btnFocused := s.ctx.ContentFocused &&
+		s.ccZone == coCCZoneButtons
+	return p.renderWithBottomButtons(
+		[]string{"Go Back", "Confirm"},
+		s.ccBtnIdx, btnFocused, h)
+}
+
+// ── UTXO table rendering ───────────────────────────────
+// Column layout matches on-chain home: Date, Label,
+// Address, Value. Shows up to coUtxoVisibleRows with
+// scroll indicators.
+
+func (s *ChannelOpenScreen) viewUtxoTable(
+	p *paneBuilder, w int, focused bool,
+) {
+	if !s.utxoFetched {
+		p.dim(" Loading...")
+		return
+	}
+	if len(s.utxos) == 0 {
+		p.dim(" No UTXOs available.")
+		return
+	}
+
+	// Column widths matching on-chain home
+	dateW := 12
+	labelW := 15
+	addrW := 18
+	valW := w - dateW - labelW - addrW - 5
+	if valW < 12 {
+		valW = 12
+	}
+
+	sepStyle := theme.TableDim
+	hdrStyle := theme.TableHeader
+
+	// Column headers
+	p.line(" " +
+		hdrStyle.Render(pad("Date", dateW)) +
+		hdrStyle.Render(pad("Label", labelW)) +
+		hdrStyle.Render(pad("Address", addrW)) +
+		hdrStyle.Render(
+			fmt.Sprintf("%*s", valW, "Value")))
+
+	// Separator
+	p.line(" " + sepStyle.Render(
+		strings.Repeat("─", w-2)))
+
+	// Visible window
+	visRows := coUtxoVisibleRows
+	if len(s.utxos) < visRows {
+		visRows = len(s.utxos)
+	}
+	startIdx := s.utxoCursor - visRows/2
+	if startIdx < 0 {
+		startIdx = 0
+	}
+	if startIdx+visRows > len(s.utxos) {
+		startIdx = len(s.utxos) - visRows
+		if startIdx < 0 {
+			startIdx = 0
+		}
+	}
+	endIdx := startIdx + visRows
+
+	hasAbove := startIdx > 0
+	hasBelow := endIdx < len(s.utxos)
+
+	checkStyle := lipgloss.NewStyle().
+		Foreground(theme.ColorCheck)
+
+	for i := startIdx; i < endIdx; i++ {
+		u := s.utxos[i]
+		isCursor := focused && s.utxoCursor == i
+		isChecked := s.utxoSelected[i]
+
+		// Date from tx lookup
+		dateStr := s.utxoDate(u.Txid)
+		if u.Confirmations == 0 {
+			dateStr = "unconfirmed"
+		}
+
+		// Label from tx lookup
+		uLabel := s.utxoTxLabel(u.Txid)
+		maxLbl := labelW - 1
+		if len(uLabel) > maxLbl {
+			uLabel = uLabel[:maxLbl-2] + ".."
+		}
+
+		// Address: first7..last7
+		addr := u.Address
+		if len(addr) > 16 {
+			addr = addr[:7] + ".." +
+				addr[len(addr)-7:]
+		}
+
+		// Formatted cells
+		dateCell := pad(dateStr, dateW)
+		labelCell := pad(uLabel, labelW)
+		addrCell := pad(addr, addrW)
+		valCell := fmt.Sprintf("%*s",
+			valW, formatSats(u.AmountSats)+" sats")
+
+		// Marker (1 char, matching on-chain home)
+		marker := " "
+		if isChecked {
+			marker = "✓"
+		}
+		if isCursor && !isChecked {
+			marker = "▸"
+		}
+
+		// Scroll indicator on edge rows
+		scrollInd := ""
+		if i == startIdx && hasAbove {
+			scrollInd = " ▲"
+		}
+		if i == endIdx-1 && hasBelow {
+			scrollInd = " ▼"
+		}
+
+		switch {
+		case isCursor:
+			p.line(marker +
+				theme.NavActive.Render(dateCell) +
+				theme.NavActive.Render(labelCell) +
+				theme.NavActive.Render(addrCell) +
+				theme.NavActive.Render(valCell) +
+				theme.Dim.Render(scrollInd))
+		case isChecked:
+			p.line(marker +
+				checkStyle.Render(dateCell) +
+				checkStyle.Render(labelCell) +
+				checkStyle.Render(addrCell) +
+				checkStyle.Render(valCell) +
+				theme.Dim.Render(scrollInd))
+		default:
+			p.line(marker +
+				theme.Dim.Render(dateCell) +
+				theme.Value.Render(labelCell) +
+				theme.Dim.Render(addrCell) +
+				theme.Value.Render(valCell) +
+				theme.Dim.Render(scrollInd))
+		}
+	}
+}
+
+// ── Helpbar bindings ───────────────────────────────────
+
+func (s *ChannelOpenScreen) coinControlBindings() []key.Binding {
+	if s.ccZone == coCCZoneButtons {
+		binds := buttonNav(s.ccBtnIdx)
+		binds = append(binds,
+			kEnter, kShiftTabBack, kBack, kQuit)
+		return binds
+	}
+	if !s.utxoFetched || len(s.utxos) == 0 {
+		return []key.Binding{
+			kTabNext, kBack, kQuit,
+		}
+	}
+	return []key.Binding{
+		bind("↑↓", "navigate", "up", "down"),
+		bind("enter/space", "select", "enter", "space"),
+		kTabNext, kBack, kQuit,
+	}
+}

--- a/internal/welcome/screen_channels_open_utxos.go
+++ b/internal/welcome/screen_channels_open_utxos.go
@@ -302,7 +302,7 @@ func (s *ChannelOpenScreen) viewCoinControl(
 	// Selection summary
 	if len(s.utxoSelected) > 0 {
 		p.field("Selected: ",
-			fmt.Sprintf("%d UTXO (%s sats)",
+			fmt.Sprintf("%d UTXO(s) (%s sats)",
 				len(s.utxoSelected),
 				formatSats(s.utxoSelectedTotal)))
 	} else {

--- a/internal/welcome/screen_offchain_home.go
+++ b/internal/welcome/screen_offchain_home.go
@@ -406,7 +406,7 @@ func (s *WalletHomeScreen) View(
 
 			marker := " "
 			if isSelected {
-				marker = "▸"
+				marker = theme.NavActive.Render("▸")
 				midLines = append(midLines,
 					marker+
 						selBg.Render(dateStr)+

--- a/internal/welcome/screen_offchain_receive.go
+++ b/internal/welcome/screen_offchain_receive.go
@@ -146,25 +146,29 @@ func (s *ReceiveScreen) HelpBindings() []key.Binding {
 func (s *ReceiveScreen) inputBindings() []key.Binding {
 	var binds []key.Binding
 	switch s.focusZone {
-	case recvZoneAmount, recvZoneMemo:
+	case recvZoneAmount:
 		binds = append(binds,
 			kUpDownFields, kTabNext, kEnterCreate,
 			kSidebar)
 		if s.ctx.HasTabs {
 			binds = append(binds, kShiftTabBar)
 		}
+	case recvZoneMemo:
+		binds = append(binds,
+			kUpDownFields, kTabNext, kEnterCreate,
+			bind("⇧tab", "amount", "shift+tab"),
+			kSidebar)
 	case recvZoneBlind:
 		binds = append(binds,
 			kUpDownFields,
 			bind("space", "toggle", "space"),
 			kEnterNext, kTabNext,
+			bind("⇧tab", "memo", "shift+tab"),
 			kSidebar)
-		if s.ctx.HasTabs {
-			binds = append(binds, kShiftTabBar)
-		}
 	case recvZoneButtons:
 		binds = append(binds,
-			kLeftRightButtons, kEnter, kShiftTabBack,
+			kLeftRightButtons, kEnter,
+			bind("⇧tab", "toggle", "shift+tab"),
 			kBack)
 	}
 	binds = append(binds, kQuit)

--- a/internal/welcome/screen_offchain_receive.go
+++ b/internal/welcome/screen_offchain_receive.go
@@ -64,6 +64,7 @@ func NewReceiveScreen(
 	ctx *ScreenContext,
 ) *ReceiveScreen {
 	amt := NewAmountInput()
+	amt.Focus() // amount is the initial focus zone
 	return &ReceiveScreen{
 		ctx:         ctx,
 		step:        recvStepInput,

--- a/internal/welcome/screen_offchain_receive.go
+++ b/internal/welcome/screen_offchain_receive.go
@@ -166,9 +166,6 @@ func (s *ReceiveScreen) inputBindings() []key.Binding {
 		binds = append(binds,
 			kLeftRightButtons, kEnter, kShiftTabBack,
 			kBack)
-		if s.ctx.HasTabs {
-			binds = append(binds, kUpTabBar)
-		}
 	}
 	binds = append(binds, kQuit)
 	return binds
@@ -595,10 +592,9 @@ func (s *ReceiveScreen) viewInput(w, h int) string {
 	// ── Blinded paths toggle ──
 	blindFocused := isFocused &&
 		s.focusZone == recvZoneBlind
-	blindLabel := theme.Label
+	blindLabel := theme.Header
 	blindMarker := " "
 	if blindFocused {
-		blindLabel = theme.NavActive
 		blindMarker = theme.NavActive.Render("▸")
 	}
 	blindValue := theme.Good.Render("● on")

--- a/internal/welcome/screen_offchain_receive.go
+++ b/internal/welcome/screen_offchain_receive.go
@@ -155,7 +155,9 @@ func (s *ReceiveScreen) inputBindings() []key.Binding {
 		}
 	case recvZoneBlind:
 		binds = append(binds,
-			kEnterToggle, kUpDownFields, kTabNext,
+			kUpDownFields,
+			bind("space", "toggle", "space"),
+			kEnterNext, kTabNext,
 			kSidebar)
 		if s.ctx.HasTabs {
 			binds = append(binds, kShiftTabBar)
@@ -192,158 +194,172 @@ func (s *ReceiveScreen) focusInputZone() {
 func (s *ReceiveScreen) handleInputKey(
 	keyStr string, msg tea.KeyPressMsg,
 ) (Screen, tea.Cmd) {
+	switch s.focusZone {
+	case recvZoneAmount:
+		return s.handleAmountKey(keyStr, msg)
+	case recvZoneMemo:
+		return s.handleMemoKey(keyStr, msg)
+	case recvZoneBlind:
+		return s.handleBlindKey(keyStr)
+	case recvZoneButtons:
+		return s.handleButtonKey(keyStr)
+	}
+	return s, nil
+}
+
+// advanceToButtons blurs text inputs and moves focus to
+// the buttons zone with Create Invoice as the default.
+func (s *ReceiveScreen) advanceToButtons() {
+	s.amountInput.Blur()
+	s.memoInput.Blur()
+	s.focusZone = recvZoneButtons
+	s.btnIdx = 1 // default to Create Invoice
+}
+
+// ── Per-zone key handlers ─────────────────────────────
+
+func (s *ReceiveScreen) handleAmountKey(
+	keyStr string, msg tea.KeyPressMsg,
+) (Screen, tea.Cmd) {
 	switch keyStr {
 	case "ctrl+c":
 		return s, tea.Quit
-
 	case "left":
-		// Buttons: move left
-		if s.focusZone == recvZoneButtons &&
-			s.btnIdx > 0 {
-			s.btnIdx--
-			return s, nil
-		}
-		// Text inputs: pass through for cursor
-		if s.focusZone == recvZoneAmount {
-			if !s.amountInput.Empty() {
-				cmd := s.amountInput.Update(
-					tea.Msg(msg))
-				return s, cmd
-			}
-		}
-		if s.focusZone == recvZoneMemo {
-			if s.memoInput.Value() != "" {
-				var cmd tea.Cmd
-				s.memoInput, cmd =
-					s.memoInput.Update(
-						tea.Msg(msg))
-				return s, cmd
-			}
+		if !s.amountInput.Empty() {
+			cmd := s.amountInput.Update(
+				tea.Msg(msg))
+			return s, cmd
 		}
 		return s, emitFocusSidebar
-
 	case "right":
-		// Buttons: move right
-		if s.focusZone == recvZoneButtons &&
-			s.btnIdx < 1 {
-			s.btnIdx++
-			return s, nil
-		}
-		// Text inputs: pass through for cursor
-		if s.focusZone == recvZoneAmount {
-			cmd := s.amountInput.Update(tea.Msg(msg))
-			return s, cmd
-		}
-		if s.focusZone == recvZoneMemo {
-			var cmd tea.Cmd
-			s.memoInput, cmd =
-				s.memoInput.Update(tea.Msg(msg))
-			return s, cmd
-		}
-		return s, nil
-
+		cmd := s.amountInput.Update(tea.Msg(msg))
+		return s, cmd
 	case "backspace":
-		if s.focusZone == recvZoneAmount {
-			cmd := s.amountInput.Update(tea.Msg(msg))
-			return s, cmd
-		}
-		if s.focusZone == recvZoneMemo {
-			var cmd tea.Cmd
-			s.memoInput, cmd =
-				s.memoInput.Update(tea.Msg(msg))
-			return s, cmd
-		}
-		return s, emitFocusParent
-
-	case "tab":
-		// Express forward jump between zones
-		if s.focusZone < recvZoneButtons {
-			s.focusZone++
-			if s.focusZone == recvZoneButtons {
-				s.amountInput.Blur()
-				s.memoInput.Blur()
-				s.btnIdx = 1 // default to Create Invoice
-			} else {
-				s.focusInputZone()
-			}
-		}
-		return s, nil
-
-	case "shift+tab":
-		// Express backward jump between zones
-		if s.focusZone > recvZoneAmount {
-			s.focusZone--
-			s.focusInputZone()
-		} else if s.ctx.HasTabs {
-			return s, emitFocusTabBar
-		}
-		return s, nil
-
-	case "down":
-		// Move to next zone at boundary
-		if s.focusZone < recvZoneButtons {
-			s.focusZone++
-			if s.focusZone == recvZoneButtons {
-				s.amountInput.Blur()
-				s.memoInput.Blur()
-				s.btnIdx = 1
-			} else {
-				s.focusInputZone()
-			}
-		}
-		return s, nil
-
-	case "up":
-		// Move to previous zone at boundary
-		if s.focusZone > recvZoneAmount {
-			s.focusZone--
-			s.focusInputZone()
-			return s, nil
-		}
+		cmd := s.amountInput.Update(tea.Msg(msg))
+		return s, cmd
+	case "up", "shift+tab":
 		if s.ctx.HasTabs {
 			return s, emitFocusTabBar
 		}
 		return s, nil
-
-	case "enter":
-		// Buttons
-		if s.focusZone == recvZoneButtons {
-			switch s.btnIdx {
-			case 0: // Clear
-				s.amountInput.Clear()
-				s.memoInput = newRecvMemoInput()
-				s.blindPaths = true
-				s.inputError = ""
-				s.focusZone = recvZoneAmount
-				s.focusInputZone()
-				return s, nil
-			case 1: // Create Invoice
-				return s.submitInvoice()
-			}
-			return s, nil
-		}
-		// Blind toggle
-		if s.focusZone == recvZoneBlind {
-			s.blindPaths = !s.blindPaths
-			return s, nil
-		}
-		// Enter in text field → advance to buttons
-		s.focusZone = recvZoneButtons
-		s.amountInput.Blur()
-		s.memoInput.Blur()
-		s.btnIdx = 1 // default to Create Invoice
+	case "down", "tab":
+		s.focusZone = recvZoneMemo
+		s.focusInputZone()
 		return s, nil
-
+	case "enter":
+		s.advanceToButtons()
+		return s, nil
 	default:
-		var cmd tea.Cmd
-		if s.focusZone == recvZoneAmount {
-			cmd = s.amountInput.Update(tea.Msg(msg))
-		} else if s.focusZone == recvZoneMemo {
-			s.memoInput, cmd =
-				s.memoInput.Update(tea.Msg(msg))
-		}
+		cmd := s.amountInput.Update(tea.Msg(msg))
 		return s, cmd
 	}
+}
+
+func (s *ReceiveScreen) handleMemoKey(
+	keyStr string, msg tea.KeyPressMsg,
+) (Screen, tea.Cmd) {
+	switch keyStr {
+	case "ctrl+c":
+		return s, tea.Quit
+	case "left":
+		if s.memoInput.Value() != "" {
+			var cmd tea.Cmd
+			s.memoInput, cmd =
+				s.memoInput.Update(tea.Msg(msg))
+			return s, cmd
+		}
+		return s, emitFocusSidebar
+	case "right":
+		var cmd tea.Cmd
+		s.memoInput, cmd =
+			s.memoInput.Update(tea.Msg(msg))
+		return s, cmd
+	case "backspace":
+		var cmd tea.Cmd
+		s.memoInput, cmd =
+			s.memoInput.Update(tea.Msg(msg))
+		return s, cmd
+	case "up", "shift+tab":
+		s.focusZone = recvZoneAmount
+		s.focusInputZone()
+		return s, nil
+	case "down", "tab":
+		s.focusZone = recvZoneBlind
+		s.focusInputZone()
+		return s, nil
+	case "enter":
+		s.advanceToButtons()
+		return s, nil
+	default:
+		var cmd tea.Cmd
+		s.memoInput, cmd =
+			s.memoInput.Update(tea.Msg(msg))
+		return s, cmd
+	}
+}
+
+func (s *ReceiveScreen) handleBlindKey(
+	keyStr string,
+) (Screen, tea.Cmd) {
+	switch keyStr {
+	case "ctrl+c":
+		return s, tea.Quit
+	case "left":
+		return s, emitFocusSidebar
+	case "backspace":
+		return s, emitFocusParent
+	case "up", "shift+tab":
+		s.focusZone = recvZoneMemo
+		s.focusInputZone()
+		return s, nil
+	case "down", "tab", "enter":
+		s.advanceToButtons()
+		return s, nil
+	case "space":
+		s.blindPaths = !s.blindPaths
+		return s, nil
+	}
+	return s, nil
+}
+
+func (s *ReceiveScreen) handleButtonKey(
+	keyStr string,
+) (Screen, tea.Cmd) {
+	switch keyStr {
+	case "ctrl+c":
+		return s, tea.Quit
+	case "left":
+		if s.btnIdx > 0 {
+			s.btnIdx--
+			return s, nil
+		}
+		return s, emitFocusSidebar
+	case "right":
+		if s.btnIdx < 1 {
+			s.btnIdx++
+		}
+		return s, nil
+	case "up", "shift+tab":
+		s.focusZone = recvZoneBlind
+		s.focusInputZone()
+		return s, nil
+	case "backspace":
+		return s, emitFocusParent
+	case "enter":
+		switch s.btnIdx {
+		case 0: // Clear
+			s.amountInput.Clear()
+			s.memoInput = newRecvMemoInput()
+			s.blindPaths = true
+			s.inputError = ""
+			s.focusZone = recvZoneAmount
+			s.focusInputZone()
+			return s, nil
+		case 1: // Create Invoice
+			return s.submitInvoice()
+		}
+	}
+	return s, nil
 }
 
 // submitInvoice validates and creates the invoice.

--- a/internal/welcome/screen_offchain_send.go
+++ b/internal/welcome/screen_offchain_send.go
@@ -558,7 +558,7 @@ func (s *SendScreen) inputBindings() []key.Binding {
 		}
 	case sendZoneButtons:
 		binds = append(binds,
-			kLeftRightButtons, kEnter, kShiftTabBack,
+			kLeftRightButtons, kEnter, kShiftTabInput,
 			kBack)
 	}
 	binds = append(binds, kQuit)

--- a/internal/welcome/screen_onchain_home.go
+++ b/internal/welcome/screen_onchain_home.go
@@ -675,7 +675,7 @@ func (s *OnChainHomeScreen) View(
 				marker = "✓"
 			}
 			if isSelected && !isChecked {
-				marker = "▸"
+				marker = theme.NavActive.Render("▸")
 			}
 
 			selStyle := theme.NavActive
@@ -812,7 +812,7 @@ func (s *OnChainHomeScreen) View(
 
 			marker := " "
 			if isSelected {
-				marker = "▸"
+				marker = theme.NavActive.Render("▸")
 				selStyle := theme.NavActive
 				txMidLines = append(txMidLines,
 					marker+
@@ -930,10 +930,9 @@ func (s *OnChainHomeScreen) renderLabelPopup(
 			"┌"+strings.Repeat("─", boxW)+"┐"))
 
 	lblActive := isFocused && !s.labelOnBtn
-	lblStyle := theme.Label
+	lblStyle := theme.Header
 	marker := " "
 	if lblActive {
-		lblStyle = theme.NavActive
 		marker = theme.NavActive.Render("▸")
 	}
 	inputView := s.labelInput.View()

--- a/internal/welcome/screen_onchain_send.go
+++ b/internal/welcome/screen_onchain_send.go
@@ -847,10 +847,9 @@ func (s *OnChainSendScreen) viewInput(
 	// ── Address input (step 0) ──────────────────
 	addrActive := isFocused &&
 		s.step == ocStepAddr
-	addrLabel := theme.Label
+	addrLabel := theme.Header
 	addrMarker := " "
 	if addrActive {
-		addrLabel = theme.NavActive
 		addrMarker = theme.NavActive.Render("▸")
 	}
 	lines = append(lines,
@@ -862,10 +861,9 @@ func (s *OnChainSendScreen) viewInput(
 	// ── Amount input (step 1) ───────────────────
 	amtActive := isFocused &&
 		s.step == ocStepAmount
-	amtLabel := theme.Label
+	amtLabel := theme.Header
 	amtMarker := " "
 	if amtActive {
-		amtLabel = theme.NavActive
 		amtMarker = theme.NavActive.Render("▸")
 	}
 
@@ -896,10 +894,9 @@ func (s *OnChainSendScreen) viewInput(
 	// ── Label input (step 2) ────────────────────
 	lblActive := isFocused &&
 		s.step == ocStepLabel
-	lblLabel := theme.Label
+	lblLabel := theme.Header
 	lblMarker := " "
 	if lblActive {
-		lblLabel = theme.NavActive
 		lblMarker = theme.NavActive.Render("▸")
 	}
 	lines = append(lines,
@@ -911,10 +908,9 @@ func (s *OnChainSendScreen) viewInput(
 	// ── Fee rate input (step 3) ─────────────────
 	feeActive := isFocused &&
 		s.step == ocStepFee
-	feeLabelStyle := theme.Label
+	feeLabelStyle := theme.Header
 	feeMarker := " "
 	if feeActive {
-		feeLabelStyle = theme.NavActive
 		feeMarker = theme.NavActive.Render("▸")
 	}
 	lines = append(lines,

--- a/internal/welcome/screen_onchain_send.go
+++ b/internal/welcome/screen_onchain_send.go
@@ -1271,8 +1271,20 @@ func (s *OnChainSendScreen) inputFieldBindings() []key.Binding {
 		bind("enter", "continue", "enter"),
 		kSidebar,
 	}
-	if s.ctx.HasTabs {
-		binds = append(binds, kShiftTabBar)
+	switch s.step {
+	case ocStepAddr:
+		if s.ctx.HasTabs {
+			binds = append(binds, kShiftTabBar)
+		}
+	case ocStepAmount:
+		binds = append(binds,
+			bind("⇧tab", "address", "shift+tab"))
+	case ocStepLabel:
+		binds = append(binds,
+			bind("⇧tab", "amount", "shift+tab"))
+	case ocStepFee:
+		binds = append(binds,
+			bind("⇧tab", "label", "shift+tab"))
 	}
 	binds = append(binds, kQuit)
 	return binds
@@ -1281,7 +1293,8 @@ func (s *OnChainSendScreen) inputFieldBindings() []key.Binding {
 func (s *OnChainSendScreen) inputButtonBindings() []key.Binding {
 	binds := buttonNav(s.sendBtnIdx)
 	binds = append(binds,
-		kEnter, kShiftTabBack,
+		kEnter,
+		bind("⇧tab", "fee", "shift+tab"),
 		bind("↑", "fields", "up"),
 		kBack, kQuit)
 	return binds

--- a/internal/welcome/screen_onchain_send.go
+++ b/internal/welcome/screen_onchain_send.go
@@ -67,7 +67,7 @@ func NewOnChainSendScreen(
 	ctx *ScreenContext,
 	ocCtx *OnChainContext,
 ) *OnChainSendScreen {
-	return &OnChainSendScreen{
+	s := &OnChainSendScreen{
 		ctx:        ctx,
 		ocCtx:      ocCtx,
 		step:       ocStepAddr,
@@ -77,6 +77,12 @@ func NewOnChainSendScreen(
 		feeInput:   NewFeeInput(),
 		sendBtnIdx: 1, // default to Create Transaction
 	}
+	// Blur inputs that aren't active on initial render.
+	// addrInput stays focused (user starts on addr step).
+	// focusStep() manages focus on all step transitions.
+	s.amtInput.Blur()
+	s.feeInput.Blur()
+	return s
 }
 
 // ── Screen interface ────────────────────────────────────
@@ -810,6 +816,10 @@ func (s *OnChainSendScreen) resetInputs() {
 	s.feeRate = 0
 	s.labelVal = ""
 	s.error = ""
+	// Blur inputs not active on addr step.
+	// addrInput starts focused (correct).
+	s.amtInput.Blur()
+	s.feeInput.Blur()
 	// Re-fill fee from cached tiers
 	if s.ocCtx.SendFeeTiers[0].SatPerVB > 0 {
 		s.feeInput.SetSats(

--- a/internal/welcome/screen_onchain_send.go
+++ b/internal/welcome/screen_onchain_send.go
@@ -77,11 +77,6 @@ func NewOnChainSendScreen(
 		feeInput:   NewFeeInput(),
 		sendBtnIdx: 1, // default to Create Transaction
 	}
-	// Blur inputs that aren't active on initial render.
-	// addrInput stays focused (user starts on addr step).
-	// focusStep() manages focus on all step transitions.
-	s.amtInput.Blur()
-	s.feeInput.Blur()
 	return s
 }
 
@@ -816,10 +811,6 @@ func (s *OnChainSendScreen) resetInputs() {
 	s.feeRate = 0
 	s.labelVal = ""
 	s.error = ""
-	// Blur inputs not active on addr step.
-	// addrInput starts focused (correct).
-	s.amtInput.Blur()
-	s.feeInput.Blur()
 	// Re-fill fee from cached tiers
 	if s.ocCtx.SendFeeTiers[0].SatPerVB > 0 {
 		s.feeInput.SetSats(

--- a/internal/welcome/screen_system_auto_unlock.go
+++ b/internal/welcome/screen_system_auto_unlock.go
@@ -649,11 +649,21 @@ func (s *AutoUnlockScreen) HelpBindings() []key.Binding {
 }
 
 func (s *AutoUnlockScreen) enableBindings() []key.Binding {
-	if s.focusZone == auZoneInput1 ||
-		s.focusZone == auZoneInput2 {
-		return []key.Binding{
+	if s.focusZone == auZoneInput1 {
+		binds := []key.Binding{
 			kEnterNext,
 			kTabNextField,
+		}
+		if s.ctx.HasTabs {
+			binds = append(binds, kShiftTabBar)
+		}
+		binds = append(binds, kQuit)
+		return binds
+	}
+	if s.focusZone == auZoneInput2 {
+		return []key.Binding{
+			kEnterNext,
+			kTabButtons,
 			bind("⇧tab", "prev field", "shift+tab"),
 			kQuit,
 		}

--- a/internal/welcome/screen_system_change_password.go
+++ b/internal/welcome/screen_system_change_password.go
@@ -178,12 +178,21 @@ func (s *ChangePasswordScreen) HelpBindings() []key.Binding {
 			binds = append(binds, buttonNav(s.btnIdx)...)
 			binds = append(binds,
 				kEnter,
-				kShiftTabBack,
+				bind("⇧tab", "fields", "shift+tab"),
 				kBack)
-		} else {
+		} else if s.focusZone == changePwZoneInputNew {
 			binds = append(binds,
 				kTabNextField,
 				kEnterNext,
+				kSidebar)
+			if s.ctx.HasTabs {
+				binds = append(binds, kShiftTabBar)
+			}
+		} else {
+			binds = append(binds,
+				kTabButtons,
+				kEnterNext,
+				bind("⇧tab", "prev field", "shift+tab"),
 				kSidebar)
 		}
 		binds = append(binds, kQuit)
@@ -478,16 +487,6 @@ func (s *ChangePasswordScreen) focusButtons(on bool) {
 func (s *ChangePasswordScreen) isOnInput() bool {
 	return s.focusZone == changePwZoneInputNew ||
 		s.focusZone == changePwZoneInputConfirm
-}
-
-func (s *ChangePasswordScreen) activeInputValue() string {
-	switch s.focusZone {
-	case changePwZoneInputNew:
-		return s.newInput.Value()
-	case changePwZoneInputConfirm:
-		return s.confInput.Value()
-	}
-	return ""
 }
 
 func (s *ChangePasswordScreen) routeKeyToInput(

--- a/internal/welcome/screen_system_home.go
+++ b/internal/welcome/screen_system_home.go
@@ -401,7 +401,7 @@ func (s *SystemHomeScreen) View(
 			style = theme.NavActive
 		}
 
-		svcLine := " " + prefix + " " + dot + " " +
+		svcLine := prefix + " " + dot + " " +
 			style.Render(name)
 
 		if isSelected && s.svcPending != "" {

--- a/internal/welcome/screen_system_home.go
+++ b/internal/welcome/screen_system_home.go
@@ -397,7 +397,7 @@ func (s *SystemHomeScreen) View(
 		prefix := " "
 		style := theme.Value
 		if isSelected {
-			prefix = "▸"
+			prefix = theme.NavActive.Render("▸")
 			style = theme.NavActive
 		}
 

--- a/internal/welcome/screen_system_ssh_key_add.go
+++ b/internal/welcome/screen_system_ssh_key_add.go
@@ -294,13 +294,16 @@ func (s *SSHKeyAddScreen) inputBindings() []key.Binding {
 		binds = append(binds, buttonNav(s.btnIdx)...)
 		binds = append(binds,
 			kEnter,
-			kShiftTabBack,
+			kShiftTabInput,
 			kBack)
 	} else {
 		binds = append(binds,
 			kTabButtons,
 			bind("enter", "add", "enter"),
 			kSidebar)
+		if s.ctx.HasTabs {
+			binds = append(binds, kShiftTabBar)
+		}
 	}
 
 	binds = append(binds, kQuit)

--- a/internal/welcome/screen_system_ssh_keys.go
+++ b/internal/welcome/screen_system_ssh_keys.go
@@ -394,7 +394,7 @@ func (s *SSHKeysScreen) viewList(w, h int) string {
 
 			marker := " "
 			if isSelected {
-				marker = "▸"
+				marker = theme.NavActive.Render("▸")
 				cursorLine = len(midLines)
 				midLines = append(midLines,
 					marker+

--- a/internal/welcome/update.go
+++ b/internal/welcome/update.go
@@ -302,6 +302,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.dispatchToTab(tabSyncthingDevice, msg)
 	case channelOpenResultMsg:
 		return m.dispatchToTab(tabOpenChannel, msg)
+	case coUtxoListMsg:
+		return m.dispatchToTab(tabOpenChannel, msg)
+	case coTxListMsg:
+		return m.dispatchToTab(tabOpenChannel, msg)
 	case newAddressMsg:
 		return m.dispatchToTab(tabOCReceive, msg)
 	case invoiceCreatedMsg:
@@ -403,7 +407,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// reason.
 		var cmds []tea.Cmd
 		for _, kind := range []tabKind{
-			tabChannel, tabOnChain,
+			tabChannel, tabOnChain, tabOpenChannel,
 		} {
 			rm, cmd, ok := m.routeToScreen(kind, msg)
 			if !ok {


### PR DESCRIPTION
Mandatory coin control for channel opens. Users must select
UTXOs before opening a channel, supporting the "1 UTXO in,
1 channel out" privacy workflow.

## Changes

**Coin control**
- RPC: OpenChannel accepts outpoints, fundMax, satPerVbyte
- File split: screen_channels_open into 4 files (main,
  custom peer, confirm, UTXO sub-step)
- Coin control sub-step with UTXO table, selection, confirm
- Amount auto-confirms from coin control, FundMax detection
- Fee rate input with tier hints, optional (LND default)
- Mandatory coin control enforced, taproot default on
- Toggle enter/space split, dual cursor fix

**Focus and styling**
- Input constructors start blurred, callers opt in
- Zone-first refactor on receive screen
- Arrow markers: NavActive sole focus indicator across TUI
- Label de-highlighting: always theme.Header
- Helpbar shift+tab labels name destinations

**Fixes and consistency**
- FundMax: don't set LocalFundingAmount when FundMax=true
- clearForm: trigger UTXO refetch instead of silent invalidation
- Toggle left/right: left always goes to sidebar
- Marker indentation normalized to col 0 across TUI
- SSH key add helpbar fixes, dead kShiftTabBack removed
- UTXO(s) pluralization, custom peer host helpbar label