### PR TITLE
fix: pin Syncthing to a verified release and fix its privacy configuration

### DIFF
--- a/internal/installer/setup.go
+++ b/internal/installer/setup.go
@@ -20,9 +20,10 @@ import (
 )
 
 const (
-	bitcoinVersion = "29.3"
-	lndVersion     = "0.20.0-beta"
-	systemUser     = "bitcoin"
+	bitcoinVersion   = "29.3"
+	lndVersion       = "0.20.0-beta"
+	syncthingVersion = "2.1.1"
+	systemUser       = "bitcoin"
 )
 
 var appVersion = "dev"
@@ -405,11 +406,34 @@ func SyncthingInstallSteps(
 	}
 	syncPassword := hexEncode(passBytes)
 
+	var syncWork string
 	steps := []InstallStep{
-		{Name: "Adding Syncthing repository",
-			Fn: installSyncthingRepo},
+		{Name: "Downloading Syncthing " + syncthingVersion,
+			Fn: func() error {
+				var err error
+				syncWork, err = os.MkdirTemp("", "rlvpn-sync-")
+				if err != nil {
+					return fmt.Errorf("create work dir: %w", err)
+				}
+				return downloadSyncthing(
+					syncthingVersion, syncWork)
+			}},
+		{Name: "Verifying Syncthing",
+			Fn: func() error {
+				if err := verifySyncthingSig(syncWork); err != nil {
+					return err
+				}
+				return verifySyncthingChecksum(syncWork)
+			}},
 		{Name: "Installing Syncthing",
-			Fn: installSyncthingPackage},
+			Fn: func() error {
+				if err := extractAndInstallSyncthing(
+					syncthingVersion, syncWork); err != nil {
+					return err
+				}
+				os.RemoveAll(syncWork)
+				return nil
+			}},
 		{Name: "Creating Syncthing directories",
 			Fn: createSyncthingDirs},
 		{Name: "Creating Syncthing service",

--- a/internal/installer/syncthing.go
+++ b/internal/installer/syncthing.go
@@ -241,8 +241,9 @@ func verifySyncthingConfig() error {
 	if !strings.Contains(content,
 		`<configuration version="`+syncthingConfigSchema+`"`) {
 		return fmt.Errorf(
-			"version tripwire: config schema is not the pinned "+
-				"version %s", syncthingConfigSchema)
+			"version tripwire: config schema does not match "+
+				"the pinned schema version %s",
+			syncthingConfigSchema)
 	}
 
 	required := []string{

--- a/internal/installer/syncthing.go
+++ b/internal/installer/syncthing.go
@@ -7,6 +7,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -18,59 +19,46 @@ import (
 	"github.com/ripsline/virtual-private-node/internal/system"
 )
 
-// ── Syncthing XML config types ───────────────────────────
-
-type syncthingConfig struct {
-	XMLName xml.Name      `xml:"configuration"`
-	GUI     syncthingGUI  `xml:"gui"`
-	Options syncthingOpts `xml:"options"`
-	Rest    []byte        `xml:",innerxml"`
-}
-
-type syncthingGUI struct {
-	Enabled               string `xml:"enabled,attr"`
-	TLS                   string `xml:"tls,attr"`
-	Address               string `xml:"address"`
-	User                  string `xml:"user,omitempty"`
-	Password              string `xml:"password,omitempty"`
-	InsecureSkipHostcheck bool   `xml:"insecureSkipHostcheck"`
-	APIKey                string `xml:"apikey,omitempty"`
-	Theme                 string `xml:"theme,omitempty"`
-}
-
-type syncthingOpts struct {
-	ListenAddresses       []string `xml:"listenAddress"`
-	GlobalAnnounceEnabled bool     `xml:"globalAnnounceEnabled"`
-	LocalAnnounceEnabled  bool     `xml:"localAnnounceEnabled"`
-	RelaysEnabled         bool     `xml:"relaysEnabled"`
-	NATEnabled            bool     `xml:"natEnabled"`
-	Rest                  []byte   `xml:",innerxml"`
-}
-
-func installSyncthingRepo() error {
-	system.SudoRun("mkdir", "-p", "/etc/apt/keyrings")
-
-	tmpKey := "/tmp/syncthing-release-key.gpg"
+// downloadSyncthing fetches the pinned release tarball and its
+// clearsigned checksum file from GitHub over Tor.
+func downloadSyncthing(version, workDir string) error {
+	filename := fmt.Sprintf(
+		"syncthing-linux-amd64-v%s.tar.gz", version)
+	url := fmt.Sprintf(
+		"https://github.com/syncthing/syncthing/releases/download/v%s/%s",
+		version, filename)
+	ascURL := fmt.Sprintf(
+		"https://github.com/syncthing/syncthing/releases/download/v%s/sha256sum.txt.asc",
+		version)
 	if err := system.DownloadRequireTor(
-		"https://syncthing.net/release-key.gpg", tmpKey); err != nil {
+		url, filepath.Join(workDir, filename)); err != nil {
 		return err
 	}
-	defer os.Remove(tmpKey)
-	if err := system.SudoRun("cp", tmpKey, paths.SyncthingKeyring); err != nil {
-		return err
+	if err := system.DownloadRequireTor(ascURL,
+		filepath.Join(workDir, "sha256sum.txt.asc")); err != nil {
+		return fmt.Errorf("download Syncthing checksums: %w", err)
 	}
-
-	repoLine := `deb [signed-by=` + paths.SyncthingKeyring +
-		`] https://apt.syncthing.net/ syncthing stable-v2`
-	return system.SudoWriteFile(paths.SyncthingSourceList,
-		[]byte(repoLine+"\n"), 0644)
+	return nil
 }
 
-func installSyncthingPackage() error {
-	if err := system.SudoRun("apt-get", "update", "-qq"); err != nil {
+// extractAndInstallSyncthing unpacks the verified tarball and
+// installs the binary to /usr/local/bin (LND pattern).
+// Tarball layout (verified June 9 2026):
+// syncthing-linux-amd64-v<ver>/syncthing
+func extractAndInstallSyncthing(version, workDir string) error {
+	filename := fmt.Sprintf(
+		"syncthing-linux-amd64-v%s.tar.gz", version)
+	if err := system.Run("tar", "-xzf",
+		filepath.Join(workDir, filename),
+		"-C", workDir); err != nil {
 		return err
 	}
-	return system.SudoRun("apt-get", "install", "-y", "-qq", "syncthing")
+	src := filepath.Join(workDir,
+		fmt.Sprintf("syncthing-linux-amd64-v%s", version),
+		"syncthing")
+	return system.SudoRun("install", "-m", "0755",
+		"-o", "root", "-g", "root",
+		src, "/usr/local/bin/")
 }
 
 func createSyncthingDirs() error {
@@ -98,6 +86,14 @@ func createSyncthingDirs() error {
 	return nil
 }
 
+// writeSyncthingService writes the systemd unit for the pinned
+// Syncthing binary. STNOUPGRADE=1 disables the binary's
+// self-upgrader (the GitHub release binary is NOT built with
+// [noupgrade], verified June 9 2026 — this env var plus
+// autoUpgradeIntervalH=0 in the config are the two controls).
+// STNODEFAULTFOLDER=1 prevents creation of the default ~/Sync
+// folder on first run. --no-restart + Restart=on-failure keeps
+// lifecycle ownership with systemd (existing posture).
 func writeSyncthingService() error {
 	content := fmt.Sprintf(`[Unit]
 Description=Syncthing File Synchronization
@@ -108,7 +104,9 @@ Wants=network-online.target
 Type=simple
 User=%s
 Group=%s
-ExecStart=/usr/bin/syncthing serve --no-browser --no-restart --config=/etc/syncthing --data=/var/lib/syncthing
+Environment=STNOUPGRADE=1
+Environment=STNODEFAULTFOLDER=1
+ExecStart=/usr/local/bin/syncthing serve --no-browser --no-restart --config=/etc/syncthing --data=/var/lib/syncthing
 Restart=on-failure
 RestartSec=10
 SuccessExitStatus=3 4
@@ -121,65 +119,166 @@ WantedBy=multi-user.target
 		[]byte(content), 0644)
 }
 
+// configureSyncthingAuth provisions Syncthing's identity and
+// writes the complete authored config BEFORE first daemon start.
+//
+// Finding H history: the previous implementation round-tripped
+// the generated config through Go structs carrying `,innerxml`,
+// which re-emitted captured raw XML alongside the typed fields —
+// duplicate <gui>/<options> blocks whose last-wins resolution
+// kept the generate defaults, silently leaving discovery and
+// relays ENABLED on every install. Struct round-trips are
+// unsalvageable here (dedup either duplicates or drops unmodeled
+// elements); the fix is to author the entire file from a
+// template tied to the pinned Syncthing version, then verify it
+// before the daemon ever starts.
 func configureSyncthingAuth(password string) error {
 	system.SudoRunSilent("chown",
 		systemUser+":"+systemUser, paths.SyncthingDir)
 
-	if err := system.SudoRun("-u", systemUser, "syncthing",
+	// 1. Crypto identity only: TLS cert/key + device ID. The
+	//    generated config.xml is read for its identity values,
+	//    then overwritten by the authored template. Explicit
+	//    binary path — never PATH resolution — so a leftover
+	//    apt-installed /usr/bin/syncthing can never be the one
+	//    that generates the identity.
+	if err := system.SudoRun("-u", systemUser,
+		"/usr/local/bin/syncthing",
 		"generate", "--home="+paths.SyncthingDir); err != nil {
 		return fmt.Errorf("syncthing generate: %w", err)
 	}
 
-	configPath := paths.SyncthingConfigXML
-	output, err := system.SudoRunOutput("cat", configPath)
+	// 2. Extract device ID, device name, and API key from the
+	//    generated config. Read by exact path — `generate` can
+	//    leave its own .syncthing.tmp.* scratch alongside.
+	output, err := system.SudoRunOutput("cat",
+		paths.SyncthingConfigXML)
 	if err != nil {
-		return fmt.Errorf("read config: %w", err)
+		return fmt.Errorf("read generated config: %w", err)
 	}
 
-	var cfg syncthingConfig
-	if err := xml.Unmarshal([]byte(output), &cfg); err != nil {
-		return fmt.Errorf("parse config: %w", err)
+	type genDevice struct {
+		ID   string `xml:"id,attr"`
+		Name string `xml:"name,attr"`
+	}
+	type genGUI struct {
+		APIKey string `xml:"apikey"`
+	}
+	type genConfig struct {
+		XMLName xml.Name    `xml:"configuration"`
+		Devices []genDevice `xml:"device"`
+		GUI     genGUI      `xml:"gui"`
+	}
+	var gen genConfig
+	if err := xml.Unmarshal([]byte(output), &gen); err != nil {
+		return fmt.Errorf("parse generated config: %w", err)
+	}
+	if len(gen.Devices) == 0 || gen.Devices[0].ID == "" {
+		return fmt.Errorf("generated config has no device ID")
+	}
+	if gen.GUI.APIKey == "" {
+		return fmt.Errorf("generated config has no API key")
 	}
 
-	// Hash password
+	// 3. Hash the GUI password.
 	hash, err := bcrypt.GenerateFromPassword(
 		[]byte(password), bcrypt.DefaultCost)
 	if err != nil {
 		return fmt.Errorf("hash password: %w", err)
 	}
 
-	// Configure GUI
-	cfg.GUI.Address = "127.0.0.1:8384"
-	cfg.GUI.User = "admin"
-	cfg.GUI.Password = string(hash)
-	cfg.GUI.InsecureSkipHostcheck = true
-
-	// Disable discovery and relays — connections are direct only
-	cfg.Options.GlobalAnnounceEnabled = false
-	cfg.Options.LocalAnnounceEnabled = false
-	cfg.Options.RelaysEnabled = false
-	cfg.Options.NATEnabled = false
-
-	// Listen on all interfaces for clearnet sync connections.
-	// Syncthing uses mutual TLS — only pre-approved Device IDs
-	// can establish a connection.
-	cfg.Options.ListenAddresses = []string{"tcp://0.0.0.0:22000"}
-	cfg.Options.Rest = nil
-
-	// Marshal back
-	xmlOutput, err := xml.MarshalIndent(cfg, "", "    ")
-	if err != nil {
-		return fmt.Errorf("marshal config: %w", err)
-	}
-
-	xmlHeader := []byte(xml.Header)
-	xmlOutput = append(xmlHeader, xmlOutput...)
-
-	if err := system.SudoWriteFile(configPath, xmlOutput, 0640); err != nil {
+	// 4. Author the complete config and write it atomically.
+	rendered := renderSyncthingConfig(
+		gen.Devices[0].ID, gen.Devices[0].Name,
+		gen.GUI.APIKey, string(hash))
+	if err := system.SudoWriteFile(paths.SyncthingConfigXML,
+		[]byte(rendered), 0640); err != nil {
 		return err
 	}
-	return system.SudoRun("chown",
-		systemUser+":"+systemUser, configPath)
+	if err := system.SudoRun("chown",
+		systemUser+":"+systemUser,
+		paths.SyncthingConfigXML); err != nil {
+		return err
+	}
+
+	// 5. Self-verify gate — the daemon must never start with a
+	//    config we have not verified.
+	return verifySyncthingConfig()
+}
+
+// verifySyncthingConfig is the pre-start self-verify gate.
+// Gate (a) — version tripwire: the installed binary must be the
+// pinned version and the written config must carry the pinned
+// schema version. When the pinned version is bumped in a future
+// release, this fails until the template is re-reviewed against
+// the new version's generate output — deliberately.
+// Gate (b) — field check: every privacy field must be PRESENT
+// with its exact intended value, with single <gui>/<options>
+// blocks and a single listen address. An absent field means the
+// schema assumption broke; refusing to start converts a silent
+// leak into a loud install failure.
+func verifySyncthingConfig() error {
+	// (a) binary version
+	verOut, err := system.RunContext(10*time.Second,
+		"/usr/local/bin/syncthing", "--version")
+	if err != nil {
+		return fmt.Errorf("syncthing --version: %w", err)
+	}
+	if !strings.Contains(verOut, "syncthing v"+syncthingVersion+" ") {
+		return fmt.Errorf(
+			"version tripwire: installed Syncthing is not the "+
+				"pinned v%s: %q", syncthingVersion,
+			strings.TrimSpace(verOut))
+	}
+
+	// (b) written config
+	content, err := system.SudoRunOutput("cat",
+		paths.SyncthingConfigXML)
+	if err != nil {
+		return fmt.Errorf("re-read config: %w", err)
+	}
+
+	if !strings.Contains(content,
+		`<configuration version="`+syncthingConfigSchema+`"`) {
+		return fmt.Errorf(
+			"version tripwire: config schema is not the pinned "+
+				"version %s", syncthingConfigSchema)
+	}
+
+	required := []string{
+		"<globalAnnounceEnabled>false</globalAnnounceEnabled>",
+		"<localAnnounceEnabled>false</localAnnounceEnabled>",
+		"<relaysEnabled>false</relaysEnabled>",
+		"<natEnabled>false</natEnabled>",
+		"<announceLANAddresses>false</announceLANAddresses>",
+		"<crashReportingEnabled>false</crashReportingEnabled>",
+		"<autoUpgradeIntervalH>0</autoUpgradeIntervalH>",
+		"<urAccepted>-1</urAccepted>",
+		"<listenAddress>tcp://0.0.0.0:22000</listenAddress>",
+	}
+	for _, want := range required {
+		if !strings.Contains(content, want) {
+			return fmt.Errorf(
+				"config self-verify failed: %s missing or wrong "+
+					"— refusing to start Syncthing", want)
+		}
+	}
+
+	for tag, n := range map[string]int{
+		"<gui ":           1,
+		"<options>":       1,
+		"<listenAddress>": 1,
+	} {
+		if got := strings.Count(content, tag); got != n {
+			return fmt.Errorf(
+				"config self-verify failed: %d %s blocks, want %d "+
+					"— refusing to start Syncthing", got, tag, n)
+		}
+	}
+
+	logger.Install("Syncthing config self-verify passed " +
+		"(pinned version, schema, privacy fields)")
+	return nil
 }
 
 func setupChannelBackupWatcher(cfg *config.AppConfig) error {
@@ -237,6 +336,17 @@ ExecStart=/bin/cp %s %s
 	return nil
 }
 
+// stopSyncthingFailSafe stops AND disables Syncthing. Used on
+// the fail-safe paths (readiness timeout, privacy-confirm
+// failure) so that a later reboot — including the automatic
+// reboot from unattended-upgrades — cannot silently restart a
+// daemon whose privacy state we could not verify. A retried
+// install re-enables via startSyncthing.
+func stopSyncthingFailSafe() {
+	system.SudoRunSilent("systemctl", "stop", "syncthing")
+	system.SudoRunSilent("systemctl", "disable", "syncthing")
+}
+
 func startSyncthing() error {
 	if err := system.SudoRun("systemctl", "daemon-reload"); err != nil {
 		return err
@@ -248,18 +358,71 @@ func startSyncthing() error {
 		return err
 	}
 
-	// Wait for Syncthing to become ready (lenient — continue regardless)
+	// Readiness probe. /rest/noauth/health is the documented
+	// unauthenticated endpoint; the previous probe hit
+	// /rest/system/status without an API key, got 403 on every
+	// try, and spun the full 30s. Fail-safe: if the daemon never
+	// readies, stop it and fail the install.
+	ready := false
 	for i := 0; i < 30; i++ {
 		output, err := system.RunContext(3*time.Second,
 			"curl", "-s", "-o", "/dev/null",
 			"-w", "%{http_code}",
-			"http://127.0.0.1:8384/rest/system/status")
+			"http://127.0.0.1:8384/rest/noauth/health")
 		if err == nil && strings.TrimSpace(output) == "200" {
+			ready = true
 			break
 		}
 		time.Sleep(1 * time.Second)
 	}
+	if !ready {
+		stopSyncthingFailSafe()
+		return fmt.Errorf(
+			"syncthing did not become ready — stopped")
+	}
 
+	// Post-start confirmation (defense in depth): the RUNNING
+	// daemon must report the privacy settings off. This is the
+	// exact check that exposed finding H. Fail-safe on mismatch.
+	return confirmSyncthingPrivacy()
+}
+
+// confirmSyncthingPrivacy reads the effective options from the
+// running daemon and hard-fails (stopping Syncthing) if any
+// announce/relay setting is enabled.
+func confirmSyncthingPrivacy() error {
+	apiKey, err := getSyncthingAPIKey()
+	if err != nil {
+		stopSyncthingFailSafe()
+		return fmt.Errorf("privacy confirm: get API key: %w", err)
+	}
+	resp, err := syncthingAPIGet(apiKey, "/rest/config/options")
+	if err != nil {
+		stopSyncthingFailSafe()
+		return fmt.Errorf("privacy confirm: get options: %w", err)
+	}
+
+	var opts struct {
+		GlobalAnnounceEnabled bool `json:"globalAnnounceEnabled"`
+		LocalAnnounceEnabled  bool `json:"localAnnounceEnabled"`
+		RelaysEnabled         bool `json:"relaysEnabled"`
+		NATEnabled            bool `json:"natEnabled"`
+	}
+	if err := json.Unmarshal([]byte(resp), &opts); err != nil {
+		stopSyncthingFailSafe()
+		return fmt.Errorf("privacy confirm: parse options: %w", err)
+	}
+	if opts.GlobalAnnounceEnabled || opts.LocalAnnounceEnabled ||
+		opts.RelaysEnabled || opts.NATEnabled {
+		stopSyncthingFailSafe()
+		return fmt.Errorf(
+			"privacy confirm FAILED: running daemon reports "+
+				"announce/relay enabled (global=%t local=%t "+
+				"relays=%t nat=%t) — Syncthing stopped",
+			opts.GlobalAnnounceEnabled, opts.LocalAnnounceEnabled,
+			opts.RelaysEnabled, opts.NATEnabled)
+	}
+	logger.Install("Syncthing privacy confirmed on running daemon")
 	return nil
 }
 
@@ -353,7 +516,7 @@ func PairSyncthingDevice(deviceID string) error {
         "deviceID": %q,
         "name": "local-backup",
         "addresses": ["dynamic"],
-        "autoAcceptFolders": true
+        "autoAcceptFolders": false
     }`, deviceID)
 
 	if err := syncthingAPIPost(apiKey,
@@ -385,7 +548,14 @@ func getSyncthingAPIKey() (string, error) {
 		return "", err
 	}
 
-	var cfg syncthingConfig
+	type guiKey struct {
+		APIKey string `xml:"apikey"`
+	}
+	type cfgFile struct {
+		XMLName xml.Name `xml:"configuration"`
+		GUI     guiKey   `xml:"gui"`
+	}
+	var cfg cfgFile
 	if err := xml.Unmarshal([]byte(output), &cfg); err != nil {
 		return "", err
 	}
@@ -406,10 +576,10 @@ func syncthingAPIPost(apiKey, endpoint, body string) error {
 	return err
 }
 
-func syncthingAPIPut(apiKey, endpoint, body string) error {
+func syncthingAPIPatch(apiKey, endpoint, body string) error {
 	_, err := system.RunContext(10*time.Second,
 		"curl", "-s",
-		"-X", "PUT",
+		"-X", "PATCH",
 		"-H", "X-API-Key: "+apiKey,
 		"-H", "Content-Type: application/json",
 		"-d", body,
@@ -485,13 +655,24 @@ func addDeviceToBackupFolder(
 				folderDevice{DeviceID: deviceID},
 			)
 
-			updated, err := json.Marshal(folders[i])
+			// PATCH only the devices array. The previous PUT sent
+			// a 3-field object (id/path/devices) with no "type" —
+			// Syncthing's PUT replaces the WHOLE folder, so
+			// type:"sendonly" reverted to "sendreceive" on every
+			// pairing (finding P, reproduced live).
+			//
+			// WARNING: PATCH replaces child arrays WHOLESALE (v2
+			// Config Endpoints docs) — this MUST send the complete
+			// merged devices array (existing + new), never a
+			// single-element array, or the local device is wiped
+			// and the folder de-shared.
+			devices, err := json.Marshal(folders[i].Devices)
 			if err != nil {
 				return err
 			}
-			return syncthingAPIPut(apiKey,
+			return syncthingAPIPatch(apiKey,
 				"/rest/config/folders/"+f.ID,
-				string(updated))
+				`{"devices":`+string(devices)+`}`)
 		}
 	}
 

--- a/internal/installer/syncthing_template.go
+++ b/internal/installer/syncthing_template.go
@@ -1,0 +1,201 @@
+// internal/installer/syncthing_template.go
+
+package installer
+
+import "strings"
+
+// syncthingConfigSchema is the config schema version this
+// template is authored against. Tied to syncthingVersion
+// (setup.go): bumping the pinned Syncthing version without
+// re-reviewing this template against the new version's
+// `syncthing generate` output MUST fail the install — that is
+// the version tripwire (verifySyncthingConfig, gate a/b).
+const syncthingConfigSchema = "52"
+
+// syncthingConfigTemplate is the COMPLETE authored config.xml,
+// written over the `syncthing generate` output before first
+// daemon start. Source of truth: verbatim `syncthing generate`
+// output of the pinned v2.1.1 GitHub binary (captured June 9
+// 2026), with these deliberate deltas ONLY:
+//
+//	Privacy (finding H field set — each verified by the
+//	self-verify gate):
+//	  listenAddress        default → tcp://0.0.0.0:22000 (single;
+//	                       kills QUIC/UDP+STUN and relay listeners)
+//	  globalAnnounceEnabled true → false   (no discovery announce)
+//	  localAnnounceEnabled  true → false   (no LAN broadcast)
+//	  relaysEnabled         true → false   (no relay registration)
+//	  natEnabled            true → false   (no UPnP/NAT-PMP)
+//	  announceLANAddresses  true → false
+//	  crashReportingEnabled true → false   (no crash.syncthing.net)
+//	  autoUpgradeIntervalH  12 → 0         (self-upgrade off;
+//	                       pairs with STNOUPGRADE=1 in the unit)
+//	  urAccepted            0 → -1         (usage reporting
+//	                       declined; no data.syncthing.net POSTs)
+//
+//	Auth (existing behavior, now authored):
+//	  gui user=admin, password=bcrypt hash,
+//	  insecureSkipHostcheck=true (required for the Tor onion GUI:
+//	  the browser sends Host: <onion>, which the host check
+//	  would reject; rebinding risk N/A in this topology)
+//
+//	Omitted: <unackedNotificationID> (auth-setup nag; credentials
+//	always exist before first start).
+//
+// Every other field is generate-output verbatim, kept at default
+// deliberately. Per-field rationale doc: finding T work item.
+//
+// Placeholders (strings.NewReplacer, NOT fmt.Sprintf — the
+// template contains literal '%' in unit="%" attributes):
+//
+//	{{DEVICE_ID}}    device ID from the generated TLS cert
+//	{{DEVICE_NAME}}  device name from the generated config
+//	{{API_KEY}}      API key from the generated config
+//	{{PASSWORD_HASH}} bcrypt hash of the GUI password
+const syncthingConfigTemplate = `<configuration version="52">
+    <device id="{{DEVICE_ID}}" name="{{DEVICE_NAME}}" compression="metadata" introducer="false" skipIntroductionRemovals="false" introducedBy="">
+        <address>dynamic</address>
+        <paused>false</paused>
+        <autoAcceptFolders>false</autoAcceptFolders>
+        <maxSendKbps>0</maxSendKbps>
+        <maxRecvKbps>0</maxRecvKbps>
+        <maxRequestKiB>0</maxRequestKiB>
+        <untrusted>false</untrusted>
+        <remoteGUIPort>0</remoteGUIPort>
+        <numConnections>0</numConnections>
+    </device>
+    <gui enabled="true" tls="false" sendBasicAuthPrompt="false">
+        <address>127.0.0.1:8384</address>
+        <user>admin</user>
+        <password>{{PASSWORD_HASH}}</password>
+        <metricsWithoutAuth>false</metricsWithoutAuth>
+        <apikey>{{API_KEY}}</apikey>
+        <insecureSkipHostcheck>true</insecureSkipHostcheck>
+        <theme>default</theme>
+        <sessionCookieDurationS>604800</sessionCookieDurationS>
+        <sessionCookiePath>/</sessionCookiePath>
+    </gui>
+    <ldap></ldap>
+    <options>
+        <listenAddress>tcp://0.0.0.0:22000</listenAddress>
+        <globalAnnounceServer>default</globalAnnounceServer>
+        <globalAnnounceEnabled>false</globalAnnounceEnabled>
+        <localAnnounceEnabled>false</localAnnounceEnabled>
+        <localAnnouncePort>21027</localAnnouncePort>
+        <localAnnounceMCAddr>[ff12::8384]:21027</localAnnounceMCAddr>
+        <maxSendKbps>0</maxSendKbps>
+        <maxRecvKbps>0</maxRecvKbps>
+        <reconnectionIntervalS>20</reconnectionIntervalS>
+        <relaysEnabled>false</relaysEnabled>
+        <relayReconnectIntervalM>10</relayReconnectIntervalM>
+        <startBrowser>true</startBrowser>
+        <natEnabled>false</natEnabled>
+        <natLeaseMinutes>60</natLeaseMinutes>
+        <natRenewalMinutes>30</natRenewalMinutes>
+        <natTimeoutSeconds>10</natTimeoutSeconds>
+        <urAccepted>-1</urAccepted>
+        <urSeen>0</urSeen>
+        <urUniqueID></urUniqueID>
+        <urURL>https://data.syncthing.net/newdata</urURL>
+        <urPostInsecurely>false</urPostInsecurely>
+        <urInitialDelayS>1800</urInitialDelayS>
+        <autoUpgradeIntervalH>0</autoUpgradeIntervalH>
+        <upgradeToPreReleases>false</upgradeToPreReleases>
+        <keepTemporariesH>24</keepTemporariesH>
+        <cacheIgnoredFiles>false</cacheIgnoredFiles>
+        <progressUpdateIntervalS>5</progressUpdateIntervalS>
+        <limitBandwidthInLan>false</limitBandwidthInLan>
+        <minHomeDiskFree unit="%">1</minHomeDiskFree>
+        <releasesURL>https://upgrades.syncthing.net/meta.json</releasesURL>
+        <overwriteRemoteDeviceNamesOnConnect>false</overwriteRemoteDeviceNamesOnConnect>
+        <tempIndexMinBlocks>10</tempIndexMinBlocks>
+        <trafficClass>0</trafficClass>
+        <setLowPriority>true</setLowPriority>
+        <maxFolderConcurrency>0</maxFolderConcurrency>
+        <crashReportingURL>https://crash.syncthing.net/newcrash</crashReportingURL>
+        <crashReportingEnabled>false</crashReportingEnabled>
+        <stunKeepaliveStartS>180</stunKeepaliveStartS>
+        <stunKeepaliveMinS>20</stunKeepaliveMinS>
+        <stunServer>default</stunServer>
+        <maxConcurrentIncomingRequestKiB>0</maxConcurrentIncomingRequestKiB>
+        <announceLANAddresses>false</announceLANAddresses>
+        <sendFullIndexOnUpgrade>false</sendFullIndexOnUpgrade>
+        <auditEnabled>false</auditEnabled>
+        <auditFile></auditFile>
+        <connectionLimitEnough>0</connectionLimitEnough>
+        <connectionLimitMax>0</connectionLimitMax>
+        <connectionPriorityTcpLan>10</connectionPriorityTcpLan>
+        <connectionPriorityQuicLan>20</connectionPriorityQuicLan>
+        <connectionPriorityTcpWan>30</connectionPriorityTcpWan>
+        <connectionPriorityQuicWan>40</connectionPriorityQuicWan>
+        <connectionPriorityRelay>50</connectionPriorityRelay>
+        <connectionPriorityUpgradeThreshold>0</connectionPriorityUpgradeThreshold>
+    </options>
+    <defaults>
+        <folder id="" label="" path="" type="sendreceive" rescanIntervalS="3600" fsWatcherEnabled="true" fsWatcherDelayS="10" fsWatcherTimeoutS="0" ignorePerms="false" autoNormalize="true">
+            <filesystemType>basic</filesystemType>
+            <device id="{{DEVICE_ID}}" introducedBy="">
+                <encryptionPassword></encryptionPassword>
+            </device>
+            <minDiskFree unit="%">1</minDiskFree>
+            <versioning>
+                <cleanupIntervalS>3600</cleanupIntervalS>
+                <fsPath></fsPath>
+                <fsType>basic</fsType>
+            </versioning>
+            <copiers>0</copiers>
+            <pullerMaxPendingKiB>0</pullerMaxPendingKiB>
+            <hashers>0</hashers>
+            <order>random</order>
+            <ignoreDelete>false</ignoreDelete>
+            <scanProgressIntervalS>0</scanProgressIntervalS>
+            <pullerPauseS>0</pullerPauseS>
+            <pullerDelayS>1</pullerDelayS>
+            <maxConflicts>10</maxConflicts>
+            <disableSparseFiles>false</disableSparseFiles>
+            <paused>false</paused>
+            <markerName>.stfolder</markerName>
+            <copyOwnershipFromParent>false</copyOwnershipFromParent>
+            <modTimeWindowS>0</modTimeWindowS>
+            <maxConcurrentWrites>16</maxConcurrentWrites>
+            <disableFsync>false</disableFsync>
+            <blockPullOrder>standard</blockPullOrder>
+            <copyRangeMethod>standard</copyRangeMethod>
+            <caseSensitiveFS>false</caseSensitiveFS>
+            <junctionsAsDirs>false</junctionsAsDirs>
+            <syncOwnership>false</syncOwnership>
+            <sendOwnership>false</sendOwnership>
+            <syncXattrs>false</syncXattrs>
+            <sendXattrs>false</sendXattrs>
+            <blockIndexing>true</blockIndexing>
+            <xattrFilter>
+                <maxSingleEntrySize>1024</maxSingleEntrySize>
+                <maxTotalSize>4096</maxTotalSize>
+            </xattrFilter>
+        </folder>
+        <device id="" compression="metadata" introducer="false" skipIntroductionRemovals="false" introducedBy="">
+            <address>dynamic</address>
+            <paused>false</paused>
+            <autoAcceptFolders>false</autoAcceptFolders>
+            <maxSendKbps>0</maxSendKbps>
+            <maxRecvKbps>0</maxRecvKbps>
+            <maxRequestKiB>0</maxRequestKiB>
+            <untrusted>false</untrusted>
+            <remoteGUIPort>0</remoteGUIPort>
+            <numConnections>0</numConnections>
+        </device>
+        <ignores></ignores>
+    </defaults>
+</configuration>
+`
+
+func renderSyncthingConfig(
+	deviceID, deviceName, apiKey, passwordHash string,
+) string {
+	return strings.NewReplacer(
+		"{{DEVICE_ID}}", deviceID,
+		"{{DEVICE_NAME}}", deviceName,
+		"{{API_KEY}}", apiKey,
+		"{{PASSWORD_HASH}}", passwordHash,
+	).Replace(syncthingConfigTemplate)
+}

--- a/internal/installer/verify.go
+++ b/internal/installer/verify.go
@@ -11,10 +11,12 @@
 // primary fingerprint). Any [GNUPG:] BADSIG line is a hard stop. The
 // GPG exit code is never trusted.
 //
-// Three callers use verifyIsolated:
+// Four callers use verifyIsolated:
 //   - verifySelfUpdate:      threshold 1 vs the rlvpn release key
 //   - verifyBitcoinCoreSigs: threshold 2 distinct builder fingerprints
 //   - verifyLNDSig:          threshold 1 vs roasbeef's fingerprint
+//   - verifySyncthingSig:    threshold 1 vs the Syncthing release key
+//                            (CLEARSIGNED — dataFile == "")
 
 package installer
 
@@ -97,6 +99,33 @@ var lndSigner = struct {
 	keyURL:      "https://raw.githubusercontent.com/lightningnetwork/lnd/master/scripts/keys/roasbeef.asc",
 }
 
+// syncthingSigner is the trusted Syncthing release signer.
+// Source: https://syncthing.net/release-key.txt, linked from
+// https://syncthing.net/security/ ("Release Signatures").
+// Cross-checked June 9 2026 against an independent temporal
+// channel: the apt keyring on a months-old production install
+// (/etc/apt/keyrings/syncthing-archive-keyring.gpg) holds the
+// identical primary fingerprint. Empirically bound: the v2.1.1
+// sha256sum.txt.asc VALIDSIG primary fingerprint (last field)
+// matches this pin on a live verification.
+//
+// NOTE: Syncthing dual-signs releases during key rotation — the
+// v2.1.1 checksum file carries a second signature from the
+// pre-rotation key (ends D26E6ED000654A3E), which our keyring
+// cannot check (ERRSIG/NO_PUBKEY) and which makes gpg exit
+// non-zero even on a genuine release. This is why exit-code
+// trust is unusable here and VALIDSIG parsing is the sole
+// source of truth (the v0.6.1 finding A/B design).
+var syncthingSigner = struct {
+	name        string
+	fingerprint string
+	keyURL      string
+}{
+	name:        "Syncthing Release Management",
+	fingerprint: "FBA2E162F2F44657B38F0309E5665F9BD5970C47",
+	keyURL:      "https://syncthing.net/release-key.txt",
+}
+
 // ── GPG setup ────────────────────────────────────────────
 
 func ensureGPG() error {
@@ -117,7 +146,14 @@ func ensureGPG() error {
 // (distinct signers). Any BADSIG line sets badSig = true.
 //
 // The GPG exit code is intentionally ignored — the VALIDSIG and
-// BADSIG parsing is the sole source of truth.
+// BADSIG parsing is the sole source of truth. (Empirically
+// necessary: Syncthing's dual-signed v2.1.1 release makes gpg
+// exit non-zero on a genuine artifact — see syncthingSigner.)
+//
+// dataFile == "" means sigFile is CLEARSIGNED (data and
+// signature in one file, e.g. Syncthing's sha256sum.txt.asc);
+// gpg is invoked with the single file argument. Otherwise the
+// signature is detached and gpg gets both arguments.
 func verifyIsolated(
 	keyFiles []string,
 	sigFile, dataFile string,
@@ -143,9 +179,13 @@ func verifyIsolated(
 	}
 
 	// Verify — exit code intentionally discarded.
-	output, _ := system.RunCombinedOutput(
-		"gpg", "--homedir", gpgHome, "--batch", "--verify",
-		"--status-fd", "1", sigFile, dataFile)
+	// Clearsigned input (dataFile == "") takes one file argument.
+	args := []string{"--homedir", gpgHome, "--batch",
+		"--verify", "--status-fd", "1", sigFile}
+	if dataFile != "" {
+		args = append(args, dataFile)
+	}
+	output, _ := system.RunCombinedOutput("gpg", args...)
 
 	// Parse status output.
 	seen := make(map[string]bool)
@@ -263,6 +303,24 @@ func verifyBitcoinCoreSigs(workDir string, minValid int) error {
 	return nil
 }
 
+func verifyBitcoin(workDir string) error {
+	logger.Verify("--- Bitcoin Core checksum verification ---")
+	// exec.Command used directly because sha256sum --check needs
+	// working directory set to where the tarball was downloaded.
+	cmd := exec.Command("sha256sum",
+		"--ignore-missing", "--check", "SHA256SUMS")
+	cmd.Dir = workDir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		logger.Verify("FAIL: Bitcoin Core checksum: %s",
+			string(output))
+		return fmt.Errorf("checksum failed: %w: %s", err, output)
+	}
+	logger.Verify("OK Bitcoin Core checksum: %s",
+		strings.TrimSpace(string(output)))
+	return nil
+}
+
 // ── LND verification ────────────────────────────────────
 
 func verifyLNDSig(workDir string, version string) error {
@@ -318,6 +376,104 @@ func verifyLNDSig(workDir string, version string) error {
 
 	logger.Verify(
 		"OK LND: signature valid (roasbeef, pinned fingerprint)")
+	return nil
+}
+
+func verifyLND(workDir string) error {
+	logger.Verify("--- LND checksum verification ---")
+	manifestFile := filepath.Join(workDir, "manifest.txt")
+	if _, err := os.Stat(manifestFile); err != nil {
+		logger.Verify("FAIL: LND manifest not found")
+		return fmt.Errorf("LND manifest not found")
+	}
+	// exec.Command used directly because sha256sum --check needs
+	// working directory set to where the tarball was downloaded.
+	cmd := exec.Command("sha256sum",
+		"--ignore-missing", "--check", "manifest.txt")
+	cmd.Dir = workDir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		logger.Verify("FAIL: LND checksum: %s",
+			string(output))
+		return fmt.Errorf("checksum failed: %w: %s", err, output)
+	}
+	logger.Verify("OK LND checksum: %s",
+		strings.TrimSpace(string(output)))
+	return nil
+}
+
+// ── Syncthing verification ──────────────────────────────
+
+// verifySyncthingSig verifies the CLEARSIGNED checksum file
+// (sha256sum.txt.asc) against the pinned release fingerprint.
+// Unlike Bitcoin Core and LND (detached signatures: signature
+// and data in separate files), Syncthing ships the checksum
+// list and its signature in ONE file. Must run BEFORE
+// verifySyncthingChecksum — the checksums inside the file are
+// untrusted until the signature over them validates.
+func verifySyncthingSig(workDir string) error {
+	logger.Verify("--- Syncthing signature verification ---")
+
+	ascFile := filepath.Join(workDir, "sha256sum.txt.asc")
+	if _, err := os.Stat(ascFile); err != nil {
+		logger.Verify("FAIL: sha256sum.txt.asc not found")
+		return fmt.Errorf("sha256sum.txt.asc not found")
+	}
+
+	keyFile := filepath.Join(workDir, "syncthing-release-key.txt")
+	if err := system.DownloadRequireTor(
+		syncthingSigner.keyURL, keyFile); err != nil {
+		logger.Verify("FAIL: download Syncthing signing key: %v", err)
+		return fmt.Errorf("download Syncthing signing key: %w", err)
+	}
+
+	pinnedFPs := map[string]bool{syncthingSigner.fingerprint: true}
+
+	// dataFile "" → clearsigned, single-argument verify.
+	distinct, hasBadSig, err := verifyIsolated(
+		[]string{keyFile}, ascFile, "", pinnedFPs)
+	if err != nil {
+		return fmt.Errorf(
+			"Syncthing signature verification failed: %w", err)
+	}
+
+	if hasBadSig {
+		logger.Verify("FAIL: bad Syncthing signature detected")
+		return fmt.Errorf(
+			"bad Syncthing signature detected — verification aborted")
+	}
+
+	if distinct < 1 {
+		logger.Verify(
+			"FAIL: Syncthing signature not valid against pinned fingerprint")
+		return fmt.Errorf("Syncthing signature verification failed")
+	}
+
+	logger.Verify(
+		"OK Syncthing: signature valid (release key, pinned fingerprint)")
+	return nil
+}
+
+// verifySyncthingChecksum checks the tarball against the
+// now-trusted clearsigned checksum file. Same sha256sum
+// pattern as verifyBitcoin/verifyLND — the only difference is
+// that the checksum source is the clearsigned .asc itself:
+// sha256sum skips the PGP armor lines (reported as "improperly
+// formatted" warnings) and matches the real checksum lines.
+func verifySyncthingChecksum(workDir string) error {
+	logger.Verify("--- Syncthing checksum verification ---")
+	// exec.Command used directly because sha256sum --check needs
+	// working directory set to where the tarball was downloaded.
+	cmd := exec.Command("sha256sum",
+		"--ignore-missing", "--check", "sha256sum.txt.asc")
+	cmd.Dir = workDir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		logger.Verify("FAIL: Syncthing checksum: %s", string(output))
+		return fmt.Errorf("checksum failed: %w: %s", err, output)
+	}
+	logger.Verify("OK Syncthing checksum: %s",
+		strings.TrimSpace(string(output)))
 	return nil
 }
 
@@ -377,48 +533,5 @@ func verifySelfUpdate(workDir string) error {
 
 	logger.Verify("OK self-update: signature valid " +
 		"(release key, pinned fingerprint)")
-	return nil
-}
-
-// ── Checksum verification ───────────────────────────────
-
-func verifyBitcoin(workDir string) error {
-	logger.Verify("--- Bitcoin Core checksum verification ---")
-	// exec.Command used directly because sha256sum --check needs
-	// working directory set to where the tarball was downloaded.
-	cmd := exec.Command("sha256sum",
-		"--ignore-missing", "--check", "SHA256SUMS")
-	cmd.Dir = workDir
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		logger.Verify("FAIL: Bitcoin Core checksum: %s",
-			string(output))
-		return fmt.Errorf("checksum failed: %w: %s", err, output)
-	}
-	logger.Verify("OK Bitcoin Core checksum: %s",
-		strings.TrimSpace(string(output)))
-	return nil
-}
-
-func verifyLND(workDir string) error {
-	logger.Verify("--- LND checksum verification ---")
-	manifestFile := filepath.Join(workDir, "manifest.txt")
-	if _, err := os.Stat(manifestFile); err != nil {
-		logger.Verify("FAIL: LND manifest not found")
-		return fmt.Errorf("LND manifest not found")
-	}
-	// exec.Command used directly because sha256sum --check needs
-	// working directory set to where the tarball was downloaded.
-	cmd := exec.Command("sha256sum",
-		"--ignore-missing", "--check", "manifest.txt")
-	cmd.Dir = workDir
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		logger.Verify("FAIL: LND checksum: %s",
-			string(output))
-		return fmt.Errorf("checksum failed: %w: %s", err, output)
-	}
-	logger.Verify("OK LND checksum: %s",
-		strings.TrimSpace(string(output)))
 	return nil
 }

--- a/internal/installer/verify_test.go
+++ b/internal/installer/verify_test.go
@@ -140,6 +140,29 @@ func testSign(
 	}
 }
 
+// testClearsign creates a CLEARSIGNED file from dataFile using
+// the key identified by fingerprint — data and signature in one
+// file, the format Syncthing uses for sha256sum.txt.asc.
+func testClearsign(
+	t *testing.T, gpgHome, fingerprint,
+	dataFile, outFile string,
+) {
+	t.Helper()
+
+	output, err := exec.Command(
+		"gpg", "--homedir", gpgHome,
+		"--batch", "--armor",
+		"--local-user", fingerprint,
+		"--clearsign",
+		"--output", outFile,
+		dataFile,
+	).CombinedOutput()
+	if err != nil {
+		t.Fatalf("clearsign with %s: %v\n%s",
+			fingerprint, err, output)
+	}
+}
+
 // ── Hermetic test suite ─────────────────────────────────
 
 func TestVerifyIsolated(t *testing.T) {
@@ -335,6 +358,123 @@ func TestVerifyIsolated(t *testing.T) {
 	})
 }
 
+// ── Clearsign test suite (Syncthing path) ───────────────
+//
+// verifyIsolated with dataFile == "" verifies a CLEARSIGNED
+// file (the format of Syncthing's sha256sum.txt.asc). These
+// cases are the automated mirror of the live verification
+// session of June 9 2026: a genuine v2.1.1 file produced
+// VALIDSIG with the pinned primary fingerprint as the LAST
+// field, and tampering with the checksum text inside the
+// armor produced BADSIG with no VALIDSIG.
+
+func TestVerifyIsolatedClearsign(t *testing.T) {
+	if !gpgAvailable() {
+		t.Skip("gpg not available — skipping")
+	}
+
+	genHome, err := os.MkdirTemp("", "rlvpn-test-gen-")
+	if err != nil {
+		t.Fatalf("create gen home: %v", err)
+	}
+	defer os.RemoveAll(genHome)
+
+	fpAlpha := testGenKey(t, genHome, "ClearAlpha", false)
+	fpBeta := testGenKey(t, genHome, "ClearBeta", false)
+
+	dataDir, err := os.MkdirTemp("", "rlvpn-test-data-")
+	if err != nil {
+		t.Fatalf("create data dir: %v", err)
+	}
+	defer os.RemoveAll(dataDir)
+
+	// Checksum-list-shaped content, like sha256sum.txt.asc.
+	dataFile := filepath.Join(dataDir, "sums.txt")
+	if err := os.WriteFile(dataFile, []byte(
+		"0123456789abcdef  syncthing-linux-amd64-v9.9.9.tar.gz\n"),
+		0600); err != nil {
+		t.Fatalf("write test data: %v", err)
+	}
+
+	keyAlpha := filepath.Join(dataDir, "alpha.asc")
+	keyBeta := filepath.Join(dataDir, "beta.asc")
+	testExportKey(t, genHome, fpAlpha, keyAlpha)
+	testExportKey(t, genHome, fpBeta, keyBeta)
+
+	clearAlpha := filepath.Join(dataDir, "sums-clear.asc")
+	testClearsign(t, genHome, fpAlpha, dataFile, clearAlpha)
+
+	// Tampered variant: modify the checksum text INSIDE the
+	// clearsigned armor (the exact shape of the live June 9
+	// negative test, which renamed the asset inside the file).
+	clearBytes, err := os.ReadFile(clearAlpha)
+	if err != nil {
+		t.Fatalf("read clearsigned file: %v", err)
+	}
+	tampered := strings.Replace(string(clearBytes),
+		"syncthing-linux-amd64", "syncthing-linux-tampered", 1)
+	if tampered == string(clearBytes) {
+		t.Fatal("tamper replacement did not apply")
+	}
+	tamperedFile := filepath.Join(dataDir, "sums-tampered.asc")
+	if err := os.WriteFile(tamperedFile,
+		[]byte(tampered), 0600); err != nil {
+		t.Fatalf("write tampered clearsign: %v", err)
+	}
+
+	// ── Case 1: Clearsigned by pinned key → accept ─────
+	t.Run("clearsign_pinned_key_accepts", func(t *testing.T) {
+		pinned := map[string]bool{fpAlpha: true}
+		distinct, bad, err := verifyIsolated(
+			[]string{keyAlpha}, clearAlpha, "", pinned)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if bad {
+			t.Fatal("unexpected BADSIG")
+		}
+		if distinct != 1 {
+			t.Fatalf("distinct = %d, want 1", distinct)
+		}
+	})
+
+	// ── Case 2: Tampered inside the armor → BADSIG ─────
+	t.Run("clearsign_tampered_badsig", func(t *testing.T) {
+		pinned := map[string]bool{fpAlpha: true}
+		distinct, bad, err := verifyIsolated(
+			[]string{keyAlpha}, tamperedFile, "", pinned)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !bad {
+			t.Fatal("expected BADSIG for tampered clearsign")
+		}
+		if distinct != 0 {
+			t.Fatalf("distinct = %d, want 0 "+
+				"(tampered content must not count)", distinct)
+		}
+	})
+
+	// ── Case 3: Clearsigned by UNPINNED key → reject ───
+	t.Run("clearsign_unpinned_key_rejects", func(t *testing.T) {
+		// Alpha clearsigned, but only Beta is pinned.
+		pinned := map[string]bool{fpBeta: true}
+		distinct, bad, err := verifyIsolated(
+			[]string{keyAlpha}, clearAlpha, "", pinned)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if bad {
+			t.Fatal("unexpected BADSIG")
+		}
+		if distinct != 0 {
+			t.Fatalf("distinct = %d, want 0 "+
+				"(signature valid but not from pinned key)",
+				distinct)
+		}
+	})
+}
+
 // ── Anchor validation ───────────────────────────────────
 
 func TestSignerFingerprints(t *testing.T) {
@@ -362,6 +502,14 @@ func TestSignerFingerprints(t *testing.T) {
 	}
 	if lndSigner.keyURL == "" {
 		t.Error("LND signer has empty keyURL")
+	}
+
+	if len(syncthingSigner.fingerprint) != 40 {
+		t.Errorf("Syncthing signer fingerprint length %d, want 40",
+			len(syncthingSigner.fingerprint))
+	}
+	if syncthingSigner.keyURL == "" {
+		t.Error("Syncthing signer has empty keyURL")
 	}
 }
 

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -93,11 +93,15 @@ const (
 	// declares PasswordAuthentication yes on cloud
 	// images). sshd's first-match-wins semantics mean
 	// loading first = winning.
-	SSHDDropIn          = "/etc/ssh/sshd_config.d/00-rlvpn-hardening.conf"
-	Fail2banJail        = "/etc/fail2ban/jail.local"
-	AutoUpgrades        = "/etc/apt/apt.conf.d/20auto-upgrades"
-	UnattendedUpgrades  = "/etc/apt/apt.conf.d/50unattended-upgrades"
-	DisableIPv6Conf     = "/etc/sysctl.d/99-disable-ipv6.conf"
+	SSHDDropIn         = "/etc/ssh/sshd_config.d/00-rlvpn-hardening.conf"
+	Fail2banJail       = "/etc/fail2ban/jail.local"
+	AutoUpgrades       = "/etc/apt/apt.conf.d/20auto-upgrades"
+	UnattendedUpgrades = "/etc/apt/apt.conf.d/50unattended-upgrades"
+	DisableIPv6Conf    = "/etc/sysctl.d/99-disable-ipv6.conf"
+	// LEGACY apt-install artifacts (pre v0.6.3 pinning). No longer
+	// written by the installer; retained ONLY so the migration
+	// for existing apt-based deployments can remove them. Delete
+	// these constants when that migration ships.
 	SyncthingKeyring    = "/etc/apt/keyrings/syncthing-archive-keyring.gpg"
 	SyncthingSourceList = "/etc/apt/sources.list.d/syncthing.list"
 )

--- a/internal/welcome/screen_addon_syncthing_install.go
+++ b/internal/welcome/screen_addon_syncthing_install.go
@@ -177,7 +177,7 @@ func (s *SyncthingInstallScreen) View(
 	p.line(" " + theme.Value.Render("This will:"))
 	p.blank()
 	p.line(" " + theme.Value.Render(
-		"  * Install Syncthing from official repository"))
+		"  * Install verified Syncthing release binary"))
 	p.line(" " + theme.Value.Render(
 		"  * Open port 22000 for sync connections"))
 	p.line(" " + theme.Value.Render(


### PR DESCRIPTION
Syncthing installs left global/local discovery, relays, and NAT traversal enabled despite the config code setting them off: the provisioning round-tripped the generated config through Go structs with xml ",innerxml" tags, emitting duplicate config blocks that the daemon resolved back to the defaults. Nodes announced their device ID and public IP to public discovery and relay servers, and ran a second default listener carrying QUIC and relay transports. Reproduced live before fixing; verified fixed on a fresh install (single listener, zero discovery/relay/STUN traffic across packet capture, socket sampling, daemon logs, and the running daemon's reported configuration).

Editing a config whose schema we didn't control was the root problem: Syncthing floated on apt and migrated its own config across upgrades. So Syncthing is now pinned like Bitcoin Core and LND: a specific release binary (v2.1.1) downloaded over Tor from the Syncthing project repo, verified against the pinned release signing key, with the apt source removed entirely and the binary's self-update switched off (downloadSyncthing, verifySyncthingSig, verifySyncthingChecksum, extractAndInstallSyncthing). With the version fixed, the installer writes the complete Syncthing configuration itself before the program ever starts, then verifies every privacy setting and refuses to start (and disables) Syncthing if anything looks wrong (configureSyncthingAuth, verifySyncthingConfig, confirmSyncthingPrivacy, stopSyncthingFailSafe). A deliberately sabotaged build was used to confirm the install fails loudly rather than starting an unverified daemon.

Also fixed: pairing a backup device quietly switched the backup folder from "send only" to "send and receive", letting a paired device change or delete the node's copy of the channel backup. LND's own files were never at risk: the node copies the channel backup out of LND's data directory into the synced folder, and nothing copies back. Folder updates now preserve the folder type, and paired devices no longer get permission to auto-share folders to the node (addDeviceToBackupFolder, PairSyncthingDevice). The install step that waited 30 seconds for Syncthing probed an endpoint that always refused it; it now probes the daemon's health endpoint, which reports liveness only, and completes in about a second (startSyncthing).

Tests: 3 new clearsign verification cases (accept pinned, reject tampered, reject unpinned); full e2e on two fresh Debian 13 VPS installs covering packet capture egress watch, forced gate-failure with the shipped tripwire wording observed firing, restart and reboot persistence, device pairing, external port scan, and firewall idempotency. The second run watched the daemon's literal first-ever start live, with packet capture running before the install was triggered: only the two intended sockets, zero UDP, zero outbound connections attributable to Syncthing. Rebuilding the same source twice produced a byte-identical binary.