### PR TITLE
fix: interrupted installs are no longer recorded as complete

### DIFF
--- a/internal/installer/engine.go
+++ b/internal/installer/engine.go
@@ -1,0 +1,345 @@
+// internal/installer/engine.go
+
+package installer
+
+import (
+	"fmt"
+
+	"github.com/ripsline/virtual-private-node/internal/logger"
+)
+
+// ── Install engine core ──────────────────────────────────
+//
+// The step model, resume planner, and step executor — with no
+// rendering. Front-ends are thin: the initial-install TUI
+// (setup.go) and the unattended runner (below) both drive the
+// same runner, so ledger recording, skip decisions, and the
+// log trail cannot diverge between them, and a failed or
+// interrupted run reaches /var/log/rlvpn.log identically from
+// either.
+//
+// Resume rules (one place, ruled 2026-07-16):
+//
+//   - MUTATION steps trust the ledger: a recorded completion
+//     is skipped. The ledger records completion, not present
+//     correctness — see the ledger.go header for the residual.
+//   - GATE steps assert a property of the world RIGHT NOW
+//     (Tor routing) and are ALWAYS re-executed, never
+//     ledger-skipped. No download step can run in a pass whose
+//     Tor routing was not verified in that same pass — by step
+//     type, not by ordering luck.
+//   - GROUP steps pass ephemeral material hand-to-hand (a
+//     MkdirTemp workdir captured in closures: download →
+//     verify → install). The workdir does not survive the
+//     process, so a group is ATOMIC for resume: it counts as
+//     complete only if its TERMINAL step (last member in list
+//     order) is recorded; otherwise every member re-runs.
+//     Re-running a download pipeline is self-verifying by
+//     construction (fresh GPG + checksum).
+
+// StepKind classifies a step for resume.
+type StepKind int
+
+const (
+	// StepMutation changes the box; its recorded completion is
+	// trusted for skipping on resume.
+	StepMutation StepKind = iota
+	// StepGate asserts the world now; it re-runs on every pass
+	// regardless of the ledger.
+	StepGate
+)
+
+// StepPhase classifies a step for the image pipeline (ruling
+// iv): bake steps run at image-build time, first-boot steps
+// must run on the deployed box (identity, hardware). Commit 5
+// ships the mechanism; the phase map is ratified by the image
+// track. All current steps are provisionally PhaseBake.
+type StepPhase int
+
+const (
+	PhaseBake StepPhase = iota
+	PhaseFirstBoot
+)
+
+type StepStatus int
+
+const (
+	StepPending StepStatus = iota
+	StepRunning
+	StepDone
+	StepFailed
+	// StepSkipped renders a resume skip: the ledger records a
+	// prior completion, the step did not execute this pass.
+	StepSkipped
+)
+
+type InstallStep struct {
+	// Key is the stable, versionless ledger key ("tor.install",
+	// "btc.download"). Names carry versions and copy edits; keys
+	// identify the step across binary versions. Runtime step
+	// lists (P2P upgrade, Syncthing) leave Key empty — they run
+	// through the welcome engine and never touch the ledger.
+	Key string
+	// Name is display-only.
+	Name  string
+	Fn    func() error
+	Kind  StepKind
+	Group string // resume-atomic pipeline; "" = self-contained
+	Phase StepPhase
+
+	Status StepStatus
+	Err    error
+}
+
+// validateSteps asserts the invariants the planner relies on:
+// every key non-empty and unique. Programmer error, not
+// environment — so it is checked once at engine start and
+// returned as an error rather than silently misplanned.
+func validateSteps(steps []InstallStep) error {
+	seen := make(map[string]bool, len(steps))
+	for i, s := range steps {
+		if s.Key == "" {
+			return fmt.Errorf(
+				"install step %d (%s) has no key", i+1, s.Name)
+		}
+		if seen[s.Key] {
+			return fmt.Errorf(
+				"install step key %q duplicated", s.Key)
+		}
+		seen[s.Key] = true
+	}
+	return nil
+}
+
+// stepPlan is the planner's decision for one step.
+type stepPlan struct {
+	Run    bool
+	Reason string // human-readable cause, logged verbatim
+}
+
+// planRun decides, for every step, run vs skip — the whole
+// resume ruling as one pure function (unit-tested per
+// scenario; no I/O, no clock).
+func planRun(steps []InstallStep, led *installLedger) []stepPlan {
+	// Terminal member of each group = last in list order.
+	terminal := map[string]string{} // group → terminal key
+	for _, s := range steps {
+		if s.Group != "" {
+			terminal[s.Group] = s.Key
+		}
+	}
+
+	plan := make([]stepPlan, len(steps))
+	for i, s := range steps {
+		switch {
+		case s.Kind == StepGate:
+			plan[i] = stepPlan{Run: true,
+				Reason: "gate: re-verified every pass"}
+		case s.Group != "":
+			tk := terminal[s.Group]
+			if led.done(tk) {
+				e := led.Steps[tk]
+				plan[i] = stepPlan{Run: false, Reason: fmt.Sprintf(
+					"group %q complete (terminal %s done by v%s at %s)",
+					s.Group, tk, e.Version, e.CompletedAt)}
+			} else {
+				plan[i] = stepPlan{Run: true, Reason: fmt.Sprintf(
+					"group %q incomplete: re-runs whole "+
+						"(ephemeral workdir)", s.Group)}
+			}
+		case led.done(s.Key):
+			e := led.Steps[s.Key]
+			plan[i] = stepPlan{Run: false, Reason: fmt.Sprintf(
+				"completed by v%s at %s", e.Version, e.CompletedAt)}
+		default:
+			plan[i] = stepPlan{Run: true, Reason: "not yet completed"}
+		}
+	}
+	return plan
+}
+
+// FilterPhase returns the steps whose Phase is at or before
+// until — the image pipeline's `--until=bake` slice (ruling
+// iv plumbing; the CLI that passes a phase arrives with the
+// commit-6 dispatch).
+func FilterPhase(steps []InstallStep, until StepPhase) []InstallStep {
+	var out []InstallStep
+	for _, s := range steps {
+		if s.Phase <= until {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// ── Runner ───────────────────────────────────────────────
+
+type stepRunner struct {
+	steps      []InstallStep
+	plan       []stepPlan
+	ledger     *installLedger
+	ledgerPath string
+	version    string
+}
+
+func newStepRunner(
+	steps []InstallStep, version, ledgerPath string,
+) (*stepRunner, error) {
+	if err := validateSteps(steps); err != nil {
+		return nil, err
+	}
+	led := loadLedger(ledgerPath)
+	plan := planRun(steps, led)
+	toRun := 0
+	for _, p := range plan {
+		if p.Run {
+			toRun++
+		}
+	}
+	if toRun < len(steps) {
+		logger.Install(
+			"resume: %d/%d steps already complete, running %d",
+			len(steps)-toRun, len(steps), toRun)
+	}
+	return &stepRunner{
+		steps:      steps,
+		plan:       plan,
+		ledger:     led,
+		ledgerPath: ledgerPath,
+		version:    version,
+	}, nil
+}
+
+// runIndex executes one step per the plan. Every path leaves a
+// log line — start, skip, complete, FAILED — so a run's trail
+// in rlvpn.log never just stops (the commit-5 addendum fix,
+// once, in the core). The ledger entry is written only after
+// Fn returns nil; a ledger persist failure is logged and does
+// NOT fail the step (this run's authority is its in-process
+// results — the ledger serves the NEXT process, and the
+// fail-safe cost is a re-run, not a wrong skip).
+func (r *stepRunner) runIndex(i int) (skipped bool, err error) {
+	s := &r.steps[i]
+	n, total := i+1, len(r.steps)
+	if !r.plan[i].Run {
+		logger.Install("step %d/%d skipped: %s (%s)",
+			n, total, s.Name, r.plan[i].Reason)
+		return true, nil
+	}
+	logger.Install("step %d/%d starting: %s", n, total, s.Name)
+	if err := s.Fn(); err != nil {
+		logger.Install("step %d/%d FAILED: %s: %v",
+			n, total, s.Name, err)
+		return false, err
+	}
+	r.ledger.markDone(s.Key, r.version)
+	if err := r.ledger.save(r.ledgerPath); err != nil {
+		logger.Install(
+			"WARNING: step %d/%d complete but ledger save "+
+				"failed (a re-run repeats it): %v", n, total, err)
+	}
+	logger.Install("step %d/%d complete: %s", n, total, s.Name)
+	return false, nil
+}
+
+// ── Outcomes ─────────────────────────────────────────────
+
+// RunOutcome distinguishes the three ways a run ends. Only
+// RunComplete may reach the InstallComplete write (IA-1-9's
+// fix): completion is derived from per-step results, never
+// from a front-end returning cleanly.
+type RunOutcome int
+
+const (
+	RunComplete RunOutcome = iota
+	RunFailed
+	RunInterrupted
+)
+
+type RunResult struct {
+	Outcome  RunOutcome
+	StepName string // failed / interrupted-at step ("" if complete)
+	StepNum  int    // 1-based
+	Total    int
+	Err      error // the failed step's error
+}
+
+// classifyRun folds a front-end's final state into a
+// RunResult. Pure — the TUI passes its flags, tests pass
+// theirs. An exit after done-and-not-failed is COMPLETE even
+// if the operator left with ctrl+c instead of enter: the steps
+// all ran; how the render loop was dismissed is irrelevant.
+func classifyRun(
+	steps []InstallStep, done, failed bool, current int,
+) RunResult {
+	total := len(steps)
+	if failed {
+		for i, s := range steps {
+			if s.Status == StepFailed {
+				return RunResult{
+					Outcome:  RunFailed,
+					StepName: s.Name,
+					StepNum:  i + 1,
+					Total:    total,
+					Err:      s.Err,
+				}
+			}
+		}
+		// Marked failed with no failed step recorded —
+		// impossible by construction; refuse to call it
+		// complete (fail-safe direction).
+		return RunResult{Outcome: RunFailed, Total: total,
+			Err: fmt.Errorf("install failed (step unknown)")}
+	}
+	if done {
+		return RunResult{Outcome: RunComplete, Total: total}
+	}
+	name := ""
+	if current >= 0 && current < total {
+		name = steps[current].Name
+	}
+	return RunResult{
+		Outcome:  RunInterrupted,
+		StepName: name,
+		StepNum:  current + 1,
+		Total:    total,
+	}
+}
+
+// ── Unattended front-end (ruling iv plumbing) ────────────
+
+// RunInstallUnattended executes steps with no TUI: one plain
+// line per step to stdout, same runner, same ledger, same log
+// trail. No CLI reaches it yet — its consumers are the
+// commit-6 `vpn install --unattended` dispatch and the image
+// build pipeline. Interruption needs no handling here: a
+// killed process leaves the ledger truthful by write ordering.
+func RunInstallUnattended(
+	steps []InstallStep, version, ledgerPath string,
+) (RunResult, error) {
+	r, err := newStepRunner(steps, version, ledgerPath)
+	if err != nil {
+		return RunResult{}, err
+	}
+	total := len(steps)
+	for i := range steps {
+		skipped, err := r.runIndex(i)
+		switch {
+		case err != nil:
+			steps[i].Status = StepFailed
+			steps[i].Err = err
+			fmt.Printf("  [FAIL] [%d/%d] %s: %v\n",
+				i+1, total, steps[i].Name, err)
+			return classifyRun(steps, false, true, i), nil
+		case skipped:
+			steps[i].Status = StepSkipped
+			fmt.Printf("  [skip] [%d/%d] %s\n",
+				i+1, total, steps[i].Name)
+		default:
+			steps[i].Status = StepDone
+			fmt.Printf("  [done] [%d/%d] %s\n",
+				i+1, total, steps[i].Name)
+		}
+	}
+	return classifyRun(steps, true, false, total), nil
+}

--- a/internal/installer/engine_test.go
+++ b/internal/installer/engine_test.go
@@ -1,0 +1,351 @@
+// internal/installer/engine_test.go
+
+package installer
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"testing"
+)
+
+// testSteps builds a miniature install list with the shapes
+// that matter: plain mutations, a gate, and a 3-member
+// pipeline group. Fns count executions into calls.
+func testSteps(calls map[string]int) []InstallStep {
+	fn := func(key string) func() error {
+		return func() error {
+			calls[key]++
+			return nil
+		}
+	}
+	return []InstallStep{
+		{Key: "user.create", Name: "Creating user",
+			Fn: fn("user.create")},
+		{Key: "tor.install", Name: "Installing Tor",
+			Fn: fn("tor.install")},
+		{Key: "tor.gate", Name: "Verifying Tor routing",
+			Kind: StepGate, Fn: fn("tor.gate")},
+		{Key: "btc.download", Group: "btc", Name: "Downloading",
+			Fn: fn("btc.download")},
+		{Key: "btc.verify", Group: "btc", Name: "Verifying",
+			Fn: fn("btc.verify")},
+		{Key: "btc.install", Group: "btc", Name: "Installing",
+			Fn: fn("btc.install")},
+		{Key: "shellenv", Name: "Shell environment",
+			Fn: fn("shellenv")},
+	}
+}
+
+func keysToRun(steps []InstallStep, plan []stepPlan) []string {
+	var out []string
+	for i, p := range plan {
+		if p.Run {
+			out = append(out, steps[i].Key)
+		}
+	}
+	return out
+}
+
+func sameKeys(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestValidateSteps(t *testing.T) {
+	ok := testSteps(map[string]int{})
+	if err := validateSteps(ok); err != nil {
+		t.Errorf("valid steps rejected: %v", err)
+	}
+
+	dup := testSteps(map[string]int{})
+	dup[1].Key = "user.create"
+	if err := validateSteps(dup); err == nil {
+		t.Error("duplicate key accepted")
+	}
+
+	empty := testSteps(map[string]int{})
+	empty[2].Key = ""
+	if err := validateSteps(empty); err == nil {
+		t.Error("empty key accepted")
+	}
+}
+
+func TestPlanScenarios(t *testing.T) {
+	all := []string{"user.create", "tor.install", "tor.gate",
+		"btc.download", "btc.verify", "btc.install", "shellenv"}
+
+	cases := []struct {
+		name    string
+		done    []string // pre-recorded ledger keys
+		wantRun []string
+	}{
+		{
+			name:    "fresh install runs everything",
+			done:    nil,
+			wantRun: all,
+		},
+		{
+			name:    "all done: only the gate re-runs",
+			done:    all,
+			wantRun: []string{"tor.gate"},
+		},
+		{
+			name: "resume after step 2: gate re-runs, rest forward",
+			done: []string{"user.create", "tor.install"},
+			wantRun: []string{"tor.gate", "btc.download",
+				"btc.verify", "btc.install", "shellenv"},
+		},
+		{
+			// THE group test: download+verify recorded but the
+			// terminal (btc.install) is not — the whole group
+			// re-runs (the workdir died with the old process).
+			name: "incomplete group re-runs whole",
+			done: []string{"user.create", "tor.install",
+				"btc.download", "btc.verify"},
+			wantRun: []string{"tor.gate", "btc.download",
+				"btc.verify", "btc.install", "shellenv"},
+		},
+		{
+			// Terminal recorded: the group is complete even if
+			// member entries are absent (only the terminal is
+			// consulted for group members).
+			name: "group judged by terminal only",
+			done: []string{"user.create", "tor.install",
+				"btc.install"},
+			wantRun: []string{"tor.gate", "shellenv"},
+		},
+		{
+			name: "unknown ledger keys ignored",
+			done: []string{"user.create", "no.such.step",
+				"another.ghost"},
+			wantRun: []string{"tor.install", "tor.gate",
+				"btc.download", "btc.verify", "btc.install",
+				"shellenv"},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			led := newLedger()
+			for _, k := range c.done {
+				led.markDone(k, "0.6.3")
+			}
+			steps := testSteps(map[string]int{})
+			plan := planRun(steps, led)
+			got := keysToRun(steps, plan)
+			if !sameKeys(got, c.wantRun) {
+				t.Errorf("run set = %v, want %v", got, c.wantRun)
+			}
+		})
+	}
+}
+
+// The gate must re-run even when its own key is recorded —
+// a recorded gate means "it held on some earlier pass," which
+// is exactly what a gate must never rely on.
+func TestPlanGateIgnoresOwnLedgerEntry(t *testing.T) {
+	led := newLedger()
+	led.markDone("tor.gate", "0.6.3")
+	steps := testSteps(map[string]int{})
+	plan := planRun(steps, led)
+	if !plan[2].Run {
+		t.Fatal("gate was ledger-skipped")
+	}
+}
+
+func TestFilterPhase(t *testing.T) {
+	steps := []InstallStep{
+		{Key: "a", Phase: PhaseBake},
+		{Key: "b", Phase: PhaseFirstBoot},
+		{Key: "c", Phase: PhaseBake},
+	}
+	bake := FilterPhase(steps, PhaseBake)
+	if len(bake) != 2 || bake[0].Key != "a" || bake[1].Key != "c" {
+		t.Errorf("bake filter = %v", bake)
+	}
+	allSteps := FilterPhase(steps, PhaseFirstBoot)
+	if len(allSteps) != 3 {
+		t.Errorf("first-boot filter kept %d of 3", len(allSteps))
+	}
+}
+
+func TestRunnerSkipDoesNotExecute(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.json")
+	led := newLedger()
+	led.markDone("user.create", "0.6.3")
+	if err := led.save(path); err != nil {
+		t.Fatal(err)
+	}
+
+	calls := map[string]int{}
+	r, err := newStepRunner(testSteps(calls), "0.6.3", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	skipped, err := r.runIndex(0)
+	if err != nil {
+		t.Fatalf("runIndex: %v", err)
+	}
+	if !skipped {
+		t.Error("recorded step not skipped")
+	}
+	if calls["user.create"] != 0 {
+		t.Error("skipped step's Fn executed")
+	}
+}
+
+func TestRunnerRecordsAfterSuccessOnly(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.json")
+	calls := map[string]int{}
+	steps := testSteps(calls)
+	boom := errors.New("boom")
+	steps[1].Fn = func() error { return boom }
+
+	r, err := newStepRunner(steps, "0.6.3", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Success: entry lands on disk.
+	if _, err := r.runIndex(0); err != nil {
+		t.Fatalf("step 0: %v", err)
+	}
+	if !loadLedger(path).done("user.create") {
+		t.Error("completed step not recorded on disk")
+	}
+
+	// Failure: no entry, error surfaced.
+	_, err = r.runIndex(1)
+	if !errors.Is(err, boom) {
+		t.Fatalf("step 1 err = %v, want boom", err)
+	}
+	if loadLedger(path).done("tor.install") {
+		t.Error("failed step recorded as done")
+	}
+}
+
+func TestClassifyRun(t *testing.T) {
+	steps := testSteps(map[string]int{})
+	total := len(steps)
+
+	res := classifyRun(steps, true, false, total)
+	if res.Outcome != RunComplete {
+		t.Errorf("complete run classified %v", res.Outcome)
+	}
+
+	failed := testSteps(map[string]int{})
+	failed[3].Status = StepFailed
+	failed[3].Err = errors.New("download failed")
+	res = classifyRun(failed, true, true, 3)
+	if res.Outcome != RunFailed {
+		t.Errorf("failed run classified %v", res.Outcome)
+	}
+	if res.StepNum != 4 || res.StepName != "Downloading" {
+		t.Errorf("failure attributed to %d/%q",
+			res.StepNum, res.StepName)
+	}
+	if res.Err == nil {
+		t.Error("failed run lost its error")
+	}
+
+	// Quit mid-run: done=false → interrupted, at the current
+	// step — never complete.
+	res = classifyRun(steps, false, false, 2)
+	if res.Outcome != RunInterrupted {
+		t.Errorf("interrupted run classified %v", res.Outcome)
+	}
+	if res.StepNum != 3 || res.StepName != "Verifying Tor routing" {
+		t.Errorf("interrupt attributed to %d/%q",
+			res.StepNum, res.StepName)
+	}
+
+	// Failed flag with no failed step: fail-safe, never complete.
+	res = classifyRun(steps, true, true, total)
+	if res.Outcome != RunFailed {
+		t.Errorf("inconsistent state classified %v (must fail safe)",
+			res.Outcome)
+	}
+}
+
+func TestRunInstallUnattendedCompleteAndResume(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.json")
+
+	// First pass: everything runs, outcome complete.
+	calls := map[string]int{}
+	res, err := RunInstallUnattended(testSteps(calls), "0.6.3", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Outcome != RunComplete {
+		t.Fatalf("first pass outcome %v", res.Outcome)
+	}
+	for k, n := range calls {
+		if n != 1 {
+			t.Errorf("first pass ran %s %d times", k, n)
+		}
+	}
+
+	// Second pass over the same ledger: only the gate runs.
+	calls2 := map[string]int{}
+	res, err = RunInstallUnattended(testSteps(calls2), "0.6.3", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Outcome != RunComplete {
+		t.Fatalf("second pass outcome %v", res.Outcome)
+	}
+	for k, n := range calls2 {
+		want := 0
+		if k == "tor.gate" {
+			want = 1
+		}
+		if n != want {
+			t.Errorf("second pass ran %s %d times, want %d",
+				k, n, want)
+		}
+	}
+}
+
+func TestRunInstallUnattendedFailureStops(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.json")
+	calls := map[string]int{}
+	steps := testSteps(calls)
+	steps[2].Fn = func() error {
+		calls["tor.gate"]++
+		return fmt.Errorf("tor not routing")
+	}
+
+	res, err := RunInstallUnattended(steps, "0.6.3", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Outcome != RunFailed {
+		t.Fatalf("outcome %v, want RunFailed", res.Outcome)
+	}
+	if res.StepNum != 3 {
+		t.Errorf("failed at %d, want 3", res.StepNum)
+	}
+	// Nothing after the failure ran.
+	for _, k := range []string{"btc.download", "btc.verify",
+		"btc.install", "shellenv"} {
+		if calls[k] != 0 {
+			t.Errorf("%s ran after the failure", k)
+		}
+	}
+	// Steps before it are recorded; the gate is not.
+	led := loadLedger(path)
+	if !led.done("user.create") || !led.done("tor.install") {
+		t.Error("pre-failure steps not recorded")
+	}
+	if led.done("tor.gate") {
+		t.Error("failed gate recorded as done")
+	}
+}

--- a/internal/installer/ledger.go
+++ b/internal/installer/ledger.go
@@ -1,0 +1,158 @@
+// internal/installer/ledger.go
+
+package installer
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/ripsline/virtual-private-node/internal/logger"
+)
+
+// ── Install ledger ───────────────────────────────────────
+//
+// The ledger is the durable record of which install steps have
+// completed. It answers exactly one question — "did this step
+// ever complete?" — and that answer gates resume skipping and
+// the InstallComplete flag. It deliberately does NOT claim the
+// box is currently correct: a recorded outcome can drift after
+// it is written (a package removed by hand, a snapshot
+// restored). Load-bearing drift surfaces as a later step
+// failing; leaf drift may not surface during a run at all. The
+// present-tense question belongs to a doctor-style health
+// check, not to resume-time probes.
+//
+// An entry is written ONLY after a step's Fn returned nil, so
+// process death at any instant — ctrl+c, connection drop,
+// power — leaves either a truthful entry or no entry.
+// Crash-safety comes from that write ordering, not from
+// shutdown handling.
+//
+// Failure direction on load: a missing file is a fresh
+// install; an unreadable or corrupt file is treated as EMPTY
+// with a logged warning. The worst case of an empty ledger is
+// redoing work; the worst case of a trusted-but-wrong ledger
+// would be wrongly skipping it. Empty is the fail-safe side.
+//
+// The ledger lives in its own file (paths.InstallStateFile),
+// not in config.json: a config load failure must not erase
+// install history, and the file's ownership story is
+// independent of config's (root-owned once install runs under
+// root dispatch).
+
+// ledgerSchema is the current on-disk schema version. A file
+// carrying a HIGHER schema was written by a newer binary; its
+// semantics are unknown to us, so it is treated as empty
+// (fail-safe: full re-run, never a wrong skip).
+const ledgerSchema = 1
+
+type ledgerEntry struct {
+	CompletedAt string `json:"completed_at"`
+	Version     string `json:"version"`
+}
+
+type installLedger struct {
+	Schema int                    `json:"schema"`
+	Steps  map[string]ledgerEntry `json:"steps"`
+}
+
+func newLedger() *installLedger {
+	return &installLedger{
+		Schema: ledgerSchema,
+		Steps:  map[string]ledgerEntry{},
+	}
+}
+
+// parseLedger interprets raw ledger bytes. Pure function —
+// separated from file I/O so every corrupt-input shape is
+// unit-testable. Any defect in the bytes yields an error; the
+// caller substitutes an empty ledger.
+func parseLedger(data []byte) (*installLedger, error) {
+	var l installLedger
+	if err := json.Unmarshal(data, &l); err != nil {
+		return nil, fmt.Errorf("unmarshal: %w", err)
+	}
+	if l.Schema > ledgerSchema {
+		return nil, fmt.Errorf(
+			"schema %d is newer than supported %d",
+			l.Schema, ledgerSchema)
+	}
+	if l.Steps == nil {
+		l.Steps = map[string]ledgerEntry{}
+	}
+	l.Schema = ledgerSchema
+	return &l, nil
+}
+
+// loadLedger reads the ledger at path. It never fails: missing
+// means fresh install, unreadable/corrupt means empty with a
+// logged warning (see the failure-direction note above).
+func loadLedger(path string) *installLedger {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			logger.Install(
+				"WARNING: install ledger unreadable, "+
+					"treating as empty (full run): %v", err)
+		}
+		return newLedger()
+	}
+	l, err := parseLedger(data)
+	if err != nil {
+		logger.Install(
+			"WARNING: install ledger corrupt, "+
+				"treating as empty (full run): %v", err)
+		return newLedger()
+	}
+	return l
+}
+
+func (l *installLedger) done(key string) bool {
+	_, ok := l.Steps[key]
+	return ok
+}
+
+func (l *installLedger) markDone(key, version string) {
+	l.Steps[key] = ledgerEntry{
+		CompletedAt: time.Now().UTC().Format(time.RFC3339),
+		Version:     version,
+	}
+}
+
+// save writes the ledger atomically: same-dir temp file, chmod,
+// sync, rename — the config.Save pattern, so the file is never
+// partially written.
+func (l *installLedger) save(path string) error {
+	data, err := json.MarshalIndent(l, "", "  ")
+	if err != nil {
+		return err
+	}
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".install-state-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp ledger: %w", err)
+	}
+	tmpPath := tmp.Name()
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := tmp.Chmod(0600); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	tmp.Close()
+
+	return os.Rename(tmpPath, path)
+}

--- a/internal/installer/ledger_test.go
+++ b/internal/installer/ledger_test.go
@@ -1,0 +1,153 @@
+// internal/installer/ledger_test.go
+
+package installer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseLedgerValid(t *testing.T) {
+	data := []byte(`{
+  "schema": 1,
+  "steps": {
+    "tor.install": {
+      "completed_at": "2026-07-16T14:02:11Z",
+      "version": "0.6.3"
+    }
+  }
+}`)
+	l, err := parseLedger(data)
+	if err != nil {
+		t.Fatalf("parseLedger: %v", err)
+	}
+	if !l.done("tor.install") {
+		t.Error("tor.install should be done")
+	}
+	if l.done("tor.gate") {
+		t.Error("tor.gate should not be done")
+	}
+	e := l.Steps["tor.install"]
+	if e.Version != "0.6.3" {
+		t.Errorf("version = %q, want 0.6.3", e.Version)
+	}
+}
+
+func TestParseLedgerCorrupt(t *testing.T) {
+	cases := []struct {
+		name string
+		data string
+	}{
+		{"garbage", "not json at all"},
+		{"truncated", `{"schema":1,"steps":{`},
+		{"wrong shape", `{"schema":"one"}`},
+		{"empty", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if _, err := parseLedger([]byte(c.data)); err == nil {
+				t.Errorf("parseLedger(%q) should error", c.data)
+			}
+		})
+	}
+}
+
+// A ledger written by a NEWER binary has unknown semantics —
+// it must be rejected (caller then treats it as empty; the
+// fail-safe cost is a full re-run, never a wrong skip).
+func TestParseLedgerFutureSchema(t *testing.T) {
+	if _, err := parseLedger(
+		[]byte(`{"schema": 2, "steps": {}}`)); err == nil {
+		t.Error("future schema should be rejected")
+	}
+}
+
+func TestParseLedgerNilStepsMap(t *testing.T) {
+	l, err := parseLedger([]byte(`{"schema": 1}`))
+	if err != nil {
+		t.Fatalf("parseLedger: %v", err)
+	}
+	if l.Steps == nil {
+		t.Fatal("Steps map must be non-nil after parse")
+	}
+	// Writable without panic.
+	l.markDone("x", "test")
+}
+
+func TestLoadLedgerMissingFile(t *testing.T) {
+	l := loadLedger(filepath.Join(t.TempDir(), "absent.json"))
+	if l == nil {
+		t.Fatal("loadLedger returned nil")
+	}
+	if len(l.Steps) != 0 {
+		t.Errorf("missing file should load empty, got %d entries",
+			len(l.Steps))
+	}
+}
+
+func TestLoadLedgerCorruptFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.json")
+	if err := os.WriteFile(
+		path, []byte("{corrupt"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	l := loadLedger(path)
+	if len(l.Steps) != 0 {
+		t.Errorf("corrupt file should load empty, got %d entries",
+			len(l.Steps))
+	}
+}
+
+func TestLedgerRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.json")
+	l := newLedger()
+	l.markDone("user.create", "0.6.3")
+	l.markDone("tor.install", "0.6.3")
+	if err := l.save(path); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	got := loadLedger(path)
+	for _, key := range []string{"user.create", "tor.install"} {
+		if !got.done(key) {
+			t.Errorf("%s lost in round trip", key)
+		}
+	}
+	if got.done("btc.install") {
+		t.Error("btc.install should not be done")
+	}
+	e := got.Steps["user.create"]
+	if e.Version != "0.6.3" {
+		t.Errorf("version = %q, want 0.6.3", e.Version)
+	}
+	if e.CompletedAt == "" {
+		t.Error("completed_at empty")
+	}
+}
+
+func TestLedgerSaveOverwrites(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.json")
+	l := newLedger()
+	l.markDone("a", "1")
+	if err := l.save(path); err != nil {
+		t.Fatal(err)
+	}
+	l.markDone("b", "1")
+	if err := l.save(path); err != nil {
+		t.Fatal(err)
+	}
+	got := loadLedger(path)
+	if !got.done("a") || !got.done("b") {
+		t.Error("second save lost entries")
+	}
+	// No stray temp files left behind.
+	entries, err := os.ReadDir(filepath.Dir(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Errorf("expected only the ledger in dir, found %d entries",
+			len(entries))
+	}
+}

--- a/internal/installer/setup.go
+++ b/internal/installer/setup.go
@@ -42,34 +42,24 @@ func NeedsInstall() bool {
 	return !cfg.InstallComplete
 }
 
-// ── Install step types ──────────────────────────────────
-// Exported for use by welcome.InstallProgressScreen.
-// The step functions themselves stay unexported — callers
-// use the builder functions below to get step slices.
-
-type StepStatus int
-
-const (
-	StepPending StepStatus = iota
-	StepRunning
-	StepDone
-	StepFailed
-)
-
-type InstallStep struct {
-	Name   string
-	Fn     func() error
-	Status StepStatus
-	Err    error
-}
+// ── Initial-install TUI front-end ────────────────────────
+// The step model (InstallStep, StepStatus, StepKind, Group,
+// Phase), the resume planner, and the step runner live in
+// engine.go; the ledger lives in ledger.go. This file owns
+// the interactive front-end and the step lists. The front-end
+// renders what the runner reports — it makes no skip or
+// record decisions of its own, so the TUI and the unattended
+// runner cannot diverge.
 
 type stepDoneMsg struct {
-	index int
-	err   error
+	index   int
+	skipped bool
+	err     error
 }
 
 type installModel struct {
 	steps         []InstallStep
+	runner        *stepRunner
 	current       int
 	done, failed  bool
 	version       string
@@ -83,7 +73,8 @@ func (m installModel) runStep(i int) tea.Cmd {
 		if i >= len(m.steps) {
 			return stepDoneMsg{index: i}
 		}
-		return stepDoneMsg{index: i, err: m.steps[i].Fn()}
+		skipped, err := m.runner.runIndex(i)
+		return stepDoneMsg{index: i, skipped: skipped, err: err}
 	}
 }
 
@@ -97,6 +88,13 @@ func (m installModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 		}
 		if msg.String() == "ctrl+c" {
+			// Quitting is allowed at any instant — an
+			// interrupt is SAFE now (the ledger records a
+			// step only after it verified complete, so any
+			// death leaves a truthful record) — and it is
+			// HONEST: a quit before all steps ran leaves
+			// m.done false, which classifies the run as
+			// interrupted, never complete (IA-1-9).
 			return m, tea.Quit
 		}
 	case stepDoneMsg:
@@ -108,7 +106,11 @@ func (m installModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.done = true
 				return m, nil
 			}
-			m.steps[msg.index].Status = StepDone
+			if msg.skipped {
+				m.steps[msg.index].Status = StepSkipped
+			} else {
+				m.steps[msg.index].Status = StepDone
+			}
 			next := msg.index + 1
 			if next < len(m.steps) {
 				m.current = next
@@ -139,6 +141,10 @@ func (m installModel) View() tea.View {
 			sty, ind = theme.ProgRunning, "[....]"
 		case StepFailed:
 			sty, ind = theme.ProgFail, "[FAIL]"
+		case StepSkipped:
+			// Resume skip: completed by an earlier run
+			// (per the install ledger).
+			sty, ind = theme.Dim, "[skip]"
 		default:
 			sty, ind = theme.ProgPending, "[wait]"
 		}
@@ -169,26 +175,40 @@ func (m installModel) View() tea.View {
 	return v
 }
 
-func RunInstallTUI(steps []InstallStep, version string) error {
+// RunInstallTUI runs the initial-install steps under the
+// interactive front-end and reports HOW the run ended —
+// complete, failed, or interrupted — via RunResult. It no
+// longer collapses "the TUI returned" into "the install
+// succeeded": that inference was IA-1-9 (a swallowed ctrl+c
+// returned cleanly and was recorded as a complete install).
+// The caller decides what each outcome means; only
+// RunComplete may reach the InstallComplete write.
+func RunInstallTUI(
+	steps []InstallStep, version string,
+) (RunResult, error) {
 	if len(steps) == 0 {
-		return nil
+		return RunResult{Outcome: RunComplete}, nil
+	}
+	runner, err := newStepRunner(
+		steps, version, paths.InstallStateFile)
+	if err != nil {
+		return RunResult{}, err
 	}
 	steps[0].Status = StepRunning
-	m := installModel{steps: steps, version: version}
+	m := installModel{
+		steps: steps, runner: runner, version: version,
+	}
 	p := tea.NewProgram(m)
 	result, err := p.Run()
 	if err != nil {
-		return err
+		return RunResult{}, err
 	}
 	final := result.(installModel)
-	if final.failed {
-		for _, s := range final.steps {
-			if s.Status == StepFailed {
-				return fmt.Errorf("%s: %w", s.Name, s.Err)
-			}
-		}
-	}
-	return nil
+	// done=false here means the render loop was quit before
+	// the last step reported — an interrupt, by any cause.
+	return classifyRun(final.steps,
+		final.done && !final.failed,
+		final.failed, final.current), nil
 }
 
 // ── Main install flow ────────────────────────────────────
@@ -206,43 +226,82 @@ func Run() error {
 		cfg = preCfg
 	}
 
-	// LND is now installed during initial setup (Tor-only default).
-	// Set config fields before buildSteps so Tor config and firewall
-	// rules include LND hidden services and ports.
+	// LND is installed during initial setup (Tor-only default).
+	// These fields are set IN MEMORY before buildSteps because
+	// the steps read them (Tor config and firewall rules include
+	// LND hidden services and ports) — but they are PERSISTED
+	// only on a complete run, below. A failed or interrupted run
+	// must not record intent as fact (IA-1-9: Gate 0 observed
+	// lnd_installed:true on disk for software never downloaded).
 	cfg.P2PMode = "tor"
 	cfg.LNDInstalled = true
 	cfg.Components = "bitcoin+lnd"
 
 	steps := buildSteps(cfg)
 
-	if err := RunInstallTUI(steps, appVersion); err != nil {
+	res, err := RunInstallTUI(steps, appVersion)
+	if err != nil {
 		return err
 	}
-	if err := setupShellEnvironment(cfg); err != nil {
-		logger.Install("Warning: shell setup failed: %v", err)
-		fmt.Printf("  Warning: shell setup failed: %v\n", err)
+	switch res.Outcome {
+	case RunFailed:
+		// The runner already logged the failure line; the
+		// error surfaces to stderr via main.
+		return fmt.Errorf("%s: %w", res.StepName, res.Err)
+	case RunInterrupted:
+		// The log trail must not just stop (commit-5
+		// addendum): record how far the run got, and that a
+		// re-run resumes.
+		logger.Install(
+			"install INTERRUPTED at step %d/%d: %s — "+
+				"run again to resume", res.StepNum, res.Total,
+			res.StepName)
+		return fmt.Errorf(
+			"install interrupted at step %d/%d (%s) — "+
+				"run again to resume", res.StepNum, res.Total,
+			res.StepName)
 	}
+
+	// Every step verified complete this run — only now may the
+	// durable record say so. InstallComplete is DERIVED from
+	// per-step results, never from a front-end returning
+	// (IA-1-9); the intent fields set above reach disk only on
+	// this path.
+	logger.Install("all %d install steps complete", res.Total)
 	cfg.InstallComplete = true
 	cfg.InstallVersion = appVersion
 	return config.Save(cfg)
 }
 
+// buildSteps returns the initial-install step list. Every step
+// carries a stable Key (the ledger identity — versionless, so
+// "which work is done" survives version bumps in display
+// names), a Kind (gates re-run every pass), and a Group where
+// steps hand ephemeral material to each other (see engine.go).
+// Phase is provisionally Bake throughout — the phase map is
+// ratified by the image-track session (ruling xiv / iv).
 func buildSteps(cfg *config.AppConfig) []InstallStep {
 	// Pipeline working directories — created in each pipeline's
 	// first step, captured by closures, cleaned up in the final
 	// step. Random paths via os.MkdirTemp prevent symlink attacks.
+	// NOTE these closures are exactly why the btc/lnd triplets
+	// are resume-atomic Groups: the workdir path lives only in
+	// this process, so a resumed process can never re-enter a
+	// pipeline midway.
 	var btcWork, lndWork string
 
 	return []InstallStep{
-		{Name: "Creating system user and directories",
+		{Key: "user.create",
+			Name: "Creating system user and directories",
 			Fn: func() error {
 				if err := createSystemUser(systemUser); err != nil {
 					return err
 				}
 				return createBitcoinDirs(systemUser)
 			}},
-		{Name: "Disabling IPv6", Fn: disableIPv6},
-		{Name: "Installing Tor",
+		{Key: "ipv6.disable", Name: "Disabling IPv6",
+			Fn: disableIPv6},
+		{Key: "tor.install", Name: "Installing Tor",
 			Fn: func() error {
 				if err := installTor(); err != nil {
 					return err
@@ -258,17 +317,22 @@ func buildSteps(cfg *config.AppConfig) []InstallStep {
 		// HARD GATE (IA-2-K): no Tor-dependent network step below —
 		// apt over the socks5h proxy, every DownloadRequireTor —
 		// runs unless Tor routing is verified. See torgate.go.
-		{Name: "Verifying Tor routing", Fn: verifyTorRouting},
-		{Name: "Configuring apt for Tor",
+		// StepGate: re-verified on EVERY pass including resumes —
+		// no download step can execute in a pass whose Tor routing
+		// was not verified in that same pass.
+		{Key: "tor.gate", Name: "Verifying Tor routing",
+			Kind: StepGate, Fn: verifyTorRouting},
+		{Key: "apt.torproxy", Name: "Configuring apt for Tor",
 			Fn: func() error {
 				if err := configureAptTor(); err != nil {
 					return err
 				}
 				return ensureGPG()
 			}},
-		{Name: "Configuring firewall",
+		{Key: "firewall", Name: "Configuring firewall",
 			Fn: func() error { return configureFirewall(cfg) }},
-		{Name: "Downloading Bitcoin Core " + bitcoinVersion,
+		{Key: "btc.download", Group: "btc",
+			Name: "Downloading Bitcoin Core " + bitcoinVersion,
 			Fn: func() error {
 				var err error
 				btcWork, err = os.MkdirTemp("", "rlvpn-btc-")
@@ -277,7 +341,8 @@ func buildSteps(cfg *config.AppConfig) []InstallStep {
 				}
 				return downloadBitcoin(bitcoinVersion, btcWork)
 			}},
-		{Name: "Verifying Bitcoin Core",
+		{Key: "btc.verify", Group: "btc",
+			Name: "Verifying Bitcoin Core",
 			Fn: func() error {
 				if err := verifyBitcoinCoreSigs(
 					btcWork, 2); err != nil {
@@ -285,7 +350,8 @@ func buildSteps(cfg *config.AppConfig) []InstallStep {
 				}
 				return verifyBitcoin(btcWork)
 			}},
-		{Name: "Installing Bitcoin Core",
+		{Key: "btc.install", Group: "btc",
+			Name: "Installing Bitcoin Core",
 			Fn: func() error {
 				if err := extractAndInstallBitcoin(
 					bitcoinVersion, btcWork); err != nil {
@@ -297,8 +363,9 @@ func buildSteps(cfg *config.AppConfig) []InstallStep {
 				}
 				return writeBitcoindService(systemUser)
 			}},
-		{Name: "Starting Bitcoin Core", Fn: startBitcoind},
-		{Name: "Configuring security",
+		{Key: "btc.start", Name: "Starting Bitcoin Core",
+			Fn: startBitcoind},
+		{Key: "security", Name: "Configuring security",
 			Fn: func() error {
 				if err := installUnattendedUpgrades(); err != nil {
 					return err
@@ -313,7 +380,8 @@ func buildSteps(cfg *config.AppConfig) []InstallStep {
 			}},
 
 		// ── LND (Tor-only, non-interactive) ─────────
-		{Name: "Downloading LND",
+		{Key: "lnd.download", Group: "lnd",
+			Name: "Downloading LND",
 			Fn: func() error {
 				var err error
 				lndWork, err = os.MkdirTemp("", "rlvpn-lnd-")
@@ -322,7 +390,8 @@ func buildSteps(cfg *config.AppConfig) []InstallStep {
 				}
 				return downloadLND(lndVersion, lndWork)
 			}},
-		{Name: "Verifying LND",
+		{Key: "lnd.verify", Group: "lnd",
+			Name: "Verifying LND",
 			Fn: func() error {
 				if err := verifyLNDSig(
 					lndWork, lndVersion); err != nil {
@@ -330,7 +399,8 @@ func buildSteps(cfg *config.AppConfig) []InstallStep {
 				}
 				return verifyLND(lndWork)
 			}},
-		{Name: "Installing LND",
+		{Key: "lnd.install", Group: "lnd",
+			Name: "Installing LND",
 			Fn: func() error {
 				if err := extractAndInstallLND(
 					lndVersion, lndWork); err != nil {
@@ -345,14 +415,22 @@ func buildSteps(cfg *config.AppConfig) []InstallStep {
 				}
 				return writeLNDServiceInitial(systemUser)
 			}},
-		{Name: "Configuring Tor for LND",
+		{Key: "tor.lnd", Name: "Configuring Tor for LND",
 			Fn: func() error {
 				if err := RebuildTorConfig(cfg); err != nil {
 					return err
 				}
 				return restartTor()
 			}},
-		{Name: "Starting LND", Fn: startLND},
+		{Key: "lnd.start", Name: "Starting LND", Fn: startLND},
+		// Formerly a post-TUI special case that warned but
+		// completed anyway (IA-1-16). As a real step it
+		// inherits the ledger, the completion gate, failure
+		// logging, and resume — the special case is dead.
+		{Key: "shellenv", Name: "Configuring shell environment",
+			Fn: func() error {
+				return setupShellEnvironment(cfg)
+			}},
 	}
 }
 

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -12,6 +12,14 @@ const (
 	ConfigDir  = "/etc/rlvpn"
 	ConfigFile = "/etc/rlvpn/config.json"
 
+	// InstallStateFile is the per-step install ledger: which
+	// install steps have completed, keyed by stable step key
+	// (installer/ledger.go). A SEPARATE file from config.json
+	// so a config load failure cannot erase install history,
+	// and so its ownership flips to root with root-dispatched
+	// install without touching config's story.
+	InstallStateFile = "/etc/rlvpn/install-state.json"
+
 	BitcoinConf = "/etc/bitcoin/bitcoin.conf"
 	BitcoinDir  = "/etc/bitcoin"
 


### PR DESCRIPTION
The installer used to decide the install had succeeded when its progress screen exited without an error. Pressing ctrl+c during the install also exits without an error, so a run interrupted at step 3 of 16 could be recorded as a complete install. The config then claimed software was installed that had never been downloaded, and the box reported itself healthy with its firewall never configured.

What changed. The installer now keeps a small ledger file that records each step the moment it verifiably completes. The install is marked complete only when every step in the list has completed. A run that fails or is interrupted leaves an honest record of exactly how far it got, and the next run resumes from the first step that never finished instead of starting over.

How it works. Every step has a stable name in the ledger. Most steps change the machine, such as installing a package or writing a config file; once recorded they are skipped on a resume. The step that verifies Tor routing is different. It asserts a fact about the machine right now, so it runs again on every pass, and no download can happen in a run that has not just verified Tor routing. The download, verify, and install sequences for Bitcoin Core and LND pass files to each other through a private working folder that disappears with the process, so each sequence resumes as a unit: unless its final step finished, the whole sequence runs again, and everything it downloads is checked again by signature and checksum. Shell setup used to be a warning that could not block completion; it is now an ordinary step like the others. Step failures and interruptions are also written to the log file now, so a failed run leaves a readable trail instead of going quiet.

Why it is safe. The ledger entry for a step is written only after the step finished and reported success, so the record can never claim more than actually happened, no matter when the process dies. A missing or unreadable ledger simply means the next run redoes all the work. Running a step again is safe: the steps tolerate repetition, downloads are verified cryptographically every time they occur, and the Tor routing check runs on every pass regardless of history. The completion flag in the config is derived from the per step record, so an interrupted install can no longer masquerade as a finished one.