### PR TITLE
fix: write privileged files atomically to close a permissions gap

### DIFF
--- a/internal/installer/lnd.go
+++ b/internal/installer/lnd.go
@@ -241,14 +241,17 @@ func setupAutoUnlock(password string) error {
 	defer os.Remove(tmpPw)
 
 	passwordFile := paths.LNDWalletPassword
-	if err := system.SudoRun("cp", tmpPw, passwordFile); err != nil {
-		return err
+	tmpDest := filepath.Join(filepath.Dir(passwordFile), ".wallet_password.tmp")
+	if err := system.SudoRun("install", "-m", "0400",
+		"-o", systemUser, "-g", systemUser, tmpPw, tmpDest); err != nil {
+		system.SudoRunSilent("rm", "-f", tmpDest)
+		logger.System("auto-unlock: install wallet password: %v", err)
+		return fmt.Errorf("install wallet password: %w", err)
 	}
-	if err := system.SudoRun("chmod", "0400", passwordFile); err != nil {
-		return err
-	}
-	if err := system.SudoRunSilent("chown", systemUser+":"+systemUser, passwordFile); err != nil {
-		logger.System("Warning: chown wallet password: %v", err)
+	if err := system.SudoRun("mv", tmpDest, passwordFile); err != nil {
+		system.SudoRunSilent("rm", "-f", tmpDest)
+		logger.System("auto-unlock: move wallet password: %v", err)
+		return fmt.Errorf("move wallet password: %w", err)
 	}
 
 	content := fmt.Sprintf(`[Unit]

--- a/internal/system/exec.go
+++ b/internal/system/exec.go
@@ -7,8 +7,11 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/ripsline/virtual-private-node/internal/logger"
 )
 
 // Run executes a command and returns an error with output on failure.
@@ -93,8 +96,11 @@ func SudoRunSilent(name string, args ...string) error {
 	return RunSilent("sudo", sudoArgs...)
 }
 
-// SudoWriteFile writes content to a system path via sudo.
-// Uses os.CreateTemp for secure temp file creation (O_EXCL prevents symlink attacks).
+// SudoWriteFile atomically writes content to a root-owned path via sudo:
+// stages in a dest-dir temp (install -m), then rename(2) onto the path, so the
+// canonical path only ever holds the final mode and a crash never leaves it
+// partial or world-readable. os.CreateTemp's O_EXCL guards the staging file
+// against symlink attacks. Write failures are logged centrally for support.
 func SudoWriteFile(path string, content []byte, perm os.FileMode) error {
 	tmpFile, err := os.CreateTemp("", "rlvpn-write-")
 	if err != nil {
@@ -109,10 +115,19 @@ func SudoWriteFile(path string, content []byte, perm os.FileMode) error {
 	}
 	tmpFile.Close()
 
-	if err := SudoRun("cp", tmpPath, path); err != nil {
+	tmpDest := filepath.Join(filepath.Dir(path), "."+filepath.Base(path)+".tmp")
+	if err := SudoRun("install", "-m", fmt.Sprintf("%04o", perm),
+		tmpPath, tmpDest); err != nil {
+		SudoRunSilent("rm", "-f", tmpDest)
+		logger.System("write %s: install: %v", path, err)
 		return err
 	}
-	return SudoRun("chmod", fmt.Sprintf("%o", perm), path)
+	if err := SudoRun("mv", tmpDest, path); err != nil {
+		SudoRunSilent("rm", "-f", tmpDest)
+		logger.System("write %s: mv: %v", path, err)
+		return err
+	}
+	return nil
 }
 
 // Download fetches a URL to a local path.


### PR DESCRIPTION
We used to copy a file into place and THEN set its permissions. For a brief moment the file existed with the wrong permissions. For wallet_password that meant the LND unlock password was readable by anyone on the system during that gap, and a crash mid-write could leave the file broken or wrongly-permissioned.

The fix: write to a temporary file first (with correct permissions already set), then rename it into place. A rename is instant and all-or-nothing, so the real file is only ever the old version or the finished new version, never a half-written one.

The temporary file is given a temporary NAME inside the target's own directory (e.g. /var/lib/lnd/.wallet_password.tmp), then renamed to the real name. It must stay in the same directory: rename is only atomic within one filesystem. Do not stage it in the /tmp directory, which can be a separate filesystem where the rename silently becomes a copy and reopens the gap.

This is fixed in SudoWriteFile, the shared helper for all 20 root-owned writes (lnd.conf, services, torrc, authorized_keys, SSH drop-in, apt configs, fail2ban, Syncthing units). setupAutoUnlock (wallet_password) gets the same fix, and a failed ownership change now stops the process instead of being ignored.