### PR TITLE
fix: install now verifies Tor is working before downloading anything

### DIFF
--- a/internal/installer/setup.go
+++ b/internal/installer/setup.go
@@ -250,11 +250,12 @@ func buildSteps(cfg *config.AppConfig) []InstallStep {
 				if err := addUserToTorGroup(systemUser); err != nil {
 					return err
 				}
-				if err := restartTor(); err != nil {
-					return err
-				}
-				return logTorStatus()
+				return restartTor()
 			}},
+		// HARD GATE (IA-2-K): no Tor-dependent network step below —
+		// apt over the socks5h proxy, every DownloadRequireTor —
+		// runs unless Tor routing is verified. See torgate.go.
+		{Name: "Verifying Tor routing", Fn: verifyTorRouting},
 		{Name: "Configuring apt for Tor",
 			Fn: func() error {
 				if err := configureAptTor(); err != nil {

--- a/internal/installer/system.go
+++ b/internal/installer/system.go
@@ -5,14 +5,11 @@ package installer
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"os/user"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/ripsline/virtual-private-node/internal/config"
-	"github.com/ripsline/virtual-private-node/internal/logger"
 	"github.com/ripsline/virtual-private-node/internal/paths"
 	"github.com/ripsline/virtual-private-node/internal/system"
 )
@@ -194,35 +191,8 @@ bantime = 600
 	return system.SudoRun("systemctl", "restart", "fail2ban")
 }
 
-// logTorStatus verifies torsocks is available and Tor is routing
-// traffic correctly. Logs the result for post-install audit.
-// Returns nil even on failure — this is informational, not blocking.
-func logTorStatus() error {
-	if _, err := exec.LookPath("torsocks"); err != nil {
-		logger.Install("WARNING: torsocks not found — downloads may use clearnet")
-		return nil
-	}
-	logger.Install("torsocks available — downloads will route through Tor")
-
-	confirmed := false
-	for attempt := 0; attempt < 3; attempt++ {
-		output, err := system.RunContext(15*time.Second,
-			"torsocks", "curl", "-s", "--max-time", "10",
-			"https://check.torproject.org/api/ip")
-		if err == nil && strings.Contains(output, `"IsTor":true`) {
-			logger.Install("Tor routing CONFIRMED via check.torproject.org")
-			confirmed = true
-			break
-		}
-		if attempt < 2 {
-			time.Sleep(3 * time.Second)
-		}
-	}
-	if !confirmed {
-		logger.Install("WARNING: Tor routing check timed out after 3 attempts — verify with: torsocks curl -s https://check.torproject.org/api/ip")
-	}
-	return nil
-}
+// The Tor routing check formerly here (logTorStatus, warn-only) is
+// superseded by the hard-gate install step in torgate.go (IA-2-K).
 
 // configureAptTor sets up apt to route all package downloads through
 // Tor's SOCKS proxy. This ensures apt-get install/upgrade commands

--- a/internal/installer/tor.go
+++ b/internal/installer/tor.go
@@ -26,12 +26,14 @@ func BuildTorConfig(cfg *config.AppConfig) string {
 	b.WriteString("# Virtual Private Node — Tor Configuration\n")
 	b.WriteString("SOCKSPort 9050\n")
 
-	if cfg.HasLND() {
-		b.WriteString("\n# Control port for LND P2P onion management\n")
-		b.WriteString("ControlPort 9051\n")
-		b.WriteString("CookieAuthentication 1\n")
-		b.WriteString("CookieAuthFileGroupReadable 1\n")
-	}
+	// Control port: always emitted. Two consumers — the install-path
+	// Tor routing gate (torgate.go reads bootstrap progress here,
+	// unconditionally) and LND's P2P onion management. Loopback-only,
+	// cookie-authenticated; emitting it without LND adds no exposure.
+	b.WriteString("\n# Control port (install routing gate + LND onion management)\n")
+	b.WriteString("ControlPort 9051\n")
+	b.WriteString("CookieAuthentication 1\n")
+	b.WriteString("CookieAuthFileGroupReadable 1\n")
 
 	b.WriteString(fmt.Sprintf(`
 # Bitcoin Core P2P (static onion address for peers)

--- a/internal/installer/tor_test.go
+++ b/internal/installer/tor_test.go
@@ -25,7 +25,9 @@ func TestTorConfigBitcoinOnly(t *testing.T) {
 	}
 
 	forbidden := []string{
-		"ControlPort",
+		// ControlPort is deliberately NOT forbidden here: it is
+		// unconditional since the install routing gate consumes it
+		// (see TestTorConfigControlPortAlways).
 		"bitcoin-rpc",
 		"lnd-rest",
 		"lnd-grpc",
@@ -145,11 +147,17 @@ func TestTorConfigTestnet4Ports(t *testing.T) {
 	}
 }
 
-func TestTorConfigNoControlPortWithoutLND(t *testing.T) {
+func TestTorConfigControlPortAlways(t *testing.T) {
+	// The install-path routing gate (torgate.go) reads bootstrap
+	// progress from the control port unconditionally, so every
+	// generated torrc must include it — LND or not.
 	cfg := config.Default()
 	content := BuildTorConfig(cfg)
 
-	if strings.Contains(content, "ControlPort") {
-		t.Error("should not have ControlPort without LND")
+	if !strings.Contains(content, "ControlPort 9051") {
+		t.Error("ControlPort must be present in every config (install gate depends on it)")
+	}
+	if !strings.Contains(content, "CookieAuthentication 1") {
+		t.Error("control port must require cookie auth")
 	}
 }

--- a/internal/installer/torgate.go
+++ b/internal/installer/torgate.go
@@ -1,0 +1,251 @@
+// internal/installer/torgate.go
+//
+// Install-path Tor hard-gate (IA-2-K). Runs as its own install step
+// between "Installing Tor" and "Configuring apt for Tor", so it must
+// succeed before ANY Tor-dependent network operation: apt over the
+// socks5h proxy (ensureGPG onward) and every DownloadRequireTor site.
+//
+// Two layers:
+//
+//  1. HARD GATE — no external dependency. Wait for Tor to report
+//     bootstrap PROGRESS=100 on its own control port (127.0.0.1:9051,
+//     cookie auth). Local, deterministic; the install step fails on
+//     timeout. This is the postcondition for restartTor: rc=0 means
+//     "the unit started", PROGRESS=100 means "Tor is routing".
+//
+//  2. TRIPWIRE — best-effort external probe. torsocks-fetch
+//     check.torproject.org/api/ip:
+//       IsTor:true   -> routing confirmed end-to-end; proceed.
+//       IsTor:false  -> PROVEN clearnet exit (torsocks present but not
+//                       intercepting, e.g. broken LD_PRELOAD lib) ->
+//                       hard fail. This is the only detector for a
+//                       fail-open torsocks; presence checks cannot
+//                       see it.
+//       unreachable  -> warn and proceed. Bootstrap is already
+//                       confirmed locally, and torsocks fail-closed
+//                       behavior ([LIVE], Gate 0) backstops the leak
+//                       half. Install success never depends on the
+//                       third-party endpoint being up.
+
+package installer
+
+import (
+	"bufio"
+	"encoding/hex"
+	"fmt"
+	"net"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/ripsline/virtual-private-node/internal/logger"
+	"github.com/ripsline/virtual-private-node/internal/system"
+)
+
+// Tor runtime constants. These are Tor-owned values, not Go logic
+// paths (same rationale as the HiddenServiceDir strings in tor.go):
+// the control port matches the generated torrc (BuildTorConfig — note
+// the ControlPort stanza is currently inside the HasLND() branch;
+// Run() forces LNDInstalled=true before buildSteps, so it is always
+// present on the install path), and the cookie path is Debian's
+// packaged tor.service runtime layout.
+const (
+	torControlAddr = "127.0.0.1:9051"
+	torCookiePath  = "/run/tor/control.authcookie"
+
+	torBootstrapTimeout = 90 * time.Second
+	torBootstrapPoll    = 3 * time.Second
+
+	torProbeURL      = "https://check.torproject.org/api/ip"
+	torProbeAttempts = 2
+)
+
+// verifyTorRouting is the "Verifying Tor routing" install step.
+func verifyTorRouting() error {
+	if _, err := exec.LookPath("torsocks"); err != nil {
+		return fmt.Errorf("torsocks not found — refusing to proceed: " +
+			"all downloads must route through Tor")
+	}
+
+	if err := waitForTorBootstrap(torBootstrapTimeout); err != nil {
+		return err
+	}
+	logger.Install("Tor bootstrap 100%% CONFIRMED (via control port)")
+
+	return runTorExitProbe()
+}
+
+// waitForTorBootstrap polls Tor's control port until it reports
+// bootstrap PROGRESS=100 or the deadline passes. Poll errors are
+// retried silently until the deadline — immediately after restartTor
+// the control port may not be listening yet.
+func waitForTorBootstrap(timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	lastProgress := -1
+	var lastErr error
+
+	for {
+		progress, err := queryTorBootstrapProgress()
+		if err == nil {
+			if progress >= 100 {
+				return nil
+			}
+			if progress != lastProgress {
+				logger.Install("Tor bootstrapping: %d%%", progress)
+				lastProgress = progress
+			}
+		} else {
+			lastErr = err
+		}
+
+		if time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(torBootstrapPoll)
+	}
+
+	detail := fmt.Sprintf("last progress %d%%", lastProgress)
+	if lastProgress < 0 && lastErr != nil {
+		detail = fmt.Sprintf("control port never answered: %v "+
+			"(is ControlPort 9051 enabled in torrc?)", lastErr)
+	}
+	return fmt.Errorf("Tor did not finish bootstrapping within %s (%s) — "+
+		"check: systemctl status tor; journalctl -u tor",
+		timeout, detail)
+}
+
+// queryTorBootstrapProgress performs one control-port round trip:
+// AUTHENTICATE with the cookie, GETINFO status/bootstrap-phase,
+// parse PROGRESS. The cookie is re-read on every attempt because Tor
+// regenerates it on restart.
+func queryTorBootstrapProgress() (int, error) {
+	// The installer user is not in debian-tor (only systemUser is
+	// added, and group changes need a re-login anyway), so read the
+	// 0640 cookie via the sudo path. Under the commit-6 root install
+	// this still works unchanged.
+	cookie, err := system.SudoReadFile(torCookiePath)
+	if err != nil {
+		return 0, fmt.Errorf("read control cookie: %w", err)
+	}
+
+	conn, err := net.DialTimeout("tcp", torControlAddr, 5*time.Second)
+	if err != nil {
+		return 0, fmt.Errorf("dial control port: %w", err)
+	}
+	defer conn.Close()
+	conn.SetDeadline(time.Now().Add(5 * time.Second))
+
+	r := bufio.NewReader(conn)
+
+	fmt.Fprintf(conn, "AUTHENTICATE %s\r\n", hex.EncodeToString(cookie))
+	line, err := r.ReadString('\n')
+	if err != nil {
+		return 0, fmt.Errorf("read auth reply: %w", err)
+	}
+	if !strings.HasPrefix(line, "250") {
+		return 0, fmt.Errorf("control auth refused: %s",
+			strings.TrimSpace(line))
+	}
+
+	fmt.Fprintf(conn, "GETINFO status/bootstrap-phase\r\n")
+	progress := -1
+	for {
+		line, err := r.ReadString('\n')
+		if err != nil {
+			return 0, fmt.Errorf("read GETINFO reply: %w", err)
+		}
+		if p, ok := parseBootstrapProgress(line); ok {
+			progress = p
+		}
+		if strings.HasPrefix(line, "250 ") ||
+			strings.HasPrefix(line, "5") {
+			break
+		}
+	}
+	fmt.Fprintf(conn, "QUIT\r\n")
+
+	if progress < 0 {
+		return 0, fmt.Errorf("no PROGRESS field in bootstrap-phase reply")
+	}
+	return progress, nil
+}
+
+// parseBootstrapProgress extracts the PROGRESS=<n> value from a
+// control-port status line, e.g.:
+//
+//	250-status/bootstrap-phase=NOTICE BOOTSTRAP PROGRESS=100 TAG=done SUMMARY="Done"
+//
+// Pure function — unit-tested.
+func parseBootstrapProgress(line string) (int, bool) {
+	const key = "PROGRESS="
+	i := strings.Index(line, key)
+	if i < 0 {
+		return 0, false
+	}
+	rest := line[i+len(key):]
+	end := 0
+	for end < len(rest) && rest[end] >= '0' && rest[end] <= '9' {
+		end++
+	}
+	if end == 0 {
+		return 0, false
+	}
+	n, err := strconv.Atoi(rest[:end])
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
+// torProbeVerdict classifies one tripwire probe result. Pure
+// function — unit-tested.
+type torProbeResult int
+
+const (
+	probeTor         torProbeResult = iota // IsTor:true — confirmed
+	probeClearnet                          // IsTor:false — PROVEN leak
+	probeUnreachable                       // error / garbage — unknown
+)
+
+func torProbeVerdict(output string, err error) torProbeResult {
+	if err != nil {
+		return probeUnreachable
+	}
+	if strings.Contains(output, `"IsTor":true`) {
+		return probeTor
+	}
+	if strings.Contains(output, `"IsTor":false`) {
+		return probeClearnet
+	}
+	return probeUnreachable
+}
+
+// runTorExitProbe runs the best-effort external tripwire. Only a
+// proven clearnet exit (IsTor:false) fails the step; an unreachable
+// endpoint warns and proceeds.
+func runTorExitProbe() error {
+	for attempt := 0; attempt < torProbeAttempts; attempt++ {
+		output, err := system.RunContext(15*time.Second,
+			"torsocks", "curl", "-s", "--max-time", "10",
+			torProbeURL)
+		switch torProbeVerdict(output, err) {
+		case probeTor:
+			logger.Install(
+				"Tor routing CONFIRMED via check.torproject.org")
+			return nil
+		case probeClearnet:
+			return fmt.Errorf("CLEARNET LEAK DETECTED: request via " +
+				"torsocks exited on clearnet (IsTor:false) — torsocks " +
+				"is present but not intercepting; refusing to proceed")
+		case probeUnreachable:
+			if attempt < torProbeAttempts-1 {
+				time.Sleep(5 * time.Second)
+			}
+		}
+	}
+	logger.Install("WARNING: Tor exit probe unreachable — proceeding on " +
+		"local bootstrap confirmation (torsocks fail-closed backstops); " +
+		"verify later with: torsocks curl -s " + torProbeURL)
+	return nil
+}

--- a/internal/installer/torgate_test.go
+++ b/internal/installer/torgate_test.go
@@ -1,0 +1,65 @@
+// internal/installer/torgate_test.go
+
+package installer
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestParseBootstrapProgress(t *testing.T) {
+	cases := []struct {
+		name string
+		line string
+		want int
+		ok   bool
+	}{
+		{"done",
+			`250-status/bootstrap-phase=NOTICE BOOTSTRAP PROGRESS=100 TAG=done SUMMARY="Done"` + "\r\n",
+			100, true},
+		{"partial",
+			`250-status/bootstrap-phase=NOTICE BOOTSTRAP PROGRESS=14 TAG=handshake SUMMARY="Handshaking with a relay"` + "\r\n",
+			14, true},
+		{"zero",
+			`250-status/bootstrap-phase=NOTICE BOOTSTRAP PROGRESS=0 TAG=starting SUMMARY="Starting"`,
+			0, true},
+		{"no progress field", `250 OK`, 0, false},
+		{"progress no digits", `PROGRESS=x`, 0, false},
+		{"empty", ``, 0, false},
+	}
+	for _, c := range cases {
+		got, ok := parseBootstrapProgress(c.line)
+		if ok != c.ok || got != c.want {
+			t.Errorf("%s: parseBootstrapProgress(%q) = (%d,%v), want (%d,%v)",
+				c.name, c.line, got, ok, c.want, c.ok)
+		}
+	}
+}
+
+func TestTorProbeVerdict(t *testing.T) {
+	cases := []struct {
+		name   string
+		output string
+		err    error
+		want   torProbeResult
+	}{
+		{"tor exit", `{"IsTor":true,"IP":"185.220.101.1"}`, nil, probeTor},
+		{"clearnet exit — the leak case",
+			`{"IsTor":false,"IP":"203.0.113.7"}`, nil, probeClearnet},
+		{"curl error", "", errors.New("exit status 6"), probeUnreachable},
+		// An error must win even if output looks like success —
+		// never confirm routing off a failed command.
+		{"error with tor-looking output",
+			`{"IsTor":true}`, errors.New("exit status 28"),
+			probeUnreachable},
+		{"captive portal / garbage", `<html>login required</html>`,
+			nil, probeUnreachable},
+		{"empty output", ``, nil, probeUnreachable},
+	}
+	for _, c := range cases {
+		if got := torProbeVerdict(c.output, c.err); got != c.want {
+			t.Errorf("%s: torProbeVerdict(%q, %v) = %v, want %v",
+				c.name, c.output, c.err, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Before this change, the installer checked whether Tor was routing traffic but only logged a warning if the check failed. The install continued either way. To be clear: this was not leaking traffic. When Tor is down, torsocks blocks the connection entirely (verified on a live system: with Tor stopped, wrapped requests are refused and nothing falls back to the regular internet). The problem was that a broken Tor surfaced minutes later as a confusing download or apt error, instead of stopping early with a clear reason.

That check is now a real gate: a new install step, Verifying Tor routing, must pass before any download runs.

How the new check works:

1. Ask Tor directly, over its local control socket, whether it has finished connecting to the Tor network. No outside website is involved. If Tor is not ready within 90 seconds, the install stops with a clear error naming the problem.

2. As an extra safety net, make one test request through torsocks to check.torproject.org, a site that reports whether a request arrived through Tor. Two very different results are possible.

   If the site answers that the request did NOT come through Tor, it means torsocks is broken in a way that silently sends traffic over the regular internet, which is the one failure nothing else can detect. The install stops immediately. This has never been observed in practice; the check is insurance.

   If the site cannot be reached at all, that proves nothing by itself, since the site may simply be down. Step 1 already confirmed Tor is fully connected, and when torsocks cannot reach Tor it refuses connections rather than sending them unprotected. So the install logs a warning and continues.

Supporting change: the generated Tor config now always includes the local control socket. It used to be added only when LND was installed, but the new check needs it on every install. The socket is reachable only from the box itself and requires authentication, so this adds no outside exposure.