### PR TITLE
fix: verification keyring binding

### DIFF
--- a/internal/installer/bitcoin.go
+++ b/internal/installer/bitcoin.go
@@ -5,44 +5,52 @@ package installer
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/ripsline/virtual-private-node/internal/config"
 	"github.com/ripsline/virtual-private-node/internal/paths"
 	"github.com/ripsline/virtual-private-node/internal/system"
 )
 
-func downloadBitcoin(version string) error {
+func downloadBitcoin(version, workDir string) error {
 	filename := fmt.Sprintf("bitcoin-%s-x86_64-linux-gnu.tar.gz", version)
 	baseURL := fmt.Sprintf("https://bitcoincore.org/bin/bitcoin-core-%s", version)
-	if err := system.DownloadRequireTor(baseURL+"/"+filename, "/tmp/"+filename); err != nil {
+	if err := system.DownloadRequireTor(
+		baseURL+"/"+filename,
+		filepath.Join(workDir, filename)); err != nil {
 		return err
 	}
-	if err := system.DownloadRequireTor(baseURL+"/SHA256SUMS", "/tmp/SHA256SUMS"); err != nil {
+	if err := system.DownloadRequireTor(
+		baseURL+"/SHA256SUMS",
+		filepath.Join(workDir, "SHA256SUMS")); err != nil {
 		return err
 	}
-	return system.DownloadRequireTor(baseURL+"/SHA256SUMS.asc", "/tmp/SHA256SUMS.asc")
+	return system.DownloadRequireTor(
+		baseURL+"/SHA256SUMS.asc",
+		filepath.Join(workDir, "SHA256SUMS.asc"))
 }
 
-func extractAndInstallBitcoin(version string) error {
+func extractAndInstallBitcoin(version, workDir string) error {
 	filename := fmt.Sprintf("bitcoin-%s-x86_64-linux-gnu.tar.gz", version)
-	if err := system.Run("tar", "-xzf", "/tmp/"+filename, "-C", "/tmp"); err != nil {
+	if err := system.Run("tar", "-xzf",
+		filepath.Join(workDir, filename),
+		"-C", workDir); err != nil {
 		return err
 	}
-	extractDir := fmt.Sprintf("/tmp/bitcoin-%s/bin", version)
+	extractDir := filepath.Join(workDir,
+		fmt.Sprintf("bitcoin-%s", version), "bin")
 	entries, err := os.ReadDir(extractDir)
 	if err != nil {
 		return fmt.Errorf("read dir: %w", err)
 	}
 	for _, entry := range entries {
-		src := fmt.Sprintf("%s/%s", extractDir, entry.Name())
-		if err := system.SudoRun("install", "-m", "0755", "-o", "root", "-g", "root", src, "/usr/local/bin/"); err != nil {
+		src := filepath.Join(extractDir, entry.Name())
+		if err := system.SudoRun("install", "-m", "0755",
+			"-o", "root", "-g", "root",
+			src, "/usr/local/bin/"); err != nil {
 			return err
 		}
 	}
-	os.Remove("/tmp/" + filename)
-	os.Remove("/tmp/SHA256SUMS")
-	os.Remove("/tmp/SHA256SUMS.asc")
-	os.RemoveAll(fmt.Sprintf("/tmp/bitcoin-%s", version))
 	return nil
 }
 

--- a/internal/installer/lnd.go
+++ b/internal/installer/lnd.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -17,36 +18,43 @@ import (
 	"github.com/ripsline/virtual-private-node/internal/system"
 )
 
-func downloadLND(version string) error {
+func downloadLND(version, workDir string) error {
 	filename := fmt.Sprintf("lnd-linux-amd64-v%s.tar.gz", version)
-	url := fmt.Sprintf("https://github.com/lightningnetwork/lnd/releases/download/v%s/%s",
+	url := fmt.Sprintf(
+		"https://github.com/lightningnetwork/lnd/releases/download/v%s/%s",
 		version, filename)
-	manifestURL := fmt.Sprintf("https://github.com/lightningnetwork/lnd/releases/download/v%s/manifest-v%s.txt",
+	manifestURL := fmt.Sprintf(
+		"https://github.com/lightningnetwork/lnd/releases/download/v%s/manifest-v%s.txt",
 		version, version)
-	if err := system.DownloadRequireTor(url, "/tmp/"+filename); err != nil {
+	if err := system.DownloadRequireTor(
+		url, filepath.Join(workDir, filename)); err != nil {
 		return err
 	}
-	if err := system.DownloadRequireTor(manifestURL, "/tmp/manifest.txt"); err != nil {
+	if err := system.DownloadRequireTor(
+		manifestURL,
+		filepath.Join(workDir, "manifest.txt")); err != nil {
 		return fmt.Errorf("download LND manifest: %w", err)
 	}
 	return nil
 }
 
-func extractAndInstallLND(version string) error {
+func extractAndInstallLND(version, workDir string) error {
 	filename := fmt.Sprintf("lnd-linux-amd64-v%s.tar.gz", version)
-	if err := system.Run("tar", "-xzf", "/tmp/"+filename, "-C", "/tmp"); err != nil {
+	if err := system.Run("tar", "-xzf",
+		filepath.Join(workDir, filename),
+		"-C", workDir); err != nil {
 		return err
 	}
-	extractDir := fmt.Sprintf("/tmp/lnd-linux-amd64-v%s", version)
+	extractDir := filepath.Join(workDir,
+		fmt.Sprintf("lnd-linux-amd64-v%s", version))
 	for _, bin := range []string{"lnd", "lncli"} {
-		src := fmt.Sprintf("%s/%s", extractDir, bin)
-		if err := system.SudoRun("install", "-m", "0755", "-o", "root", "-g", "root", src, "/usr/local/bin/"); err != nil {
+		src := filepath.Join(extractDir, bin)
+		if err := system.SudoRun("install", "-m", "0755",
+			"-o", "root", "-g", "root",
+			src, "/usr/local/bin/"); err != nil {
 			return err
 		}
 	}
-	os.Remove("/tmp/" + filename)
-	os.Remove("/tmp/manifest.txt")
-	os.RemoveAll(extractDir)
 	return nil
 }
 

--- a/internal/installer/setup.go
+++ b/internal/installer/setup.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -223,6 +224,11 @@ func Run() error {
 }
 
 func buildSteps(cfg *config.AppConfig) []InstallStep {
+	// Pipeline working directories — created in each pipeline's
+	// first step, captured by closures, cleaned up in the final
+	// step. Random paths via os.MkdirTemp prevent symlink attacks.
+	var btcWork, lndWork string
+
 	return []InstallStep{
 		{Name: "Creating system user and directories",
 			Fn: func() error {
@@ -259,23 +265,28 @@ func buildSteps(cfg *config.AppConfig) []InstallStep {
 			Fn: func() error { return configureFirewall(cfg) }},
 		{Name: "Downloading Bitcoin Core " + bitcoinVersion,
 			Fn: func() error {
-				if err := importBitcoinCoreKeys(); err != nil {
-					return err
+				var err error
+				btcWork, err = os.MkdirTemp("", "rlvpn-btc-")
+				if err != nil {
+					return fmt.Errorf("create work dir: %w", err)
 				}
-				return downloadBitcoin(bitcoinVersion)
+				return downloadBitcoin(bitcoinVersion, btcWork)
 			}},
 		{Name: "Verifying Bitcoin Core",
 			Fn: func() error {
-				if err := verifyBitcoinCoreSigs(2); err != nil {
+				if err := verifyBitcoinCoreSigs(
+					btcWork, 2); err != nil {
 					return err
 				}
-				return verifyBitcoin()
+				return verifyBitcoin(btcWork)
 			}},
 		{Name: "Installing Bitcoin Core",
 			Fn: func() error {
-				if err := extractAndInstallBitcoin(bitcoinVersion); err != nil {
+				if err := extractAndInstallBitcoin(
+					bitcoinVersion, btcWork); err != nil {
 					return err
 				}
+				os.RemoveAll(btcWork)
 				if err := writeBitcoinConfig(cfg); err != nil {
 					return err
 				}
@@ -299,23 +310,28 @@ func buildSteps(cfg *config.AppConfig) []InstallStep {
 		// ── LND (Tor-only, non-interactive) ─────────
 		{Name: "Downloading LND",
 			Fn: func() error {
-				if err := importLNDKey(); err != nil {
-					return err
+				var err error
+				lndWork, err = os.MkdirTemp("", "rlvpn-lnd-")
+				if err != nil {
+					return fmt.Errorf("create work dir: %w", err)
 				}
-				return downloadLND(lndVersion)
+				return downloadLND(lndVersion, lndWork)
 			}},
 		{Name: "Verifying LND",
 			Fn: func() error {
-				if err := verifyLNDSig(lndVersion); err != nil {
+				if err := verifyLNDSig(
+					lndWork, lndVersion); err != nil {
 					return err
 				}
-				return verifyLND()
+				return verifyLND(lndWork)
 			}},
 		{Name: "Installing LND",
 			Fn: func() error {
-				if err := extractAndInstallLND(lndVersion); err != nil {
+				if err := extractAndInstallLND(
+					lndVersion, lndWork); err != nil {
 					return err
 				}
+				os.RemoveAll(lndWork)
 				if err := createLNDDirs(systemUser); err != nil {
 					return err
 				}
@@ -436,87 +452,47 @@ func SelfUpdateSteps(newVersion string) []InstallStep {
 	baseURL := fmt.Sprintf(
 		"https://github.com/ripsline/virtual-private-node/releases/download/v%s",
 		newVersion)
-	expectedFP := "AFA0EBACDC9A4C4AA7B0154AC97CE10F170BA5FE"
 	tarball := fmt.Sprintf("rlvpn-%s-amd64.tar.gz",
 		newVersion)
+
+	var workDir string
 
 	return []InstallStep{
 		{Name: "Downloading v" + newVersion,
 			Fn: func() error {
-				return system.DownloadRequireTor(
+				var err error
+				workDir, err = os.MkdirTemp("",
+					"rlvpn-update-")
+				if err != nil {
+					return fmt.Errorf(
+						"create work dir: %w", err)
+				}
+				if err := system.DownloadRequireTor(
 					baseURL+"/"+tarball,
-					"/tmp/"+tarball)
-			}},
-		{Name: "Downloading checksums",
-			Fn: func() error {
+					filepath.Join(workDir, tarball)); err != nil {
+					return err
+				}
 				if err := system.DownloadRequireTor(
 					baseURL+"/SHA256SUMS",
-					"/tmp/rlvpn-SHA256SUMS"); err != nil {
+					filepath.Join(workDir,
+						"SHA256SUMS")); err != nil {
 					return err
 				}
 				return system.DownloadRequireTor(
 					baseURL+"/SHA256SUMS.asc",
-					"/tmp/rlvpn-SHA256SUMS.asc")
-			}},
-		{Name: "Importing release key",
-			Fn: func() error {
-				// Skip download if key is already imported
-				// (e.g. from a previous update).
-				output, err := system.RunCombinedOutput(
-					"gpg", "--batch", "--with-colons",
-					"--list-keys", expectedFP)
-				if err == nil &&
-					strings.Contains(output, expectedFP) {
-					return nil
-				}
-
-				keyFile := "/tmp/rlvpn-release-key.asc"
-				keyURL := fmt.Sprintf(
-					"https://keys.openpgp.org/vks/v1/by-fingerprint/%s",
-					expectedFP)
-				if err := system.DownloadRequireTor(
-					keyURL, keyFile); err != nil {
-					return fmt.Errorf(
-						"could not download signing key: %w",
-						err)
-				}
-				defer os.Remove(keyFile)
-				if _, err := system.RunCombinedOutput(
-					"gpg", "--batch", "--import",
-					keyFile); err != nil {
-					return fmt.Errorf(
-						"could not import signing key: %w",
-						err)
-				}
-				output, err = system.RunCombinedOutput(
-					"gpg", "--batch", "--with-colons",
-					"--list-keys", expectedFP)
-				if err != nil ||
-					!strings.Contains(output, expectedFP) {
-					return fmt.Errorf(
-						"release key fingerprint mismatch")
-				}
-				return nil
+					filepath.Join(workDir,
+						"SHA256SUMS.asc"))
 			}},
 		{Name: "Verifying signature",
 			Fn: func() error {
-				output, err := system.RunCombinedOutput(
-					"gpg", "--batch", "--verify",
-					"/tmp/rlvpn-SHA256SUMS.asc",
-					"/tmp/rlvpn-SHA256SUMS")
-				if err != nil {
-					return fmt.Errorf(
-						"signature verification failed: %s",
-						output)
-				}
-				return nil
+				return verifySelfUpdate(workDir)
 			}},
 		{Name: "Verifying checksum",
 			Fn: func() error {
 				cmd := exec.Command("sha256sum",
 					"--ignore-missing", "--check",
-					"rlvpn-SHA256SUMS")
-				cmd.Dir = "/tmp"
+					"SHA256SUMS")
+				cmd.Dir = workDir
 				output, err := cmd.CombinedOutput()
 				if err != nil {
 					return fmt.Errorf(
@@ -528,19 +504,17 @@ func SelfUpdateSteps(newVersion string) []InstallStep {
 		{Name: "Installing new binary",
 			Fn: func() error {
 				if err := system.Run("tar", "-xzf",
-					"/tmp/"+tarball, "-C",
-					"/tmp"); err != nil {
+					filepath.Join(workDir, tarball),
+					"-C", workDir); err != nil {
 					return err
 				}
 				if err := system.SudoRun("install",
-					"-m", "755", "/tmp/rlvpn",
+					"-m", "755",
+					filepath.Join(workDir, "rlvpn"),
 					"/usr/local/bin/rlvpn"); err != nil {
 					return err
 				}
-				os.Remove("/tmp/" + tarball)
-				os.Remove("/tmp/rlvpn-SHA256SUMS")
-				os.Remove("/tmp/rlvpn-SHA256SUMS.asc")
-				os.Remove("/tmp/rlvpn")
+				os.RemoveAll(workDir)
 				return nil
 			}},
 	}

--- a/internal/installer/verify.go
+++ b/internal/installer/verify.go
@@ -46,7 +46,9 @@ const rlvpnReleaseFP = "AFA0EBACDC9A4C4AA7B0154AC97CE10F170BA5FE"
 // bitcoinCoreSigners are the trusted Bitcoin Core builder keys.
 // Source: github.com/bitcoin-core/guix.sigs/tree/main/builder-keys
 // Cross-check: each key's fingerprint against the .gpg file at
-// the listed URL. Threshold: 2 of 5 distinct signers required.
+// the listed URL. Verified against Bitcoin Core 29.3 SHA256SUMS.asc
+// on a live install (June 4 2026). Primary-key fingerprints, not
+// subkeys. Threshold: 2 of 5 distinct signers required.
 var bitcoinCoreSigners = []struct {
 	name        string
 	fingerprint string
@@ -59,36 +61,39 @@ var bitcoinCoreSigners = []struct {
 	},
 	{
 		name:        "guggero",
-		fingerprint: "FDE04B7075113BFB085020B57BBD8D4D95DB9F03",
+		fingerprint: "F4FC70F07310028424EFC20A8E4256593F177720",
 		keyURL:      "https://raw.githubusercontent.com/bitcoin-core/guix.sigs/main/builder-keys/guggero.gpg",
 	},
 	{
 		name:        "hebasto",
-		fingerprint: "CBE89ED88EE8525FD8D79F1EDB56ADFD8B5EF498",
+		fingerprint: "D1DBF2C4B96F2DEBF4C16654410108112E7EA81F",
 		keyURL:      "https://raw.githubusercontent.com/bitcoin-core/guix.sigs/main/builder-keys/hebasto.gpg",
 	},
 	{
 		name:        "theStack",
-		fingerprint: "9343A22960A50972CC1EFD7DB3B5CB8DB648B27F",
+		fingerprint: "6A8F9C266528E25AEB1D7731C2371D91CB716EA7",
 		keyURL:      "https://raw.githubusercontent.com/bitcoin-core/guix.sigs/main/builder-keys/theStack.gpg",
 	},
 	{
 		name:        "willcl-ark",
-		fingerprint: "A0083660F235A27000CD3C81CE6EC49945C17EA6",
+		fingerprint: "67AA5B46E7AF78053167FE343B8F814A784218F8",
 		keyURL:      "https://raw.githubusercontent.com/bitcoin-core/guix.sigs/main/builder-keys/willcl-ark.gpg",
 	},
 }
 
 // lndSigner is the trusted LND release signer.
 // Source: github.com/lightningnetwork/lnd/tree/master/scripts/keys
-// Cross-check: roasbeef.asc at the listed URL.
+// Cross-check: roasbeef.asc at the listed URL. Verified against
+// LND v0.20.0-beta manifest signature on a live install (June 4
+// 2026). Primary-key fingerprint — the signing subkey (2962...)
+// is owned by this primary.
 var lndSigner = struct {
 	name        string
 	fingerprint string
 	keyURL      string
 }{
 	name:        "roasbeef",
-	fingerprint: "296212681AADF05656A2CDEE90525F7DEEE0AD86",
+	fingerprint: "A5B61896952D9FDA83BC054CDC42612E89237182",
 	keyURL:      "https://raw.githubusercontent.com/lightningnetwork/lnd/master/scripts/keys/roasbeef.asc",
 }
 

--- a/internal/installer/verify.go
+++ b/internal/installer/verify.go
@@ -1,19 +1,52 @@
 // internal/installer/verify.go
 
+// Trust model
+//
+// All signing-key fingerprints are pinned in this file as the sole trust
+// anchors. Keys are fetched fresh each run and imported into an ephemeral
+// GPG home directory (os.MkdirTemp, 0700). Signatures are verified via
+// gpg --status-fd 1; only [GNUPG:] VALIDSIG lines whose primary-key
+// fingerprint (the LAST whitespace-delimited field) matches a pinned
+// value are counted. Distinct signers are counted once (deduped by
+// primary fingerprint). Any [GNUPG:] BADSIG line is a hard stop. The
+// GPG exit code is never trusted.
+//
+// Three callers use verifyIsolated:
+//   - verifySelfUpdate:      threshold 1 vs the rlvpn release key
+//   - verifyBitcoinCoreSigs: threshold 2 distinct builder fingerprints
+//   - verifyLNDSig:          threshold 1 vs roasbeef's fingerprint
+
 package installer
 
 import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/ripsline/virtual-private-node/internal/logger"
 	"github.com/ripsline/virtual-private-node/internal/system"
 )
 
-// ── Trusted signing keys ─────────────────────────────────
+// ── Trust anchors ───────────────────────────────────────
+//
+// Each fingerprint was sourced and cross-checked as noted.
+// To re-verify: download the key from the listed URL, import
+// into an ephemeral keyring, and confirm the fingerprint with
+// gpg --with-colons --list-keys.
 
+// rlvpnReleaseFP is the primary fingerprint of the rlvpn
+// release signing key.
+// Source: generated locally; public key hosted at
+// keys.openpgp.org. Cross-check: SIGNING_KEY_FP in
+// virtual-private-node.sh (line 24).
+const rlvpnReleaseFP = "AFA0EBACDC9A4C4AA7B0154AC97CE10F170BA5FE"
+
+// bitcoinCoreSigners are the trusted Bitcoin Core builder keys.
+// Source: github.com/bitcoin-core/guix.sigs/tree/main/builder-keys
+// Cross-check: each key's fingerprint against the .gpg file at
+// the listed URL. Threshold: 2 of 5 distinct signers required.
 var bitcoinCoreSigners = []struct {
 	name        string
 	fingerprint string
@@ -46,6 +79,9 @@ var bitcoinCoreSigners = []struct {
 	},
 }
 
+// lndSigner is the trusted LND release signer.
+// Source: github.com/lightningnetwork/lnd/tree/master/scripts/keys
+// Cross-check: roasbeef.asc at the listed URL.
 var lndSigner = struct {
 	name        string
 	fingerprint string
@@ -65,67 +101,93 @@ func ensureGPG() error {
 	return system.SudoRun("apt-get", "install", "-y", "-qq", "gnupg")
 }
 
-// ── Key import ───────────────────────────────────────────
+// ── Isolated signature verification ─────────────────────
 
-func importBitcoinCoreKeys() error {
-	logger.Verify("--- Bitcoin Core key import ---")
-	imported := 0
-	for _, signer := range bitcoinCoreSigners {
-		keyFile := fmt.Sprintf("/tmp/btc-key-%s.gpg", signer.name)
-		if err := system.DownloadRequireTor(signer.keyURL, keyFile); err != nil {
-			logger.Verify("SKIP %s: download failed: %v", signer.name, err)
-			continue
-		}
-
-		system.RunCombinedOutput("gpg", "--batch", "--import", keyFile)
-		os.Remove(keyFile)
-
-		if gpgHasFingerprint(signer.fingerprint) {
-			imported++
-			logger.Verify("OK %s: imported (fingerprint %s)", signer.name, signer.fingerprint)
-		} else {
-			logger.Verify("SKIP %s: fingerprint not found after import", signer.name)
-		}
-	}
-
-	logger.Verify("Bitcoin Core keys imported: %d/%d", imported, len(bitcoinCoreSigners))
-	if imported == 0 {
-		logger.Verify("FAIL: no Bitcoin Core signing keys imported")
-		return fmt.Errorf("could not import any Bitcoin Core signing keys")
-	}
-	return nil
-}
-
-func importLNDKey() error {
-	logger.Verify("--- LND key import ---")
-	keyFile := "/tmp/lnd-key-roasbeef.asc"
-	if err := system.DownloadRequireTor(lndSigner.keyURL, keyFile); err != nil {
-		logger.Verify("FAIL: download LND signing key: %v", err)
-		return fmt.Errorf("download LND signing key: %w", err)
-	}
-	defer os.Remove(keyFile)
-
-	output, err := system.RunCombinedOutput("gpg", "--batch", "--import", keyFile)
+// verifyIsolated verifies a detached GPG signature inside an
+// ephemeral keyring. It creates a temporary GPG home directory,
+// imports the provided key files, and runs gpg --verify with
+// --status-fd 1. Only VALIDSIG lines whose primary-key
+// fingerprint (the LAST field) matches a pinned fingerprint are
+// counted, and each primary fingerprint is counted at most once
+// (distinct signers). Any BADSIG line sets badSig = true.
+//
+// The GPG exit code is intentionally ignored — the VALIDSIG and
+// BADSIG parsing is the sole source of truth.
+func verifyIsolated(
+	keyFiles []string,
+	sigFile, dataFile string,
+	pinnedFPs map[string]bool,
+) (distinctValidSigners int, badSig bool, err error) {
+	// Ephemeral GPG home — 0700, random path, cleaned up on return.
+	gpgHome, err := os.MkdirTemp("", "rlvpn-gpg-")
 	if err != nil {
-		logger.Verify("FAIL: import LND key: %s", output)
-		return fmt.Errorf("import LND key: %w: %s", err, output)
+		return 0, false, fmt.Errorf(
+			"create ephemeral gpg home: %w", err)
+	}
+	defer os.RemoveAll(gpgHome)
+
+	// Import key files into the ephemeral keyring.
+	for _, kf := range keyFiles {
+		output, importErr := system.RunCombinedOutput(
+			"gpg", "--homedir", gpgHome,
+			"--batch", "--import", kf)
+		if importErr != nil {
+			logger.Verify("SKIP key import %s: %v: %s",
+				filepath.Base(kf), importErr, output)
+		}
 	}
 
-	if !gpgHasFingerprint(lndSigner.fingerprint) {
-		logger.Verify("FAIL: LND key fingerprint mismatch (expected %s)", lndSigner.fingerprint)
-		return fmt.Errorf("LND key fingerprint mismatch")
+	// Verify — exit code intentionally discarded.
+	output, _ := system.RunCombinedOutput(
+		"gpg", "--homedir", gpgHome, "--batch", "--verify",
+		"--status-fd", "1", sigFile, dataFile)
+
+	// Parse status output.
+	seen := make(map[string]bool)
+	for _, line := range strings.Split(output, "\n") {
+		trimmed := strings.TrimSpace(line)
+
+		if strings.HasPrefix(trimmed, "[GNUPG:] BADSIG") {
+			badSig = true
+			logger.Verify("BADSIG: %s", trimmed)
+		}
+
+		if strings.HasPrefix(trimmed, "[GNUPG:] VALIDSIG") {
+			fields := strings.Fields(trimmed)
+			// VALIDSIG layout (after [GNUPG:] VALIDSIG):
+			//   <signing-fpr> <date> <ts> <exp> <ver> <res>
+			//   <pkalgo> <halgo> <sigclass> <primary-fpr>
+			// The LAST field is the primary-key fingerprint.
+			// When a subkey signs, the first field after
+			// VALIDSIG is the subkey fingerprint — we must
+			// match the LAST field (primary) against our pins.
+			if len(fields) >= 3 {
+				primaryFP := fields[len(fields)-1]
+				if pinnedFPs[primaryFP] {
+					if !seen[primaryFP] {
+						seen[primaryFP] = true
+						logger.Verify(
+							"VALIDSIG pinned: %s", primaryFP)
+					}
+				} else {
+					logger.Verify(
+						"VALIDSIG unpinned (ignored): %s",
+						primaryFP)
+				}
+			}
+		}
 	}
 
-	logger.Verify("OK roasbeef: imported (fingerprint %s)", lndSigner.fingerprint)
-	return nil
+	return len(seen), badSig, nil
 }
 
-// ── Signature verification ───────────────────────────────
+// ── Bitcoin Core verification ───────────────────────────
 
-func verifyBitcoinCoreSigs(minValid int) error {
+func verifyBitcoinCoreSigs(workDir string, minValid int) error {
 	logger.Verify("--- Bitcoin Core signature verification ---")
-	sumsFile := "/tmp/SHA256SUMS"
-	sigFile := "/tmp/SHA256SUMS.asc"
+
+	sumsFile := filepath.Join(workDir, "SHA256SUMS")
+	sigFile := filepath.Join(workDir, "SHA256SUMS.asc")
 
 	if _, err := os.Stat(sumsFile); err != nil {
 		logger.Verify("FAIL: SHA256SUMS not found")
@@ -136,136 +198,222 @@ func verifyBitcoinCoreSigs(minValid int) error {
 		return fmt.Errorf("SHA256SUMS.asc not found")
 	}
 
-	outputStr, _ := system.RunCombinedOutput("gpg", "--batch", "--verify",
-		"--status-fd", "1", sigFile, sumsFile)
-
-	validCount := ParseGoodSigCount(outputStr)
-	badCount := ParseBadSigCount(outputStr)
-
-	for _, line := range strings.Split(outputStr, "\n") {
-		if strings.Contains(line, "GOODSIG") {
-			logger.Verify("GOODSIG: %s", strings.TrimSpace(line))
-		}
-		if strings.Contains(line, "BADSIG") {
-			logger.Verify("BADSIG: %s", strings.TrimSpace(line))
-		}
+	// Pin ALL fingerprints regardless of download success.
+	// The pinned set is the trust anchor — it does not change
+	// based on which keys we managed to download.
+	pinnedFPs := make(map[string]bool)
+	for _, signer := range bitcoinCoreSigners {
+		pinnedFPs[signer.fingerprint] = true
 	}
 
-	logger.Verify("Bitcoin Core valid signatures: %d/%d required (bad: %d)",
-		validCount, minValid, badCount)
-
-	if badCount > 0 {
-		logger.Verify("FAIL: %d bad signatures detected", badCount)
-		return fmt.Errorf("bad signatures detected: %d", badCount)
+	// Download signing keys into the pipeline work directory.
+	var keyFiles []string
+	for _, signer := range bitcoinCoreSigners {
+		keyFile := filepath.Join(workDir,
+			fmt.Sprintf("btc-key-%s.gpg", signer.name))
+		if err := system.DownloadRequireTor(
+			signer.keyURL, keyFile); err != nil {
+			logger.Verify("SKIP %s: download failed: %v",
+				signer.name, err)
+			continue
+		}
+		keyFiles = append(keyFiles, keyFile)
+		logger.Verify("OK %s: key downloaded", signer.name)
 	}
 
-	if validCount < minValid {
-		logger.Verify("FAIL: insufficient valid signatures: got %d, need %d",
-			validCount, minValid)
+	if len(keyFiles) == 0 {
+		logger.Verify("FAIL: no Bitcoin Core signing keys downloaded")
+		return fmt.Errorf(
+			"could not download any Bitcoin Core signing keys")
+	}
+
+	distinct, hasBadSig, err := verifyIsolated(
+		keyFiles, sigFile, sumsFile, pinnedFPs)
+	if err != nil {
+		return fmt.Errorf(
+			"signature verification failed: %w", err)
+	}
+
+	if hasBadSig {
+		logger.Verify("FAIL: bad signature detected")
+		return fmt.Errorf(
+			"bad signature detected — verification aborted")
+	}
+
+	logger.Verify(
+		"Bitcoin Core valid pinned signatures: %d/%d required",
+		distinct, minValid)
+
+	if distinct < minValid {
+		logger.Verify(
+			"FAIL: insufficient valid signatures: got %d, need %d",
+			distinct, minValid)
 		return fmt.Errorf(
 			"insufficient valid signatures: got %d, need %d",
-			validCount, minValid)
+			distinct, minValid)
 	}
 
-	logger.Verify("OK Bitcoin Core: %d valid signatures", validCount)
+	logger.Verify("OK Bitcoin Core: %d valid pinned signatures",
+		distinct)
 	return nil
 }
 
-func verifyLNDSig(version string) error {
-	logger.Verify("--- LND signature verification ---")
-	manifestFile := "/tmp/manifest.txt"
-	sigFile := fmt.Sprintf("/tmp/manifest-roasbeef-v%s.sig", version)
+// ── LND verification ────────────────────────────────────
 
+func verifyLNDSig(workDir string, version string) error {
+	logger.Verify("--- LND signature verification ---")
+
+	manifestFile := filepath.Join(workDir, "manifest.txt")
 	if _, err := os.Stat(manifestFile); err != nil {
 		logger.Verify("FAIL: LND manifest not found")
-		return fmt.Errorf("LND manifest not found at %s", manifestFile)
+		return fmt.Errorf("LND manifest not found at %s",
+			manifestFile)
 	}
 
+	// Download signature file.
+	sigFile := filepath.Join(workDir,
+		fmt.Sprintf("manifest-roasbeef-v%s.sig", version))
 	sigURL := fmt.Sprintf(
 		"https://github.com/lightningnetwork/lnd/releases/download/v%s/manifest-roasbeef-v%s.sig",
 		version, version)
-	if err := system.DownloadRequireTor(sigURL, sigFile); err != nil {
+	if err := system.DownloadRequireTor(
+		sigURL, sigFile); err != nil {
 		logger.Verify("FAIL: download LND signature: %v", err)
 		return fmt.Errorf("download LND signature: %w", err)
 	}
-	defer os.Remove(sigFile)
 
-	outputStr, _ := system.RunCombinedOutput("gpg", "--batch", "--verify",
-		"--status-fd", "1", sigFile, manifestFile)
+	// Download signing key.
+	keyFile := filepath.Join(workDir, "lnd-key-roasbeef.asc")
+	if err := system.DownloadRequireTor(
+		lndSigner.keyURL, keyFile); err != nil {
+		logger.Verify("FAIL: download LND signing key: %v", err)
+		return fmt.Errorf("download LND signing key: %w", err)
+	}
 
-	if !strings.Contains(outputStr, "GOODSIG") {
-		logger.Verify("FAIL: LND signature invalid: %s", outputStr)
+	pinnedFPs := map[string]bool{lndSigner.fingerprint: true}
+
+	distinct, hasBadSig, err := verifyIsolated(
+		[]string{keyFile}, sigFile, manifestFile, pinnedFPs)
+	if err != nil {
+		return fmt.Errorf(
+			"LND signature verification failed: %w", err)
+	}
+
+	if hasBadSig {
+		logger.Verify("FAIL: bad LND signature detected")
+		return fmt.Errorf(
+			"bad LND signature detected — verification aborted")
+	}
+
+	if distinct < 1 {
+		logger.Verify(
+			"FAIL: LND signature not valid against pinned fingerprint")
 		return fmt.Errorf("LND signature verification failed")
 	}
 
-	for _, line := range strings.Split(outputStr, "\n") {
-		if strings.Contains(line, "GOODSIG") {
-			logger.Verify("GOODSIG: %s", strings.TrimSpace(line))
-		}
-	}
-
-	logger.Verify("OK LND: signature valid")
+	logger.Verify(
+		"OK LND: signature valid (roasbeef, pinned fingerprint)")
 	return nil
 }
 
-// ── Checksum verification ────────────────────────────────
+// ── Self-update verification ────────────────────────────
 
-func verifyBitcoin() error {
+func verifySelfUpdate(workDir string) error {
+	logger.Verify("--- Self-update signature verification ---")
+
+	sumsFile := filepath.Join(workDir, "SHA256SUMS")
+	sigFile := filepath.Join(workDir, "SHA256SUMS.asc")
+
+	if _, err := os.Stat(sumsFile); err != nil {
+		logger.Verify("FAIL: SHA256SUMS not found")
+		return fmt.Errorf("SHA256SUMS not found")
+	}
+	if _, err := os.Stat(sigFile); err != nil {
+		logger.Verify("FAIL: SHA256SUMS.asc not found")
+		return fmt.Errorf("SHA256SUMS.asc not found")
+	}
+
+	// Download the release signing key fresh into the work
+	// directory. verifyIsolated imports it into an ephemeral
+	// GPG home — the shared keyring is never touched.
+	keyFile := filepath.Join(workDir, "release-key.asc")
+	keyURL := fmt.Sprintf(
+		"https://keys.openpgp.org/vks/v1/by-fingerprint/%s",
+		rlvpnReleaseFP)
+	if err := system.DownloadRequireTor(
+		keyURL, keyFile); err != nil {
+		logger.Verify(
+			"FAIL: download release signing key: %v", err)
+		return fmt.Errorf(
+			"download release signing key: %w", err)
+	}
+
+	pinnedFPs := map[string]bool{rlvpnReleaseFP: true}
+
+	distinct, hasBadSig, err := verifyIsolated(
+		[]string{keyFile}, sigFile, sumsFile, pinnedFPs)
+	if err != nil {
+		return fmt.Errorf(
+			"signature verification failed: %w", err)
+	}
+
+	if hasBadSig {
+		logger.Verify("FAIL: bad signature detected")
+		return fmt.Errorf(
+			"bad signature detected — verification aborted")
+	}
+
+	if distinct < 1 {
+		logger.Verify(
+			"FAIL: signature not from the release signing key")
+		return fmt.Errorf(
+			"signature not from the release signing key")
+	}
+
+	logger.Verify("OK self-update: signature valid " +
+		"(release key, pinned fingerprint)")
+	return nil
+}
+
+// ── Checksum verification ───────────────────────────────
+
+func verifyBitcoin(workDir string) error {
 	logger.Verify("--- Bitcoin Core checksum verification ---")
 	// exec.Command used directly because sha256sum --check needs
-	// working directory set to /tmp where the tarball was downloaded.
-	cmd := exec.Command("sha256sum", "--ignore-missing", "--check", "SHA256SUMS")
-	cmd.Dir = "/tmp"
+	// working directory set to where the tarball was downloaded.
+	cmd := exec.Command("sha256sum",
+		"--ignore-missing", "--check", "SHA256SUMS")
+	cmd.Dir = workDir
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		logger.Verify("FAIL: Bitcoin Core checksum: %s", string(output))
+		logger.Verify("FAIL: Bitcoin Core checksum: %s",
+			string(output))
 		return fmt.Errorf("checksum failed: %w: %s", err, output)
 	}
-	logger.Verify("OK Bitcoin Core checksum: %s", strings.TrimSpace(string(output)))
+	logger.Verify("OK Bitcoin Core checksum: %s",
+		strings.TrimSpace(string(output)))
 	return nil
 }
 
-func verifyLND() error {
+func verifyLND(workDir string) error {
 	logger.Verify("--- LND checksum verification ---")
-	if _, err := os.Stat("/tmp/manifest.txt"); err != nil {
+	manifestFile := filepath.Join(workDir, "manifest.txt")
+	if _, err := os.Stat(manifestFile); err != nil {
 		logger.Verify("FAIL: LND manifest not found")
 		return fmt.Errorf("LND manifest not found")
 	}
 	// exec.Command used directly because sha256sum --check needs
-	// working directory set to /tmp where the tarball was downloaded.
-	cmd := exec.Command("sha256sum", "--ignore-missing", "--check", "manifest.txt")
-	cmd.Dir = "/tmp"
+	// working directory set to where the tarball was downloaded.
+	cmd := exec.Command("sha256sum",
+		"--ignore-missing", "--check", "manifest.txt")
+	cmd.Dir = workDir
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		logger.Verify("FAIL: LND checksum: %s", string(output))
+		logger.Verify("FAIL: LND checksum: %s",
+			string(output))
 		return fmt.Errorf("checksum failed: %w: %s", err, output)
 	}
-	logger.Verify("OK LND checksum: %s", strings.TrimSpace(string(output)))
+	logger.Verify("OK LND checksum: %s",
+		strings.TrimSpace(string(output)))
 	return nil
-}
-
-// ── Helpers ──────────────────────────────────────────────
-
-func gpgHasFingerprint(fingerprint string) bool {
-	output, err := system.RunCombinedOutput("gpg", "--batch", "--list-keys",
-		"--with-colons", fingerprint)
-	if err != nil {
-		return false
-	}
-	return strings.Contains(output, fingerprint)
-}
-
-// ParseGoodSigCount counts GOODSIG lines in GPG status output.
-func ParseGoodSigCount(output string) int {
-	return strings.Count(output, "GOODSIG")
-}
-
-// ParseBadSigCount counts BADSIG lines in GPG status output.
-func ParseBadSigCount(output string) int {
-	return strings.Count(output, "BADSIG")
-}
-
-// HasGoodSig checks if GPG output contains at least one GOODSIG.
-func HasGoodSig(output string) bool {
-	return strings.Contains(output, "GOODSIG")
 }

--- a/internal/installer/verify_test.go
+++ b/internal/installer/verify_test.go
@@ -3,117 +3,339 @@
 package installer
 
 import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 )
 
-func TestParseGoodSigCount(t *testing.T) {
-	tests := []struct {
-		name   string
-		output string
-		want   int
-	}{
-		{
-			name:   "two valid",
-			output: "[GNUPG:] GOODSIG E777299FC265DD04 fanquake\n[GNUPG:] GOODSIG FDE04B7075113BFB guggero\n",
-			want:   2,
-		},
-		{
-			name:   "one valid one error",
-			output: "[GNUPG:] GOODSIG E777299FC265DD04 fanquake\n[GNUPG:] ERRSIG 9343A22960A50972\n",
-			want:   1,
-		},
-		{
-			name:   "none",
-			output: "[GNUPG:] ERRSIG E777299FC265DD04\n",
-			want:   0,
-		},
-		{
-			name:   "empty",
-			output: "",
-			want:   0,
-		},
-		{
-			name:   "five valid",
-			output: "[GNUPG:] GOODSIG A f\n[GNUPG:] GOODSIG B g\n[GNUPG:] GOODSIG C h\n[GNUPG:] GOODSIG D t\n[GNUPG:] GOODSIG E w\n",
-			want:   5,
-		},
+// ── Test helpers ────────────────────────────────────────
+
+func gpgAvailable() bool {
+	_, err := exec.LookPath("gpg")
+	return err == nil
+}
+
+// testGenKey generates a GPG key in the given homedir and
+// returns the primary-key fingerprint. If addSigningSubkey
+// is true, the primary key has certify-only usage and a
+// separate signing subkey is added.
+func testGenKey(
+	t *testing.T, gpgHome, name string,
+	addSigningSubkey bool,
+) string {
+	t.Helper()
+
+	var params string
+	if addSigningSubkey {
+		params = fmt.Sprintf(`%%no-protection
+Key-Type: RSA
+Key-Length: 2048
+Key-Usage: cert
+Subkey-Type: RSA
+Subkey-Length: 2048
+Subkey-Usage: sign
+Name-Real: %s
+Name-Email: %s@test.local
+%%commit
+`, name, name)
+	} else {
+		params = fmt.Sprintf(`%%no-protection
+Key-Type: RSA
+Key-Length: 2048
+Key-Usage: sign
+Name-Real: %s
+Name-Email: %s@test.local
+%%commit
+`, name, name)
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := ParseGoodSigCount(tt.output)
-			if got != tt.want {
-				t.Errorf("got %d, want %d", got, tt.want)
+
+	paramFile := filepath.Join(gpgHome, "params-"+name)
+	if err := os.WriteFile(
+		paramFile, []byte(params), 0600); err != nil {
+		t.Fatalf("write key params for %s: %v", name, err)
+	}
+
+	output, err := exec.Command(
+		"gpg", "--homedir", gpgHome,
+		"--batch", "--gen-key", paramFile,
+	).CombinedOutput()
+	if err != nil {
+		t.Fatalf("generate key %s: %v\n%s", name, err, output)
+	}
+
+	return testGetFingerprint(t, gpgHome, name)
+}
+
+// testGetFingerprint extracts the primary-key fingerprint for
+// the named key from the given GPG homedir.
+func testGetFingerprint(
+	t *testing.T, gpgHome, name string,
+) string {
+	t.Helper()
+
+	output, err := exec.Command(
+		"gpg", "--homedir", gpgHome,
+		"--batch", "--with-colons",
+		"--list-keys", name,
+	).CombinedOutput()
+	if err != nil {
+		t.Fatalf("list key %s: %v\n%s", name, err, output)
+	}
+
+	for _, line := range strings.Split(string(output), "\n") {
+		if strings.HasPrefix(line, "fpr:") {
+			fields := strings.Split(line, ":")
+			if len(fields) >= 10 && fields[9] != "" {
+				return fields[9]
 			}
-		})
+		}
+	}
+	t.Fatalf("fingerprint not found for %s in:\n%s",
+		name, output)
+	return ""
+}
+
+// testExportKey exports the public key for the given fingerprint
+// to a file.
+func testExportKey(
+	t *testing.T, gpgHome, fingerprint, destFile string,
+) {
+	t.Helper()
+
+	output, err := exec.Command(
+		"gpg", "--homedir", gpgHome,
+		"--batch", "--armor",
+		"--export", fingerprint,
+	).CombinedOutput()
+	if err != nil {
+		t.Fatalf("export key %s: %v", fingerprint, err)
+	}
+	if err := os.WriteFile(destFile, output, 0600); err != nil {
+		t.Fatalf("write key file: %v", err)
 	}
 }
 
-func TestParseBadSigCount(t *testing.T) {
-	tests := []struct {
-		name   string
-		output string
-		want   int
-	}{
-		{
-			name:   "no bad sigs",
-			output: "[GNUPG:] GOODSIG A fanquake\n",
-			want:   0,
-		},
-		{
-			name:   "one bad sig",
-			output: "[GNUPG:] BADSIG A fanquake\n",
-			want:   1,
-		},
-		{
-			name:   "mixed good and bad",
-			output: "[GNUPG:] GOODSIG A fanquake\n[GNUPG:] BADSIG B guggero\n[GNUPG:] BADSIG C hebasto\n",
-			want:   2,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := ParseBadSigCount(tt.output)
-			if got != tt.want {
-				t.Errorf("got %d, want %d", got, tt.want)
-			}
-		})
+// testSign creates an armored detached signature of dataFile
+// using the key identified by fingerprint.
+func testSign(
+	t *testing.T, gpgHome, fingerprint,
+	dataFile, sigFile string,
+) {
+	t.Helper()
+
+	output, err := exec.Command(
+		"gpg", "--homedir", gpgHome,
+		"--batch", "--armor",
+		"--local-user", fingerprint,
+		"--detach-sign",
+		"--output", sigFile,
+		dataFile,
+	).CombinedOutput()
+	if err != nil {
+		t.Fatalf("sign with %s: %v\n%s",
+			fingerprint, err, output)
 	}
 }
 
-func TestHasGoodSig(t *testing.T) {
-	if HasGoodSig("") {
-		t.Error("empty string should not have GOODSIG")
+// ── Hermetic test suite ─────────────────────────────────
+
+func TestVerifyIsolated(t *testing.T) {
+	if !gpgAvailable() {
+		t.Skip("gpg not available — skipping")
 	}
-	if !HasGoodSig("[GNUPG:] GOODSIG A fanquake") {
-		t.Error("should detect GOODSIG")
+
+	// Set up a key-generation homedir with two distinct keys
+	// and one subkey-only key.
+	genHome, err := os.MkdirTemp("", "rlvpn-test-gen-")
+	if err != nil {
+		t.Fatalf("create gen home: %v", err)
 	}
-	if HasGoodSig("[GNUPG:] BADSIG A fanquake") {
-		t.Error("BADSIG should not count as GOODSIG")
+	defer os.RemoveAll(genHome)
+
+	fpAlpha := testGenKey(t, genHome, "Alpha", false)
+	fpBeta := testGenKey(t, genHome, "Beta", false)
+	fpSubkey := testGenKey(t, genHome, "SubkeySigner", true)
+
+	// Create test data file.
+	dataDir, err := os.MkdirTemp("", "rlvpn-test-data-")
+	if err != nil {
+		t.Fatalf("create data dir: %v", err)
 	}
+	defer os.RemoveAll(dataDir)
+
+	dataFile := filepath.Join(dataDir, "testdata.txt")
+	if err := os.WriteFile(
+		dataFile, []byte("test data content\n"), 0600); err != nil {
+		t.Fatalf("write test data: %v", err)
+	}
+
+	// Create a tampered data file (for case 2).
+	tamperedFile := filepath.Join(dataDir, "tampered.txt")
+	if err := os.WriteFile(
+		tamperedFile,
+		[]byte("tampered data content\n"), 0600); err != nil {
+		t.Fatalf("write tampered data: %v", err)
+	}
+
+	// Export all keys to files (for verifyIsolated to import).
+	keyAlpha := filepath.Join(dataDir, "alpha.asc")
+	keyBeta := filepath.Join(dataDir, "beta.asc")
+	keySubkey := filepath.Join(dataDir, "subkey.asc")
+	testExportKey(t, genHome, fpAlpha, keyAlpha)
+	testExportKey(t, genHome, fpBeta, keyBeta)
+	testExportKey(t, genHome, fpSubkey, keySubkey)
+
+	// Sign test data with each key.
+	sigAlpha := filepath.Join(dataDir, "sig-alpha.asc")
+	sigBeta := filepath.Join(dataDir, "sig-beta.asc")
+	sigSubkey := filepath.Join(dataDir, "sig-subkey.asc")
+	testSign(t, genHome, fpAlpha, dataFile, sigAlpha)
+	testSign(t, genHome, fpBeta, dataFile, sigBeta)
+	testSign(t, genHome, fpSubkey, dataFile, sigSubkey)
+
+	// Create combined signatures for multi-signer tests.
+	sigAlphaData, _ := os.ReadFile(sigAlpha)
+	sigBetaData, _ := os.ReadFile(sigBeta)
+
+	// Alpha + Beta combined (for case 5).
+	sigAlphaBeta := filepath.Join(dataDir, "sig-alpha-beta.asc")
+	if err := os.WriteFile(
+		sigAlphaBeta,
+		append(sigAlphaData, sigBetaData...),
+		0600); err != nil {
+		t.Fatalf("write combined sig: %v", err)
+	}
+
+	// Alpha + Alpha combined (for case 4).
+	sigAlphaAlpha := filepath.Join(dataDir,
+		"sig-alpha-alpha.asc")
+	if err := os.WriteFile(
+		sigAlphaAlpha,
+		append(sigAlphaData, sigAlphaData...),
+		0600); err != nil {
+		t.Fatalf("write double sig: %v", err)
+	}
+
+	// ── Case 1: Good sig from a pinned key → accept ────
+	t.Run("pinned_key_accepts", func(t *testing.T) {
+		pinned := map[string]bool{fpAlpha: true}
+		distinct, bad, err := verifyIsolated(
+			[]string{keyAlpha}, sigAlpha, dataFile, pinned)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if bad {
+			t.Fatal("unexpected BADSIG")
+		}
+		if distinct != 1 {
+			t.Fatalf("distinct = %d, want 1", distinct)
+		}
+	})
+
+	// ── Case 2: Tampered file → BADSIG → reject ────────
+	t.Run("tampered_file_badsig", func(t *testing.T) {
+		pinned := map[string]bool{fpAlpha: true}
+		_, bad, err := verifyIsolated(
+			[]string{keyAlpha}, sigAlpha, tamperedFile, pinned)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !bad {
+			t.Fatal("expected BADSIG for tampered file")
+		}
+	})
+
+	// ── Case 3: Good sig from UNPINNED key → reject ────
+	t.Run("unpinned_key_rejects", func(t *testing.T) {
+		// Alpha signed, but only Beta is pinned.
+		pinned := map[string]bool{fpBeta: true}
+		distinct, bad, err := verifyIsolated(
+			[]string{keyAlpha}, sigAlpha, dataFile, pinned)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if bad {
+			t.Fatal("unexpected BADSIG")
+		}
+		if distinct != 0 {
+			t.Fatalf("distinct = %d, want 0 "+
+				"(signature valid but not from pinned key)",
+				distinct)
+		}
+	})
+
+	// ── Case 4: Same key twice → counts as 1 ───────────
+	//     → fails threshold 2
+	t.Run("same_key_twice_counts_once", func(t *testing.T) {
+		pinned := map[string]bool{fpAlpha: true}
+		distinct, bad, err := verifyIsolated(
+			[]string{keyAlpha},
+			sigAlphaAlpha, dataFile, pinned)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if bad {
+			t.Fatal("unexpected BADSIG")
+		}
+		if distinct != 1 {
+			t.Fatalf("distinct = %d, want 1 "+
+				"(same key signing twice should count once)",
+				distinct)
+		}
+		// Would fail threshold 2.
+		if distinct >= 2 {
+			t.Fatal("same key twice should not clear threshold 2")
+		}
+	})
+
+	// ── Case 5: Two different pinned keys → clears 2 ───
+	t.Run("two_pinned_keys_clears_threshold", func(t *testing.T) {
+		pinned := map[string]bool{
+			fpAlpha: true,
+			fpBeta:  true,
+		}
+		distinct, bad, err := verifyIsolated(
+			[]string{keyAlpha, keyBeta},
+			sigAlphaBeta, dataFile, pinned)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if bad {
+			t.Fatal("unexpected BADSIG")
+		}
+		if distinct != 2 {
+			t.Fatalf("distinct = %d, want 2", distinct)
+		}
+	})
+
+	// ── Case 6: Subkey-signed → matches primary FP ─────
+	t.Run("subkey_signed_matches_primary", func(t *testing.T) {
+		// fpSubkey is the PRIMARY fingerprint. The signing
+		// subkey has a different fingerprint. verifyIsolated
+		// must match the VALIDSIG last field (primary), not
+		// the first field (subkey).
+		pinned := map[string]bool{fpSubkey: true}
+		distinct, bad, err := verifyIsolated(
+			[]string{keySubkey},
+			sigSubkey, dataFile, pinned)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if bad {
+			t.Fatal("unexpected BADSIG")
+		}
+		if distinct != 1 {
+			t.Fatalf("distinct = %d, want 1 "+
+				"(subkey-signed should match primary FP)",
+				distinct)
+		}
+	})
 }
 
-func TestBadSigShouldBlockVerification(t *testing.T) {
-	// This test documents the security fix:
-	// Even with 2 good sigs, if there's a bad sig, verification should fail
-	output := "[GNUPG:] GOODSIG A fanquake\n[GNUPG:] GOODSIG B guggero\n[GNUPG:] BADSIG C hebasto\n"
-
-	good := ParseGoodSigCount(output)
-	bad := ParseBadSigCount(output)
-
-	if good < 2 {
-		t.Error("expected at least 2 good sigs")
-	}
-	if bad == 0 {
-		t.Error("expected bad sigs to be detected")
-	}
-
-	// In the fixed code, bad > 0 means verification fails
-	// regardless of good sig count
-	if bad > 0 && good >= 2 {
-		t.Log("PASS: bad sigs detected even with sufficient good sigs")
-	}
-}
+// ── Anchor validation ───────────────────────────────────
 
 func TestSignerFingerprints(t *testing.T) {
 	if len(bitcoinCoreSigners) != 5 {
@@ -143,25 +365,17 @@ func TestSignerFingerprints(t *testing.T) {
 	}
 }
 
-func TestReleaseKeyFingerprintFormat(t *testing.T) {
-	// The release signing key fingerprint is defined in setup.go's SelfUpdateSteps.
-	// We can't easily access it from here since it's a local variable,
-	// but we can test the fingerprint validation logic.
-
-	validFP := "ABCDEF1234567890ABCDEF1234567890ABCDEF12"
-	if len(validFP) != 40 {
-		t.Errorf("test fingerprint length: got %d, want 40", len(validFP))
+func TestReleaseKeyFingerprint(t *testing.T) {
+	if len(rlvpnReleaseFP) != 40 {
+		t.Errorf("release key fingerprint length %d, want 40",
+			len(rlvpnReleaseFP))
 	}
 
-	// Test that our GPG output parsing would match a fingerprint
-	sampleOutput := "fpr:::::::::ABCDEF1234567890ABCDEF1234567890ABCDEF12:"
-	if !strings.Contains(sampleOutput, validFP) {
-		t.Error("fingerprint should be found in GPG colon output")
-	}
-
-	// Test that a wrong fingerprint doesn't match
-	wrongFP := "0000000000000000000000000000000000000000"
-	if strings.Contains(sampleOutput, wrongFP) {
-		t.Error("wrong fingerprint should not match")
+	// Cross-check: must match the value baked into
+	// virtual-private-node.sh SIGNING_KEY_FP (line 24).
+	expected := "AFA0EBACDC9A4C4AA7B0154AC97CE10F170BA5FE"
+	if rlvpnReleaseFP != expected {
+		t.Errorf("release FP = %s, want %s",
+			rlvpnReleaseFP, expected)
 	}
 }


### PR DESCRIPTION
Replace three independent verification paths with a shared
verifyIsolated helper. Each verification now runs in an ephemeral
GPG homedir, parses VALIDSIG primary-key fingerprints against a
pinned set, counts distinct signers, and treats any BADSIG as a
hard stop. The GPG exit code is no longer trusted.

Self-update: threshold 1 vs ripsline key (was shared-keyring
AND exit-code only). Bitcoin Core: threshold 2 distinct builder
fingerprints (was GOODSIG substring count). LND: threshold 1 vs
roasbeef (was any-GOODSIG acceptance).

The previous code downloaded the correct keys from upstream URLs
and GPG did verify signatures against them, so installed software
was genuine. But the verification logic had two gaps: signatures
were accepted from any key in the shared keyring (not just the
intended signer), and the pinned fingerprints were only checked
at import time, never matched against actual signatures. This
fix closes both gaps.

5 signing-key fingerprints corrected to primary-key values.

Download and verification pipelines use os.MkdirTemp working
directories instead of hardcoded /tmp paths. Trust anchors
consolidated in verify.go with provenance comments. Dead helpers
removed. 6-case test suite included.