### PR TITLE
feature: install checks the environment

### DIFF
--- a/internal/installer/preflight.go
+++ b/internal/installer/preflight.go
@@ -1,0 +1,432 @@
+// internal/installer/preflight.go
+
+package installer
+
+// Install preflight (sprint principle 3): before the install engine
+// mutates anything, assert the environmental bets this binary makes
+// and refuse to proceed if the box is not one we can trust. All
+// checks run and every failure is reported at once, so the operator
+// fixes everything in one round trip.
+//
+// Placement: called at the top of Run(), before the install TUI
+// opens, at the seam the old checkOS() occupied (preflight absorbs
+// it). A refused box is untouched — no user created, no config
+// written, no service restarted. The commit-6 root install re-homes
+// this call under the `vpn install` dispatch; notes for that session
+// are on the individual checks below.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/ripsline/virtual-private-node/internal/logger"
+	"github.com/ripsline/virtual-private-node/internal/paths"
+	"github.com/ripsline/virtual-private-node/internal/system"
+)
+
+// PreflightResult is one check's outcome. Err == nil means pass.
+type PreflightResult struct {
+	Name string
+	Err  error
+}
+
+// Check names double as report labels — short, present-tense facts.
+const (
+	checkNameDebian    = "Debian version is exactly 13"
+	checkNameSudo      = "passwordless sudo works"
+	checkNameTorsocks  = "torsocks is installed"
+	checkNameIOLogging = "sudo I/O logging is disabled"
+	checkNameDpkg      = "package system is healthy (dpkg --audit)"
+	checkNameUfw       = "ufw is installable"
+)
+
+// RunPreflight runs every check, prints a full report to stderr on
+// any failure (and mirrors the failures to the log file, so the log
+// trail never just stops), and returns a summary error that aborts
+// the install before its first step.
+func RunPreflight() error {
+	results := runPreflightChecks()
+
+	failed := 0
+	for _, r := range results {
+		if r.Err != nil {
+			failed++
+		}
+	}
+	if failed == 0 {
+		logger.Install("Preflight passed (%d/%d checks)",
+			len(results), len(results))
+		return nil
+	}
+
+	fmt.Fprint(os.Stderr, "\n"+FormatPreflightReport(results))
+	for _, r := range results {
+		if r.Err != nil {
+			logger.Install("Preflight FAIL: %s: %v", r.Name, r.Err)
+		}
+	}
+	return fmt.Errorf(
+		"preflight: %d of %d checks failed — nothing was changed",
+		failed, len(results))
+}
+
+// runPreflightChecks executes the checks in dependency order. The
+// sudoers scan needs working sudo to read root-owned files, so it is
+// reported as a failure (not silently passed) when the sudo check
+// already failed — fail-safe direction: cannot verify means refuse.
+func runPreflightChecks() []PreflightResult {
+	results := []PreflightResult{
+		{checkNameDebian, checkDebian13()},
+	}
+
+	sudoErr := checkPasswordlessSudo()
+	results = append(results, PreflightResult{checkNameSudo, sudoErr})
+	results = append(results,
+		PreflightResult{checkNameTorsocks, checkTorsocks()})
+
+	var ioLogErr error
+	if sudoErr != nil {
+		ioLogErr = errors.New(
+			"skipped — cannot read the sudo configuration " +
+				"while passwordless sudo is not working")
+	} else {
+		ioLogErr = checkSudoersIOLogging()
+	}
+	results = append(results,
+		PreflightResult{checkNameIOLogging, ioLogErr})
+
+	results = append(results,
+		PreflightResult{checkNameDpkg, checkDpkgAudit()})
+	results = append(results,
+		PreflightResult{checkNameUfw, checkUfwInstallable()})
+	return results
+}
+
+// ── Check 1: OS ──────────────────────────────────────────
+
+// checkDebian13 asserts /etc/os-release says ID=debian AND
+// VERSION_ID exactly 13 (ruling ix). Exactly, not at-least:
+// every external interface this binary invokes (sshd -T -C flags,
+// chpasswd, dpkg, apt) is [LIVE]-verified against the package
+// versions frozen in Debian 13; a future Debian 14 ships new
+// versions that may falsify those contracts (precedent: the
+// commit-2 -G/-C flag rejection). Debian 14 support = re-verify
+// the interface inventory, then widen this check in a release.
+func checkDebian13() error {
+	data, err := os.ReadFile(paths.OSRelease)
+	if err != nil {
+		return fmt.Errorf("cannot read %s: %w", paths.OSRelease, err)
+	}
+	return checkOSRelease(string(data))
+}
+
+// checkOSRelease parses os-release content. Pure function —
+// unit-tested. Line-anchored prefix parsing, not substring search,
+// so ID_LIKE=debian (Ubuntu and friends) can never match.
+func checkOSRelease(content string) error {
+	id, versionID := "", ""
+	for _, raw := range strings.Split(content, "\n") {
+		line := strings.TrimSpace(raw)
+		if v, ok := strings.CutPrefix(line, "ID="); ok {
+			id = strings.Trim(v, `"`)
+		}
+		if v, ok := strings.CutPrefix(line, "VERSION_ID="); ok {
+			versionID = strings.Trim(v, `"`)
+		}
+	}
+	if id != "debian" {
+		return fmt.Errorf(
+			"this installer supports Debian only (found ID=%q)", id)
+	}
+	if versionID != "13" {
+		return fmt.Errorf(
+			"this release is verified for Debian 13 only "+
+				"(found VERSION_ID=%q); newer Debian releases are "+
+				"refused until their system commands are re-verified",
+			versionID)
+	}
+	return nil
+}
+
+// ── Check 2: sudo ────────────────────────────────────────
+
+// checkPasswordlessSudo asserts the bootstrap's NOPASSWD rule is
+// actually usable: `sudo -n true` fails instead of prompting when a
+// password would be required. Without this, a half-bootstrapped box
+// dies mid-install with the sudo error buried in whichever step ran
+// first.
+//
+// SCAFFOLDING for the pre-commit-6 world: once `vpn install` runs
+// as root (commit 6) there is no sudo rule to depend on during
+// install, and commit 7 deletes NOPASSWD entirely. The commit-6
+// session deletes this check.
+func checkPasswordlessSudo() error {
+	if _, err := system.RunContext(
+		15*time.Second, "sudo", "-n", "true"); err != nil {
+		return fmt.Errorf(
+			"passwordless sudo is not working (%v) — re-run the "+
+				"bootstrap script or restore /etc/sudoers.d/%s",
+			err, paths.AdminUser)
+	}
+	return nil
+}
+
+// ── Check 3: torsocks ────────────────────────────────────
+
+// checkTorsocks asserts torsocks is on PATH. The bootstrap script
+// installed it before this binary ever ran, so its absence means a
+// tampered or unfinished bootstrap. All downloads route through it
+// (the torgate step re-checks at its own point in the sequence).
+// Retired when the Go-native Tor client lands (standalone queue #6).
+func checkTorsocks() error {
+	if _, err := exec.LookPath("torsocks"); err != nil {
+		return errors.New(
+			"torsocks not found — all downloads must route " +
+				"through Tor; re-run the bootstrap script")
+	}
+	return nil
+}
+
+// ── Check 4: sudo I/O logging (IA-3-H) ───────────────────
+
+// checkSudoersIOLogging asserts no sudoers file enables sudo's
+// input/output recording. With log_input set, the moment this app
+// pipes the admin password to `sudo chpasswd`, sudo would tee the
+// plaintext to /var/log/sudo-io — a passive credential sink. Scope:
+// /etc/sudoers plus every file sudo's @includedir would parse in
+// /etc/sudoers.d. Residual (documented, accepted): a nonstandard
+// @includedir pointing elsewhere is not followed.
+func checkSudoersIOLogging() error {
+	files := []string{paths.SudoersFile}
+	entries, err := os.ReadDir(paths.SudoersDir)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return fmt.Errorf(
+				"cannot list %s: %w", paths.SudoersDir, err)
+		}
+	} else {
+		for _, e := range entries {
+			if e.IsDir() || !sudoersFileIncluded(e.Name()) {
+				continue
+			}
+			files = append(files,
+				filepath.Join(paths.SudoersDir, e.Name()))
+		}
+	}
+
+	for _, f := range files {
+		data, err := system.SudoReadFile(f)
+		if err != nil {
+			return fmt.Errorf("cannot read %s: %w", f, err)
+		}
+		if directive, found :=
+			sudoersEnablesIOLogging(string(data)); found {
+			return fmt.Errorf(
+				"%s enables sudo I/O recording (%s) — it would "+
+					"write the admin password to disk when this app "+
+					"sets it; remove that setting and try again",
+				f, directive)
+		}
+	}
+	return nil
+}
+
+// sudoersFileIncluded mirrors sudo's @includedir rule: files whose
+// names contain a '.' or end in '~' are ignored by sudo, so a
+// finding in them would be a false refusal. Pure — unit-tested.
+func sudoersFileIncluded(name string) bool {
+	return !strings.Contains(name, ".") &&
+		!strings.HasSuffix(name, "~")
+}
+
+// sudoersEnablesIOLogging reports whether sudoers content enables
+// I/O recording, via either mechanism:
+//
+//   - a Defaults option: `Defaults log_input` / `Defaults
+//     log_output` (negation-aware: an odd number of leading '!'
+//     disables; comments and @include/#include lines cannot enable
+//     anything and are skipped)
+//   - a command tag in a user spec: `LOG_INPUT:` / `LOG_OUTPUT:`
+//     (uppercase, colon-suffixed; NOLOG_* tags disable and do not
+//     match)
+//
+// Direction on ambiguity: over-refusal. Pure — unit-tested.
+func sudoersEnablesIOLogging(content string) (string, bool) {
+	// Join backslash line continuations first.
+	content = strings.ReplaceAll(content, "\\\n", " ")
+
+	for _, raw := range strings.Split(content, "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		for _, f := range strings.Fields(line) {
+			if f == "LOG_INPUT:" || f == "LOG_OUTPUT:" {
+				return f, true
+			}
+		}
+
+		if !strings.HasPrefix(line, "Defaults") {
+			continue
+		}
+		rest := line[len("Defaults"):]
+		for _, tok := range strings.FieldsFunc(rest,
+			func(r rune) bool {
+				return r == ' ' || r == '\t' ||
+					r == ',' || r == '='
+			}) {
+			neg := 0
+			for strings.HasPrefix(tok, "!") {
+				tok = tok[1:]
+				neg++
+			}
+			if (tok == "log_input" || tok == "log_output") &&
+				neg%2 == 0 {
+				return tok, true
+			}
+		}
+	}
+	return "", false
+}
+
+// ── Check 5: dpkg ────────────────────────────────────────
+
+// checkDpkgAudit asserts the package database has no packages stuck
+// in broken states — a wedged dpkg would otherwise kill the install
+// midway through the engine's own apt operations. Read-only; no
+// lock taken.
+func checkDpkgAudit() error {
+	out, err := system.RunContext(60*time.Second, "dpkg", "--audit")
+	return dpkgAuditVerdict(out, err)
+}
+
+// dpkgAuditVerdict: clean means rc 0 AND empty output — no bet on
+// dpkg's exit-code behavior across versions (principle 2). Pure —
+// unit-tested.
+func dpkgAuditVerdict(output string, err error) error {
+	if err != nil {
+		return fmt.Errorf("dpkg --audit failed: %v", err)
+	}
+	if s := strings.TrimSpace(output); s != "" {
+		first := strings.SplitN(s, "\n", 2)[0]
+		return fmt.Errorf(
+			"dpkg reports packages in a broken state (%s ...) — "+
+				"fix with: sudo dpkg --configure -a && "+
+				"sudo apt-get -f install", first)
+	}
+	return nil
+}
+
+// ── Check 6: ufw ─────────────────────────────────────────
+
+// checkUfwInstallable asserts apt's on-disk package index can
+// deliver ufw when the engine's firewall step apt-installs it
+// mid-sequence. Offline; installs nothing; passes instantly when
+// ufw is already present (re-runs).
+//
+// Today this is nearly redundant — the bootstrap script proved apt
+// working minutes earlier — but it becomes LOAD-BEARING at commit 6
+// when the binary absorbs the script and nothing has pre-proven
+// apt. It lives here so commit 6 inherits it for free.
+func checkUfwInstallable() error {
+	if _, err := exec.LookPath("ufw"); err == nil {
+		return nil
+	}
+	out, err := runAptCachePolicy("ufw", 30*time.Second)
+	if err != nil {
+		return fmt.Errorf("apt-cache policy ufw failed: %v", err)
+	}
+	return ufwCandidateVerdict(out)
+}
+
+// runAptCachePolicy runs `apt-cache policy <pkg>` with LC_ALL=C so
+// the Candidate line is stable across locales. Local exec (not the
+// system wrappers) purely for the env override; no sudo involved.
+func runAptCachePolicy(
+	pkg string, timeout time.Duration,
+) (string, error) {
+	ctx, cancel := context.WithTimeout(
+		context.Background(), timeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "apt-cache", "policy", pkg)
+	cmd.Env = append(os.Environ(), "LC_ALL=C")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("apt-cache policy %s: %w", pkg, err)
+	}
+	return string(out), nil
+}
+
+// ufwCandidateVerdict parses apt-cache policy output: installable
+// means a Candidate line with a real version. Pure — unit-tested.
+func ufwCandidateVerdict(output string) error {
+	for _, raw := range strings.Split(output, "\n") {
+		line := strings.TrimSpace(raw)
+		if v, ok := strings.CutPrefix(line, "Candidate:"); ok {
+			v = strings.TrimSpace(v)
+			if v != "" && v != "(none)" {
+				return nil
+			}
+			return errors.New(
+				"apt has no installable ufw candidate — package " +
+					"lists may be broken; run: sudo apt-get update")
+		}
+	}
+	return errors.New(
+		"no Candidate line in apt-cache policy output — apt " +
+			"package lists may be missing; run: sudo apt-get update")
+}
+
+// ── Report formatting ────────────────────────────────────
+
+// FormatPreflightReport renders the full check list with every
+// failure's reason. Pure — unit-tested.
+func FormatPreflightReport(results []PreflightResult) string {
+	var b strings.Builder
+	b.WriteString("  Preflight — checking the environment " +
+		"before changing anything:\n\n")
+	failed := 0
+	for _, r := range results {
+		if r.Err == nil {
+			fmt.Fprintf(&b, "    [ OK ] %s\n", r.Name)
+			continue
+		}
+		failed++
+		fmt.Fprintf(&b, "    [FAIL] %s\n", r.Name)
+		for _, line := range wrapText(r.Err.Error(), 56) {
+			fmt.Fprintf(&b, "           %s\n", line)
+		}
+	}
+	if failed > 0 {
+		b.WriteString("\n  Refusing to install. Nothing on this " +
+			"system has been changed.\n")
+	}
+	return b.String()
+}
+
+// wrapText word-wraps s to width columns. Words longer than width
+// get their own line, unbroken. Pure — unit-tested.
+func wrapText(s string, width int) []string {
+	words := strings.Fields(s)
+	if len(words) == 0 {
+		return nil
+	}
+	var lines []string
+	cur := words[0]
+	for _, w := range words[1:] {
+		if len(cur)+1+len(w) <= width {
+			cur += " " + w
+			continue
+		}
+		lines = append(lines, cur)
+		cur = w
+	}
+	return append(lines, cur)
+}

--- a/internal/installer/preflight.go
+++ b/internal/installer/preflight.go
@@ -204,21 +204,11 @@ func checkTorsocks() error {
 // @includedir pointing elsewhere is not followed.
 func checkSudoersIOLogging() error {
 	files := []string{paths.SudoersFile}
-	entries, err := os.ReadDir(paths.SudoersDir)
+	dropIns, err := listSudoersDropIns()
 	if err != nil {
-		if !os.IsNotExist(err) {
-			return fmt.Errorf(
-				"cannot list %s: %w", paths.SudoersDir, err)
-		}
-	} else {
-		for _, e := range entries {
-			if e.IsDir() || !sudoersFileIncluded(e.Name()) {
-				continue
-			}
-			files = append(files,
-				filepath.Join(paths.SudoersDir, e.Name()))
-		}
+		return err
 	}
+	files = append(files, dropIns...)
 
 	for _, f := range files {
 		data, err := system.SudoReadFile(f)
@@ -235,6 +225,48 @@ func checkSudoersIOLogging() error {
 		}
 	}
 	return nil
+}
+
+// listSudoersDropIns enumerates the files sudo's @includedir would
+// parse. The directory is enumerated THROUGH sudo: /etc/sudoers.d
+// itself is not world-listable on Debian 13 ([LIVE], commit-4 run —
+// an unprivileged os.ReadDir here got permission denied, which
+// would have refused every clean box). find emits regular files
+// only, so a stray subdirectory can never reach the file reads. A
+// missing directory means nothing to scan; any other stat failure
+// refuses (stat needs no permission on the directory itself).
+func listSudoersDropIns() ([]string, error) {
+	if _, err := os.Stat(paths.SudoersDir); err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf(
+			"cannot stat %s: %w", paths.SudoersDir, err)
+	}
+	out, err := system.SudoRunOutput("find", paths.SudoersDir,
+		"-maxdepth", "1", "-type", "f")
+	if err != nil {
+		return nil, fmt.Errorf(
+			"cannot list %s: %w", paths.SudoersDir, err)
+	}
+	return filterSudoersDropIns(out), nil
+}
+
+// filterSudoersDropIns applies sudo's includedir filename rule to
+// find output (one absolute path per line). Pure — unit-tested.
+func filterSudoersDropIns(findOutput string) []string {
+	var files []string
+	for _, line := range strings.Split(findOutput, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if !sudoersFileIncluded(filepath.Base(line)) {
+			continue
+		}
+		files = append(files, line)
+	}
+	return files
 }
 
 // sudoersFileIncluded mirrors sudo's @includedir rule: files whose

--- a/internal/installer/preflight_test.go
+++ b/internal/installer/preflight_test.go
@@ -101,6 +101,37 @@ func TestSudoersFileIncluded(t *testing.T) {
 	}
 }
 
+// ── filterSudoersDropIns ─────────────────────────────────
+
+func TestFilterSudoersDropIns(t *testing.T) {
+	findOutput := "/etc/sudoers.d/ripsline\n" +
+		"/etc/sudoers.d/zz-preflight-test\n" +
+		"/etc/sudoers.d/README\n" +
+		"/etc/sudoers.d/backup.bak\n" +
+		"/etc/sudoers.d/ripsline~\n"
+	got := filterSudoersDropIns(findOutput)
+	want := []string{
+		"/etc/sudoers.d/ripsline",
+		"/etc/sudoers.d/zz-preflight-test",
+		"/etc/sudoers.d/README",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("entry %d: got %q, want %q",
+				i, got[i], want[i])
+		}
+	}
+	if out := filterSudoersDropIns(""); len(out) != 0 {
+		t.Errorf("empty find output: got %v, want none", out)
+	}
+	if out := filterSudoersDropIns("\n  \n"); len(out) != 0 {
+		t.Errorf("blank lines: got %v, want none", out)
+	}
+}
+
 // ── sudoersEnablesIOLogging ──────────────────────────────
 
 func TestSudoersIOLoggingDetected(t *testing.T) {

--- a/internal/installer/preflight_test.go
+++ b/internal/installer/preflight_test.go
@@ -1,0 +1,284 @@
+// internal/installer/preflight_test.go
+
+package installer
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// ── checkOSRelease ───────────────────────────────────────
+
+func TestCheckOSReleaseAccepts(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+	}{
+		{"debian 13 quoted",
+			"PRETTY_NAME=\"Debian GNU/Linux 13 (trixie)\"\n" +
+				"NAME=\"Debian GNU/Linux\"\n" +
+				"VERSION_ID=\"13\"\n" +
+				"VERSION=\"13 (trixie)\"\n" +
+				"VERSION_CODENAME=trixie\n" +
+				"ID=debian\n"},
+		{"debian 13 unquoted",
+			"ID=debian\nVERSION_ID=13\n"},
+		{"leading whitespace tolerated",
+			"  ID=debian\n  VERSION_ID=\"13\"\n"},
+	}
+	for _, tt := range cases {
+		if err := checkOSRelease(tt.content); err != nil {
+			t.Errorf("%s: unexpected refusal: %v", tt.name, err)
+		}
+	}
+}
+
+func TestCheckOSReleaseRefuses(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+		wantIn  string
+	}{
+		{"debian 12",
+			"ID=debian\nVERSION_ID=\"12\"\n",
+			"Debian 13 only"},
+		{"debian 14",
+			"ID=debian\nVERSION_ID=\"14\"\n",
+			"Debian 13 only"},
+		{"ubuntu with ID_LIKE=debian",
+			"ID=ubuntu\nID_LIKE=debian\nVERSION_ID=\"24.04\"\n",
+			"Debian only"},
+		{"debian sid, no VERSION_ID",
+			"ID=debian\nVERSION_CODENAME=sid\n",
+			"Debian 13 only"},
+		{"empty content", "", "Debian only"},
+	}
+	for _, tt := range cases {
+		err := checkOSRelease(tt.content)
+		if err == nil {
+			t.Errorf("%s: accepted, want refusal", tt.name)
+			continue
+		}
+		if !strings.Contains(err.Error(), tt.wantIn) {
+			t.Errorf("%s: error %q does not mention %q",
+				tt.name, err, tt.wantIn)
+		}
+	}
+}
+
+// The old checkOS accepted 13-or-newer via substring matching;
+// this guards the two deliberate tightenings (exactly 13, and
+// line-anchored ID parsing) against regression.
+func TestCheckOSReleaseExactlyThirteen(t *testing.T) {
+	for _, ver := range []string{"14", "15", "12", "11"} {
+		content := "ID=debian\nVERSION_ID=\"" + ver + "\"\n"
+		if err := checkOSRelease(content); err == nil {
+			t.Errorf("VERSION_ID=%s accepted, want refusal", ver)
+		}
+	}
+}
+
+// ── sudoersFileIncluded ──────────────────────────────────
+
+func TestSudoersFileIncluded(t *testing.T) {
+	cases := []struct {
+		name string
+		want bool
+	}{
+		{"ripsline", true},
+		{"README", true},
+		{"99-custom", true},
+		{"backup.bak", false},    // contains '.'
+		{"50-cloud.conf", false}, // contains '.'
+		{"ripsline~", false},     // editor backup
+	}
+	for _, tt := range cases {
+		if got := sudoersFileIncluded(tt.name); got != tt.want {
+			t.Errorf("sudoersFileIncluded(%q) = %v, want %v",
+				tt.name, got, tt.want)
+		}
+	}
+}
+
+// ── sudoersEnablesIOLogging ──────────────────────────────
+
+func TestSudoersIOLoggingDetected(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+	}{
+		{"plain log_input", "Defaults log_input\n"},
+		{"plain log_output", "Defaults log_output\n"},
+		{"user-scoped", "Defaults:ripsline log_input\n"},
+		{"comma list", "Defaults env_reset, log_input\n"},
+		{"double negation enables", "Defaults !!log_input\n"},
+		{"tab separated", "Defaults\tlog_output\n"},
+		{"line continuation",
+			"Defaults env_reset, \\\n    log_input\n"},
+		{"LOG_INPUT tag",
+			"ripsline ALL=(ALL) LOG_INPUT: /usr/bin/foo\n"},
+		{"LOG_OUTPUT tag",
+			"ripsline ALL=(ALL) NOPASSWD: LOG_OUTPUT: ALL\n"},
+		{"buried among safe lines",
+			"# comment\nDefaults env_reset\n" +
+				"ripsline ALL=(ALL) NOPASSWD:ALL\n" +
+				"Defaults log_input\n"},
+	}
+	for _, tt := range cases {
+		if _, found := sudoersEnablesIOLogging(tt.content); !found {
+			t.Errorf("%s: not detected", tt.name)
+		}
+	}
+}
+
+func TestSudoersIOLoggingClean(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+	}{
+		{"empty", ""},
+		{"bootstrap rule only",
+			"ripsline ALL=(ALL) NOPASSWD:ALL\n"},
+		{"stock debian",
+			"Defaults env_reset\n" +
+				"Defaults mail_badpass\n" +
+				"Defaults use_pty\n" + // no disk sink by itself
+				"root ALL=(ALL:ALL) ALL\n" +
+				"@includedir /etc/sudoers.d\n"},
+		{"commented out", "#Defaults log_input\n"},
+		{"commented with space", "# Defaults log_input\n"},
+		{"explicitly negated", "Defaults !log_input\n"},
+		{"negated both",
+			"Defaults !log_input\nDefaults !log_output\n"},
+		{"iolog_dir alone does not enable",
+			"Defaults iolog_dir=/var/log/sudo-io\n"},
+		{"NOLOG tags disable",
+			"ripsline ALL=(ALL) NOLOG_INPUT: NOLOG_OUTPUT: ALL\n"},
+		{"similar option names",
+			"Defaults log_year\nDefaults logfile=/var/log/sudo\n"},
+	}
+	for _, tt := range cases {
+		if d, found := sudoersEnablesIOLogging(tt.content); found {
+			t.Errorf("%s: false positive on %q", tt.name, d)
+		}
+	}
+}
+
+// ── dpkgAuditVerdict ─────────────────────────────────────
+
+func TestDpkgAuditVerdict(t *testing.T) {
+	if err := dpkgAuditVerdict("", nil); err != nil {
+		t.Errorf("clean audit refused: %v", err)
+	}
+	if err := dpkgAuditVerdict("  \n ", nil); err != nil {
+		t.Errorf("whitespace-only output refused: %v", err)
+	}
+	if err := dpkgAuditVerdict(
+		"The following packages are only half configured:\n"+
+			" somepkg\n", nil); err == nil {
+		t.Error("broken-state output accepted")
+	}
+	if err := dpkgAuditVerdict("", errors.New("exit status 2")); err == nil {
+		t.Error("nonzero exit accepted")
+	}
+}
+
+// ── ufwCandidateVerdict ──────────────────────────────────
+
+func TestUfwCandidateVerdict(t *testing.T) {
+	good := "ufw:\n" +
+		"  Installed: (none)\n" +
+		"  Candidate: 0.36.2-9\n" +
+		"  Version table:\n" +
+		"     0.36.2-9 500\n"
+	if err := ufwCandidateVerdict(good); err != nil {
+		t.Errorf("real candidate refused: %v", err)
+	}
+
+	none := "ufw:\n  Installed: (none)\n  Candidate: (none)\n"
+	if err := ufwCandidateVerdict(none); err == nil {
+		t.Error("Candidate (none) accepted")
+	}
+
+	if err := ufwCandidateVerdict(""); err == nil {
+		t.Error("empty output accepted")
+	}
+}
+
+// ── report formatting ────────────────────────────────────
+
+func TestFormatPreflightReportAllPass(t *testing.T) {
+	out := FormatPreflightReport([]PreflightResult{
+		{Name: "check one", Err: nil},
+		{Name: "check two", Err: nil},
+	})
+	if !strings.Contains(out, "[ OK ] check one") ||
+		!strings.Contains(out, "[ OK ] check two") {
+		t.Errorf("missing OK lines:\n%s", out)
+	}
+	if strings.Contains(out, "Refusing to install") {
+		t.Errorf("refusal line present with zero failures:\n%s", out)
+	}
+}
+
+func TestFormatPreflightReportWithFailure(t *testing.T) {
+	out := FormatPreflightReport([]PreflightResult{
+		{Name: "check one", Err: nil},
+		{Name: "check two", Err: errors.New(
+			"something specific went wrong and here is a " +
+				"longer explanation that should wrap across lines")},
+	})
+	if !strings.Contains(out, "[FAIL] check two") {
+		t.Errorf("missing FAIL line:\n%s", out)
+	}
+	if !strings.Contains(out, "something specific went wrong") {
+		t.Errorf("missing failure reason:\n%s", out)
+	}
+	if !strings.Contains(out,
+		"Nothing on this system has been changed") {
+		t.Errorf("missing untouched-box line:\n%s", out)
+	}
+}
+
+// ── wrapText ─────────────────────────────────────────────
+
+func TestWrapText(t *testing.T) {
+	lines := wrapText("aa bb cc dd", 5)
+	want := []string{"aa bb", "cc dd"}
+	if len(lines) != len(want) {
+		t.Fatalf("got %d lines %v, want %v", len(lines), lines, want)
+	}
+	for i := range want {
+		if lines[i] != want[i] {
+			t.Errorf("line %d: got %q, want %q", i, lines[i], want[i])
+		}
+	}
+	if got := wrapText("", 10); got != nil {
+		t.Errorf("empty input: got %v, want nil", got)
+	}
+	// A word longer than the width gets its own unbroken line.
+	long := wrapText("short averyverylongword end", 6)
+	found := false
+	for _, l := range long {
+		if l == "averyverylongword" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("long word split or lost: %v", long)
+	}
+}
+
+// ── check names are stable report labels ─────────────────
+
+func TestPreflightCheckNamesNonEmpty(t *testing.T) {
+	for _, n := range []string{
+		checkNameDebian, checkNameSudo, checkNameTorsocks,
+		checkNameIOLogging, checkNameDpkg, checkNameUfw,
+	} {
+		if strings.TrimSpace(n) == "" {
+			t.Error("empty check name")
+		}
+	}
+}

--- a/internal/installer/setup.go
+++ b/internal/installer/setup.go
@@ -194,7 +194,10 @@ func RunInstallTUI(steps []InstallStep, version string) error {
 // ── Main install flow ────────────────────────────────────
 
 func Run() error {
-	if err := checkOS(); err != nil {
+	// Preflight (principle 3): assert the environment before the
+	// first mutation; refuses with a full report on any failure.
+	// Absorbs the old checkOS(). See preflight.go.
+	if err := RunPreflight(); err != nil {
 		return err
 	}
 

--- a/internal/installer/setup_test.go
+++ b/internal/installer/setup_test.go
@@ -4,7 +4,6 @@ package installer
 
 import (
 	"os"
-	"strconv"
 	"strings"
 	"testing"
 
@@ -111,34 +110,5 @@ func TestVersionCacheFileConsistency(t *testing.T) {
 	}
 }
 
-func TestCheckOSReadsFile(t *testing.T) {
-	err := checkOS()
-	if err != nil {
-		t.Logf("checkOS returned error (expected on non-Debian): %v", err)
-	}
-}
-
-func TestCheckOSVersionParsing(t *testing.T) {
-	tests := []struct {
-		ver  string
-		pass bool
-	}{
-		{"13", true},
-		{"14", true},
-		{"15", true},
-		{"12", false},
-		{"11", false},
-		{"9", false},
-	}
-	for _, tt := range tests {
-		verNum, err := strconv.Atoi(tt.ver)
-		if err != nil {
-			t.Fatalf("bad test version: %s", tt.ver)
-		}
-		result := verNum >= 13
-		if result != tt.pass {
-			t.Errorf("version %q >= 13: got %v, want %v",
-				tt.ver, result, tt.pass)
-		}
-	}
-}
+// The checkOS tests formerly here moved to preflight_test.go
+// (TestCheckOSRelease*), against the preflight's exactly-13 rule.

--- a/internal/installer/system.go
+++ b/internal/installer/system.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"os/user"
-	"strconv"
 	"strings"
 
 	"github.com/ripsline/virtual-private-node/internal/config"
@@ -14,33 +13,9 @@ import (
 	"github.com/ripsline/virtual-private-node/internal/system"
 )
 
-func checkOS() error {
-	data, err := os.ReadFile("/etc/os-release")
-	if err != nil {
-		return fmt.Errorf("cannot read /etc/os-release")
-	}
-	content := string(data)
-	if !strings.Contains(content, "ID=debian") {
-		return fmt.Errorf("requires Debian 13+")
-	}
-	for _, line := range strings.Split(content, "\n") {
-		if strings.HasPrefix(line, "VERSION_ID=") {
-			ver := strings.Trim(
-				strings.TrimPrefix(line, "VERSION_ID="), `"`)
-			verNum, err := strconv.Atoi(ver)
-			if err != nil {
-				return fmt.Errorf(
-					"cannot parse Debian version: %s", ver)
-			}
-			if verNum < 13 {
-				return fmt.Errorf(
-					"requires Debian 13+, found %s", ver)
-			}
-			return nil
-		}
-	}
-	return fmt.Errorf("cannot determine Debian version")
-}
+// The OS check formerly here (checkOS, Debian 13-or-newer) is
+// superseded by the preflight's exactly-13 assertion (ruling ix).
+// See preflight.go.
 
 func createSystemUser(username string) error {
 	if _, err := user.Lookup(username); err == nil {

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -85,6 +85,10 @@ const (
 // ── System ───────────────────────────────────────────────
 
 const (
+	OSRelease   = "/etc/os-release"
+	SudoersFile = "/etc/sudoers"
+	SudoersDir  = "/etc/sudoers.d"
+
 	SyncthingConfigXML = "/etc/syncthing/config.xml"
 	UFWDefault         = "/etc/default/ufw"
 	SSHDConfig         = "/etc/ssh/sshd_config"


### PR DESCRIPTION
The installer previously discovered environment problems only when a step failed partway through, leaving a half configured box. It now verifies the environment up front and refuses cleanly, before anything is modified.

Six read only checks run before the first install step. The OS must be exactly Debian 13: every system command this app relies on has been verified against that release, and other releases are refused until they are verified too. The sudo configuration must not enable input or output recording, which would write the admin password to a log file at the moment the app sets it. The remaining checks assert that passwordless sudo works, torsocks is present, the package database is healthy, and the firewall package is installable. Failures are reported together, each with a fix hint, and mirrored to the app log.

A refused box is untouched, so fixing the problem and retrying is always safe. The parsing rules behind the checks are pure functions with unit tests covering both directions of each rule.