### PR TITLE
fix: password minimum enforced in code instead of trusting pam

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,7 +41,7 @@ type AppConfig struct {
 	Theme              string            `json:"theme,omitempty"`
 
 	// SSHPasswordAuthDisabled mirrors the value
-	// 99-rlvpn-hardening.conf writes for sshd's
+	// 00-rlvpn-hardening.conf writes for sshd's
 	// PasswordAuthentication directive. False = password
 	// auth enabled (matches debian default and the
 	// bootstrap-written drop-in, which is silent on the

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -42,6 +42,15 @@ func TestDefaultValues(t *testing.T) {
 	if cfg.WalletCreated {
 		t.Error("WalletCreated: expected false")
 	}
+	// Password auth must default to ENABLED (false).
+	// The SSH lockout guards fail safe only because a
+	// fresh or clobbered config yields this value; a
+	// future change flipping the default would turn a
+	// config-load failure into a possible lockout.
+	if cfg.SSHPasswordAuthDisabled {
+		t.Error("SSHPasswordAuthDisabled: expected false " +
+			"(password auth enabled by default)")
+	}
 }
 
 func TestHasLND(t *testing.T) {

--- a/internal/installer/sshd.go
+++ b/internal/installer/sshd.go
@@ -14,8 +14,13 @@ import (
 )
 
 // BuildSSHHardeningConfig generates the complete contents
-// of /etc/ssh/sshd_config.d/99-rlvpn-hardening.conf from
-// AppConfig. Pure function — no side effects.
+// of /etc/ssh/sshd_config.d/00-rlvpn-hardening.conf from
+// AppConfig. Pure function — no side effects. (The 00-
+// prefix is load-bearing: sshd applies the first match
+// per directive, so this drop-in must sort before a
+// provider's 50-cloud-init.conf to win contested
+// directives. paths.SSHDDropIn is the single source of
+// truth for the name.)
 //
 // Bootstrap writes the same static lines minus the
 // PasswordAuthentication directive (it's intentionally

--- a/internal/installer/userpassword.go
+++ b/internal/installer/userpassword.go
@@ -9,31 +9,84 @@ import (
 	"strings"
 )
 
+// MinLoginPasswordLen is the minimum length for the admin
+// user's login password. UI screens import this for their
+// hint copy; enforcement lives in NewLoginPassword so the
+// two can never disagree.
+const MinLoginPasswordLen = 16
+
+// LoginPassword is a validated login password. The only way
+// to obtain a non-zero LoginPassword is NewLoginPassword,
+// so any value that reaches a privileged function has
+// already passed validation. The zero value is unvalidated
+// and is rejected by SetUserPassword.
+type LoginPassword struct {
+	v string
+}
+
+// NewLoginPassword validates s and returns it as a
+// LoginPassword. Policy: at least MinLoginPasswordLen
+// characters and no newline (chpasswd's stdin protocol is
+// line-based, so an embedded newline would be interpreted
+// as a second, malformed change request).
+//
+// This is the ONLY enforcement point for password quality.
+// chpasswd runs as root here, and root-invoked password
+// changes bypass PAM's quality rules (confirmed on the
+// target image: a 5-character password was accepted with
+// exit code 0). There is no PAM backstop.
+func NewLoginPassword(s string) (LoginPassword, error) {
+	if s == "" {
+		return LoginPassword{},
+			errors.New("password is empty")
+	}
+	if strings.ContainsAny(s, "\n") {
+		return LoginPassword{},
+			errors.New("password has newline")
+	}
+	if len(s) < MinLoginPasswordLen {
+		return LoginPassword{}, fmt.Errorf(
+			"password must be at least %d characters",
+			MinLoginPasswordLen)
+	}
+	return LoginPassword{v: s}, nil
+}
+
+// String implements fmt.Stringer so that formatting a
+// LoginPassword with %v or %s can never leak the password
+// into a log line or error message.
+func (LoginPassword) String() string { return "[redacted]" }
+
+// GoString implements fmt.GoStringer so %#v is covered too.
+func (LoginPassword) GoString() string { return "[redacted]" }
+
 // SetUserPassword changes the given user's login password
 // via `sudo chpasswd`. The password is piped to chpasswd's
 // stdin so it never appears in argv (which would leak via
 // /proc/*/cmdline or `ps`).
 //
-// PAM rules apply — if the password is too short, weak,
-// or otherwise rejected by /etc/pam.d/common-password,
-// chpasswd will fail and we surface its stderr verbatim.
-func SetUserPassword(username, newPassword string) error {
+// The password arrives as a LoginPassword, so validation
+// has already happened at construction; the zero-value
+// check below closes the one remaining hole (a zero
+// LoginPassword was never validated).
+func SetUserPassword(
+	username string, password LoginPassword,
+) error {
 	if username == "" {
 		return errors.New("username is empty")
-	}
-	if newPassword == "" {
-		return errors.New("password is empty")
 	}
 	if strings.ContainsAny(username, ":\n") {
 		return errors.New("username has invalid chars")
 	}
-	if strings.ContainsAny(newPassword, "\n") {
-		return errors.New("password has newline")
+	if password.v == "" {
+		return errors.New(
+			"password was not validated " +
+				"(zero LoginPassword)")
 	}
 
 	cmd := exec.Command("sudo", "chpasswd")
 	cmd.Stdin = strings.NewReader(
-		username + ":" + newPassword + "\n")
+		username + ":" + password.v + "\n")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		msg := strings.TrimSpace(string(out))

--- a/internal/installer/userpassword_test.go
+++ b/internal/installer/userpassword_test.go
@@ -1,0 +1,104 @@
+// internal/installer/userpassword_test.go
+
+package installer
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestNewLoginPassword(t *testing.T) {
+	long := strings.Repeat("a", MinLoginPasswordLen)
+
+	cases := []struct {
+		name    string
+		in      string
+		wantErr bool
+	}{
+		{"empty", "", true},
+		{"one below minimum",
+			long[:MinLoginPasswordLen-1], true},
+		{"exactly minimum", long, false},
+		{"above minimum", long + "extra", false},
+		{"embedded newline",
+			long + "\n" + long, true},
+		{"trailing newline", long + "\n", true},
+		{"colon is allowed (only the username " +
+			"side of chpasswd's line is delimited)",
+			"with:colon:" + long, false},
+		{"spaces allowed",
+			"correct horse battery staple", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewLoginPassword(tc.in)
+			if tc.wantErr && err == nil {
+				t.Errorf("NewLoginPassword(%q): "+
+					"expected error, got nil", tc.in)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("NewLoginPassword(%q): "+
+					"unexpected error: %v", tc.in, err)
+			}
+		})
+	}
+}
+
+// The password must never leak through the fmt verbs that
+// end up in logs and error chains.
+func TestLoginPasswordRedaction(t *testing.T) {
+	secret := strings.Repeat("s3cret!!", 4)
+	pw, err := NewLoginPassword(secret)
+	if err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	for _, verb := range []string{
+		"%v", "%s", "%#v", "%+v",
+	} {
+		got := fmt.Sprintf(verb, pw)
+		if strings.Contains(got, secret) {
+			t.Errorf("fmt %s leaked the password: %q",
+				verb, got)
+		}
+		if got != "[redacted]" {
+			t.Errorf("fmt %s: got %q, want %q",
+				verb, got, "[redacted]")
+		}
+	}
+
+	wrapped := fmt.Errorf("op failed: %v", pw)
+	if strings.Contains(wrapped.Error(), secret) {
+		t.Errorf("error wrapping leaked the password: %q",
+			wrapped.Error())
+	}
+}
+
+// SetUserPassword's own guards fire before any exec, so
+// they are testable without sudo/chpasswd present.
+func TestSetUserPasswordRejectsBeforeExec(t *testing.T) {
+	valid, err := NewLoginPassword(
+		strings.Repeat("a", MinLoginPasswordLen))
+	if err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	if err := SetUserPassword("", valid); err == nil {
+		t.Error("empty username: expected error")
+	}
+	if err := SetUserPassword(
+		"bad:user", valid); err == nil {
+		t.Error("username with colon: expected error")
+	}
+	if err := SetUserPassword(
+		"bad\nuser", valid); err == nil {
+		t.Error("username with newline: expected error")
+	}
+	if err := SetUserPassword(
+		"someuser", LoginPassword{}); err == nil {
+		t.Error("zero-value LoginPassword: " +
+			"expected error")
+	}
+}

--- a/internal/welcome/screen_system_change_password.go
+++ b/internal/welcome/screen_system_change_password.go
@@ -25,8 +25,6 @@ import (
 // as root (uid 0) so we never accidentally rewrite root's
 // password from a misconfigured launch.
 
-const minPasswordLen = 16
-
 type changePwStep int
 
 const (
@@ -44,7 +42,7 @@ const (
 type changePwDoneMsg struct{ err error }
 
 func setUserPasswordCmd(
-	username, newPassword string,
+	username string, newPassword installer.LoginPassword,
 ) tea.Cmd {
 	return func() tea.Msg {
 		return changePwDoneMsg{
@@ -141,7 +139,7 @@ func (s *ChangePasswordScreen) HandleMsg(
 		// to whichever input is currently focused.
 		// Strip a single trailing newline since password
 		// managers often add one; embedded newlines are
-		// rejected by SetUserPassword anyway.
+		// rejected by NewLoginPassword at submit anyway.
 		if s.step != changePwStepInput {
 			return s, nil
 		}
@@ -349,15 +347,19 @@ func (s *ChangePasswordScreen) submit() (Screen, tea.Cmd) {
 		s.inputErr = "Passwords do not match"
 		return s, nil
 	}
-	if len(newPw) < minPasswordLen {
-		s.inputErr = "Password must be at least " +
-			strconv.Itoa(minPasswordLen) + " characters"
+	// Validation policy (minimum length, no newline)
+	// lives in the constructor, shared with the
+	// privileged boundary — this screen just surfaces
+	// its error.
+	pw, err := installer.NewLoginPassword(newPw)
+	if err != nil {
+		s.inputErr = err.Error()
 		return s, nil
 	}
 
 	s.inputErr = ""
 	s.step = changePwStepWorking
-	return s, setUserPasswordCmd(s.username, newPw)
+	return s, setUserPasswordCmd(s.username, pw)
 }
 
 func (s *ChangePasswordScreen) viewInput(w, h int) string {
@@ -380,7 +382,8 @@ func (s *ChangePasswordScreen) viewInput(w, h int) string {
 	p.dim("before submitting — this screen will not")
 	p.dim("show it back to you.")
 	p.blank()
-	p.dim("Minimum length: " + strconv.Itoa(minPasswordLen) +
+	p.dim("Minimum length: " +
+		strconv.Itoa(installer.MinLoginPasswordLen) +
 		" characters.")
 	p.blank()
 

--- a/internal/welcome/screen_system_p2p_upgrade.go
+++ b/internal/welcome/screen_system_p2p_upgrade.go
@@ -420,6 +420,12 @@ func (s *P2PUpgradeScreen) viewConfirm(
 		"  • Open ports 9735 and 8080"+
 			" in the firewall"))
 	p.line(" " + theme.Value.Render(
+		"  • Expose LND's full REST API (port 8080)"))
+	p.line(" " + theme.Value.Render(
+		"    to the internet, protected by TLS and"))
+	p.line(" " + theme.Value.Render(
+		"    macaroon authentication"))
+	p.line(" " + theme.Value.Render(
 		"  • Allow Zeus to connect over clearnet"))
 	p.line(" " + theme.Value.Render(
 		"  • Restart LND with the new config"))

--- a/internal/welcome/screen_system_ssh_key_detail.go
+++ b/internal/welcome/screen_system_ssh_key_detail.go
@@ -247,10 +247,15 @@ func (s *SSHKeyDetailScreen) viewConfirm(
 
 	p.blank()
 
-	// Lockout copy is driven by the actual auth state.
-	// Invariant: never let the system end up with zero
-	// auth methods. Hard-block only when removing this
-	// key would leave neither keys nor password.
+	// Lockout copy is driven by this app's recorded
+	// setting, which can diverge from sshd's effective
+	// config — so the copy below never asserts the
+	// live state as fact. The authoritative gate is in
+	// the installer: removing the LAST key triggers a
+	// live query of sshd's effective config, and the
+	// removal is refused unless password login is
+	// actually available. Invariant: never let the
+	// system end up with zero auth methods.
 	passwordAuthEnabled :=
 		!s.ctx.Cfg.SSHPasswordAuthDisabled
 	isLastKey := s.keyCount <= 1
@@ -258,19 +263,26 @@ func (s *SSHKeyDetailScreen) viewConfirm(
 
 	switch {
 	case hardBlock:
-		p.warn("This is your only key and password " +
-			"auth is disabled.")
-		p.warn("Removing it would lock you out.")
+		p.warn("This is your only key, and this app's")
+		p.warn("settings say password auth is disabled.")
+		p.warn("Removing it could lock you out.")
 		p.warn("Re-enable password auth first.")
 		p.blank()
 	case isLastKey:
-		p.warn("This is your only key, but password " +
-			"auth is enabled —")
-		p.warn("you'll still be able to log in by " +
-			"password.")
+		p.warn("This is your only SSH key. Removal is")
+		p.warn("only permitted if password login is")
+		p.warn("actually available — the system checks")
+		p.warn("the live sshd configuration and")
+		p.warn("refuses otherwise.")
 		p.blank()
 	}
-	p.warn("Remove this key?")
+	// Under a hard block there is no Remove button, so
+	// don't ask a question the operator cannot answer.
+	if hardBlock {
+		p.warn("Removal is blocked.")
+	} else {
+		p.warn("Remove this key?")
+	}
 
 	// When hard-blocked, show only Go Back (no Remove).
 	buttons := []string{"Go Back", "Remove"}

--- a/internal/welcome/screen_system_ssh_keys.go
+++ b/internal/welcome/screen_system_ssh_keys.go
@@ -300,15 +300,21 @@ func (s *SSHKeysScreen) viewList(w, h int) string {
 			s.btnIdx, onButtons, w))
 	headerLines = append(headerLines, "")
 
-	// Status line: shows the actual SSH password auth
-	// state. Mirrors what's surfaced in the Password
-	// Auth screen.
+	// Status line: shows THIS APP'S recorded password
+	// auth setting, and says so — sshd's effective
+	// config can diverge (e.g. a provider's cloud-init
+	// drop-in that disabled password auth before this
+	// app ever ran). The guard that actually protects
+	// key removal derives the live state from sshd
+	// itself; this label must not claim more than the
+	// app can verify.
 	pwAuthLabel := theme.Success.Render("enabled")
 	if s.ctx.Cfg.SSHPasswordAuthDisabled {
 		pwAuthLabel = theme.Warning.Render("disabled")
 	}
 	headerLines = append(headerLines,
-		" "+theme.Label.Render("Password Auth: ")+
+		" "+theme.Label.Render(
+			"Password Auth (app setting): ")+
 			pwAuthLabel)
 	headerLines = append(headerLines, "")
 

--- a/internal/welcome/screen_system_ssh_password_auth.go
+++ b/internal/welcome/screen_system_ssh_password_auth.go
@@ -290,6 +290,10 @@ func (s *SSHPasswordAuthScreen) viewConfirm(
 		p.dim("Confirm that:")
 		p.dim("  • You have at least one key that works")
 		p.dim("  • You have tested logging in with it")
+		p.blank()
+		p.warn("After applying: keep this session open")
+		p.warn("and verify key login from a new")
+		p.warn("terminal before disconnecting.")
 	} else {
 		p.title(theme.Header, "Enable password auth?")
 		p.blank()


### PR DESCRIPTION
What changed
The minimum password length is now enforced inside the installer, not only in the terminal UI. A new LoginPassword type carries the validated password and SetUserPassword accepts only that type. The installer comment that promised a PAM backstop for weak passwords was wrong and has been corrected. Two source comments that named the sshd hardening file with a 99 prefix now name the real 00 prefix. The default config test now asserts that password authentication defaults to enabled. Several screens got wording fixes: the SSH keys header labels its password auth line as an app setting, the key removal warnings no longer state the live sshd state as fact, the disable confirmation now tells the operator to keep the session open and verify key login from a new terminal before disconnecting, and the hybrid upgrade consent screen now discloses that port 8080 exposes the LND REST API.

How it works
A password can only become a LoginPassword through its constructor, which rejects anything shorter than 16 characters or containing a newline. The compiler therefore guarantees that every caller of SetUserPassword validated first. The type formats as the word redacted under all printf verbs, so a password cannot reach a log line through an error path. The terminal UI calls the same constructor for its own validation, so both boundaries share one rule and cannot drift apart.

Why it is safe
Password changes run through chpasswd as root, and root invoked changes skip the PAM quality rules. We confirmed this on a live Debian 13 box where a five character password was accepted. Enforcement in our own code is therefore the only enforcement there is. Everything else in this commit is comments, screen wording, and one test assertion; no privileged behavior changed. The wording changes make the screens claim less, not more: they now describe what the app records and what the installer actually checks, matching the guard behavior that shipped in the previous commit.