### PR TITLE
fix: ssh lockout guards check reality instead of trusting callers

### DIFF
--- a/internal/installer/sshd.go
+++ b/internal/installer/sshd.go
@@ -5,6 +5,8 @@ package installer
 import (
 	"errors"
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/ripsline/virtual-private-node/internal/config"
 	"github.com/ripsline/virtual-private-node/internal/paths"
@@ -38,26 +40,23 @@ PasswordAuthentication %s
 `, passwordAuth)
 }
 
-// RebuildSSHHardeningConfig writes the drop-in to disk
-// and restarts sshd. Idempotent.
+// RebuildSSHHardeningConfig writes the drop-in to disk and
+// restarts sshd. Idempotent.
+//
+// Two lockout guards live here, at the write boundary, so
+// every current and future caller inherits them:
+//
+//  1. Policy: refuses to write a config that disables
+//     password authentication while zero SSH keys exist —
+//     that would leave the system with zero auth methods.
+//  2. Syntax: after the new drop-in is swapped in, the
+//     merged sshd configuration is validated (sshd -t)
+//     BEFORE any restart. An invalid config would stop
+//     sshd from starting at all — a total lockout. On
+//     validation failure the previous drop-in content is
+//     restored and sshd keeps running its current config.
 func RebuildSSHHardeningConfig(cfg *config.AppConfig) error {
-	content := BuildSSHHardeningConfig(cfg)
-	if err := system.SudoWriteFile(
-		paths.SSHDDropIn, []byte(content), 0644); err != nil {
-		return fmt.Errorf(
-			"write sshd drop-in: %w", err)
-	}
-	return restartSSHD()
-}
-
-// SetSSHPasswordAuth flips the password-auth flag in cfg
-// and rebuilds the drop-in. Refuses to disable password
-// auth when no SSH keys exist — that would leave the
-// system with zero auth methods.
-func SetSSHPasswordAuth(
-	cfg *config.AppConfig, disabled bool,
-) error {
-	if disabled {
+	if cfg.SSHPasswordAuthDisabled {
 		keys, err := ListAuthorizedKeys()
 		if err != nil {
 			return fmt.Errorf(
@@ -65,13 +64,150 @@ func SetSSHPasswordAuth(
 		}
 		if len(keys) == 0 {
 			return errors.New(
-				"cannot disable password auth with " +
-					"no SSH keys configured — add a key " +
-					"first")
+				"refusing to disable password " +
+					"authentication with no SSH keys " +
+					"configured — add a key first")
 		}
 	}
+
+	// Capture the previous drop-in so an invalid merged
+	// config can be rolled back before any restart. A
+	// missing file is fine (first write); any other read
+	// failure aborts, because proceeding would mean a
+	// validation failure could not be rolled back.
+	prev, prevErr := system.SudoReadFile(paths.SSHDDropIn)
+	prevExists := true
+	if prevErr != nil {
+		if os.IsNotExist(prevErr) ||
+			strings.Contains(prevErr.Error(),
+				"No such file") {
+			prevExists = false
+		} else {
+			return fmt.Errorf(
+				"read current sshd drop-in: %w", prevErr)
+		}
+	}
+
+	content := BuildSSHHardeningConfig(cfg)
+	if err := system.SudoWriteFile(
+		paths.SSHDDropIn, []byte(content), 0644); err != nil {
+		return fmt.Errorf(
+			"write sshd drop-in: %w", err)
+	}
+
+	// Validate the merged config (all of sshd_config plus
+	// every drop-in) before restarting.
+	if out, err := system.SudoRunCombinedOutput(
+		"sshd", "-t"); err != nil {
+		detail := strings.TrimSpace(out)
+		if restoreErr := restorePreviousDropIn(
+			prev, prevExists); restoreErr != nil {
+			return fmt.Errorf(
+				"sshd rejected the new config (%s) and "+
+					"restoring the previous drop-in also "+
+					"failed (%v) — sshd was NOT restarted "+
+					"and keeps running its current config; "+
+					"inspect %s before restarting sshd",
+				detail, restoreErr, paths.SSHDDropIn)
+		}
+		return fmt.Errorf(
+			"sshd rejected the new config, previous "+
+				"drop-in restored, sshd not restarted: %s",
+			detail)
+	}
+
+	return restartSSHD()
+}
+
+// restorePreviousDropIn puts the drop-in back to its
+// pre-rebuild state: the captured content, or absent if the
+// file did not exist before.
+func restorePreviousDropIn(prev []byte, existed bool) error {
+	if !existed {
+		return system.SudoRun("rm", "-f", paths.SSHDDropIn)
+	}
+	return system.SudoWriteFile(
+		paths.SSHDDropIn, prev, 0644)
+}
+
+// SetSSHPasswordAuth flips the password-auth flag in cfg and
+// rebuilds the drop-in. The zero-auth lockout guard lives in
+// RebuildSSHHardeningConfig (the write boundary), so every
+// caller passes through it. On ANY failure the in-memory
+// flag is restored, keeping cfg, disk, and sshd in
+// agreement.
+func SetSSHPasswordAuth(
+	cfg *config.AppConfig, disabled bool,
+) error {
+	prev := cfg.SSHPasswordAuthDisabled
 	cfg.SSHPasswordAuthDisabled = disabled
-	return RebuildSSHHardeningConfig(cfg)
+	if err := RebuildSSHHardeningConfig(cfg); err != nil {
+		cfg.SSHPasswordAuthDisabled = prev
+		return err
+	}
+	return nil
+}
+
+// EffectiveSSHPasswordAuth reports whether sshd's EFFECTIVE
+// configuration permits password authentication for the
+// admin user, by asking sshd itself:
+//
+//	sshd -T -C user=<admin>,host=localhost,addr=127.0.0.1
+//
+// -T prints the fully resolved configuration; -C supplies
+// the simulated connection so Match blocks targeting the
+// admin user or their group are honored. Reading any single
+// file — including our own drop-in — would answer with one
+// file's vote, not the first-match-wins election result
+// across sshd_config and every drop-in (e.g. a provider's
+// 50-cloud-init.conf).
+//
+// -T, not -G: upstream defines -C as the connection spec
+// "for the -T extended test mode", and Debian 13's OpenSSH
+// (10.0p1, frozen for the release's life) rejects -C with
+// -G outright. -G only gained -C support in later OpenSSH.
+// -T also runs config-validity and host-key sanity checks,
+// so it ERRORS on a broken sshd setup — which is aligned:
+// callers refuse on error, and a box with a broken sshd is
+// exactly where the last key must not be removed.
+//
+// The host/addr values are synthetic: a future connection's
+// real source address is unknowable, so a Match rule scoped
+// to source ADDRESSES is evaluated against 127.0.0.1. That
+// residual biases toward over-refusal; user/group-targeted
+// rules (the hardening pattern that occurs in practice)
+// resolve exactly.
+//
+// Callers MUST treat an error as "password auth
+// unavailable" and refuse the risky action — never as
+// unknown-so-proceed.
+func EffectiveSSHPasswordAuth() (bool, error) {
+	out, err := system.SudoRunOutput("sshd", "-T",
+		"-C", "user="+paths.AdminUser+
+			",host=localhost,addr=127.0.0.1")
+	if err != nil {
+		return false, fmt.Errorf(
+			"query effective sshd config: %w", err)
+	}
+	return parsePasswordAuth(out)
+}
+
+// parsePasswordAuth extracts the passwordauthentication
+// value from sshd -T output (one "keyword value" pair per
+// line, keywords normalized to lowercase by sshd). Pure
+// function so it is testable without sshd present.
+func parsePasswordAuth(sshdOutput string) (bool, error) {
+	for _, line := range strings.Split(sshdOutput, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 2 && strings.EqualFold(
+			fields[0], "passwordauthentication") {
+			return strings.EqualFold(
+				fields[1], "yes"), nil
+		}
+	}
+	return false, errors.New(
+		"passwordauthentication not present in " +
+			"sshd -T output")
 }
 
 func restartSSHD() error {

--- a/internal/installer/sshd_test.go
+++ b/internal/installer/sshd_test.go
@@ -1,0 +1,152 @@
+// internal/installer/sshd_test.go
+
+package installer
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ripsline/virtual-private-node/internal/config"
+)
+
+// realistic excerpt of sshd -T output: lowercase keywords,
+// one "keyword value" pair per line, target buried mid-list.
+const sshdTFixture = `port 22
+addressfamily any
+listenaddress [::]:22
+listenaddress 0.0.0.0:22
+usepam yes
+pubkeyauthentication yes
+passwordauthentication no
+kbdinteractiveauthentication no
+permitrootlogin no
+x11forwarding no
+`
+
+func TestParsePasswordAuth(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    bool
+		wantErr bool
+	}{
+		{
+			name:  "realistic -T output, no",
+			input: sshdTFixture,
+			want:  false,
+		},
+		{
+			name: "realistic -T output, yes",
+			input: strings.Replace(sshdTFixture,
+				"passwordauthentication no",
+				"passwordauthentication yes", 1),
+			want: true,
+		},
+		{
+			name:  "single line yes",
+			input: "passwordauthentication yes\n",
+			want:  true,
+		},
+		{
+			name:  "single line no",
+			input: "passwordauthentication no\n",
+			want:  false,
+		},
+		{
+			// sshd normalizes to lowercase; the parser
+			// tolerates case anyway.
+			name:  "mixed case tolerated",
+			input: "PasswordAuthentication Yes\n",
+			want:  true,
+		},
+		{
+			// Unknown value is not "yes" → treated as
+			// disabled (fail-safe direction).
+			name:  "unexpected value treated as no",
+			input: "passwordauthentication maybe\n",
+			want:  false,
+		},
+		{
+			name:    "directive absent errors",
+			input:   "port 22\nusepam yes\n",
+			wantErr: true,
+		},
+		{
+			name:    "empty input errors",
+			input:   "",
+			wantErr: true,
+		},
+		{
+			// Substring must not match: only an exact
+			// two-field keyword line counts.
+			name: "no substring false positive",
+			input: "somepasswordauthentication yes\n" +
+				"passwordauthenticationx yes\n",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parsePasswordAuth(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("want error, got "+
+						"result %v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("got %v, want %v",
+					got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildSSHHardeningConfig(t *testing.T) {
+	cfg := config.Default()
+
+	cfg.SSHPasswordAuthDisabled = false
+	enabled := BuildSSHHardeningConfig(cfg)
+	if !strings.Contains(enabled,
+		"PasswordAuthentication yes\n") {
+		t.Fatalf("enabled config missing "+
+			"'PasswordAuthentication yes':\n%s", enabled)
+	}
+
+	cfg.SSHPasswordAuthDisabled = true
+	disabled := BuildSSHHardeningConfig(cfg)
+	if !strings.Contains(disabled,
+		"PasswordAuthentication no\n") {
+		t.Fatalf("disabled config missing "+
+			"'PasswordAuthentication no':\n%s", disabled)
+	}
+
+	// Static hardening lines present in both states.
+	for _, line := range []string{
+		"PermitRootLogin no",
+		"PubkeyAuthentication yes",
+		"X11Forwarding no",
+	} {
+		if !strings.Contains(enabled, line) ||
+			!strings.Contains(disabled, line) {
+			t.Fatalf("static line %q missing", line)
+		}
+	}
+
+	// Exactly one PasswordAuthentication directive —
+	// a duplicate would silently lose first-match-wins.
+	if n := strings.Count(disabled,
+		"PasswordAuthentication"); n != 1 {
+		t.Fatalf("want exactly 1 PasswordAuthentication "+
+			"directive, got %d", n)
+	}
+
+	if !strings.HasSuffix(disabled, "\n") {
+		t.Fatal("config must end with a newline")
+	}
+}

--- a/internal/installer/sshkeys.go
+++ b/internal/installer/sshkeys.go
@@ -178,14 +178,19 @@ func AppendAuthorizedKey(line string) error {
 
 // RemoveAuthorizedKey removes the key matching the given
 // fingerprint from authorized_keys. Refuses to remove the
-// last key only when password auth is also disabled — the
-// invariant is "never leave the system with zero auth
-// methods." If passwordAuthEnabled is true, removing the
-// last key is allowed (the operator can still log in via
-// password).
-func RemoveAuthorizedKey(
-	fingerprint string, passwordAuthEnabled bool,
-) error {
+// last key when password authentication is not actually
+// available — the invariant is "never leave the system with
+// zero auth methods."
+//
+// Whether password auth is available is derived from sshd's
+// EFFECTIVE configuration (EffectiveSSHPasswordAuth), never
+// from a caller-supplied claim or this app's own config:
+// those can diverge from reality (e.g. a provider's
+// cloud-init drop-in disabled password auth before this app
+// ever ran, while the app's config still says enabled). The
+// query runs only when the last key is being removed, so
+// ordinary removals cost no extra privileged call.
+func RemoveAuthorizedKey(fingerprint string) error {
 	data, err := system.SudoReadFile(
 		paths.AuthorizedKeysFile)
 	if err != nil {
@@ -216,11 +221,21 @@ func RemoveAuthorizedKey(
 	if !found {
 		return errors.New("key not found")
 	}
-	if keyCount <= 1 && !passwordAuthEnabled {
-		return errors.New(
-			"cannot remove the last SSH key while " +
-				"password auth is disabled — re-enable " +
-				"password auth first")
+	if keyCount <= 1 {
+		pwAuthEnabled, err := EffectiveSSHPasswordAuth()
+		if err != nil {
+			return fmt.Errorf(
+				"cannot verify password auth state "+
+					"(%w) — refusing to remove the last "+
+					"SSH key", err)
+		}
+		if !pwAuthEnabled {
+			return errors.New(
+				"cannot remove the last SSH key while " +
+					"password authentication is disabled " +
+					"in the effective sshd configuration " +
+					"— enable password auth first")
+		}
 	}
 
 	// Second pass: rebuild without the target line.

--- a/internal/welcome/screen_system_ssh_key_detail.go
+++ b/internal/welcome/screen_system_ssh_key_detail.go
@@ -220,8 +220,7 @@ func (s *SSHKeyDetailScreen) handleConfirmKey(
 		case 1: // Remove
 			s.step = sshKeyDetailStepWorking
 			return s, removeSSHKeyCmd(
-				s.keyInfo.Fingerprint,
-				passwordAuthEnabled)
+				s.keyInfo.Fingerprint)
 		}
 	}
 	return s, nil

--- a/internal/welcome/screen_system_ssh_keys.go
+++ b/internal/welcome/screen_system_ssh_keys.go
@@ -60,13 +60,11 @@ func addSSHKeyCmd(line string) tea.Cmd {
 	}
 }
 
-func removeSSHKeyCmd(
-	fingerprint string, passwordAuthEnabled bool,
-) tea.Cmd {
+func removeSSHKeyCmd(fingerprint string) tea.Cmd {
 	return func() tea.Msg {
 		return sshKeyRemoveMsg{
 			err: installer.RemoveAuthorizedKey(
-				fingerprint, passwordAuthEnabled)}
+				fingerprint)}
 	}
 }
 

--- a/internal/welcome/update.go
+++ b/internal/welcome/update.go
@@ -440,9 +440,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case sshKeyRemoveMsg:
 		return m.dispatchToTab(tabSSHKeyDetail, msg)
 	case sshPwAuthDoneMsg:
-		// Cfg was mutated by SetSSHPasswordAuth before
-		// the msg was returned; persist before routing.
-		m.saveCfg()
+		// Persist only when the operation succeeded. On
+		// failure SetSSHPasswordAuth restored the
+		// in-memory value, so there is nothing new to
+		// save — and saving would durably record a value
+		// for an operation that failed. Same pattern as
+		// syncthingRemovedMsg.
+		if msg.err == nil {
+			m.saveCfg()
+		}
 		return m.dispatchToTab(tabSSHPasswordAuth, msg)
 	case changePwDoneMsg:
 		return m.dispatchToTab(tabSSHChangePassword, msg)


### PR DESCRIPTION
The guard that prevents disabling password login while no SSH keys exist now lives inside the function that writes the sshd configuration, so every current and future caller passes through it.

Removing the last SSH key previously trusted the caller to say whether password login was enabled. It now asks sshd directly for its effective configuration, using a simulated connection for the admin user. This accounts for settings applied outside the app, such as the configuration that cloud provisioning tools install, and honors conditional rules that target the admin user.

After writing a new configuration snippet, the app now asks sshd to validate the merged configuration before restarting it. If validation fails, the previous snippet is restored and sshd keeps running its current configuration. This prevents a restart into a broken state where no new connections would be accepted.

A failed toggle of password login no longer records its intended value to the config file, and the in memory value is restored, so what the app believes always matches what the system enforces.

Every failure in these paths refuses the risky action rather than proceeding. When the effective configuration cannot be read, removal of the last key is refused. When keys cannot be counted, disabling password login is refused. When the new configuration cannot be validated or restored, sshd is not restarted.