### PR TITLE
feature: sudo vpn install replaces the bootstrap script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
 # Binary
+/vpn
+vpn-test*
+# Old binary names — kept one release cycle for stale local
+# builds, drop after v0.7.0.
 /rlvpn
 rlvpn-test*
 
@@ -19,4 +23,3 @@ release/
 
 # Dev
 notes/
-test-run.sh

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -155,8 +155,11 @@ sudo sh -c 'rm -f /usr/local/bin/rlvpn; rm -rf /etc/rlvpn; rm -f /var/log/rlvpn.
 ```
 
 `userdel` will warn that the user is currently logged in — that's
-expected and fine; your session keeps working until you close it. If you
-want to keep the old log for your records, copy `/var/log/rlvpn.log`
+expected and fine (a warning about a missing mail spool is also normal).
+Your session's shell keeps working until you close it, though `sudo`
+from it will not — the removal you just ran took ripsline's admin
+rights with it, which is why it had to be a single command. If you want
+to keep the old log for your records, copy `/var/log/rlvpn.log`
 somewhere first.
 
 Then `exit`. The migration is complete.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,203 @@
+# Migrating from rlvpn to vpn (v0.6.3 → v0.7.0)
+
+Virtual Private Node has a new home and a new name. The project moved to
+`github.com/virtualprivatenode/vpn`, the binary is now `vpn`, the admin
+user is now `vpn`, and the bootstrap script is gone — installation is a
+subcommand of the signed binary itself: `sudo vpn install`.
+
+This is a **one-time manual upgrade**. The built-in updater cannot cross
+the rename (it looks for release files under the old name, which no longer
+exist), and that is deliberate: it makes a half-migrated box impossible.
+If your node shows an update it fails to download — this document is why.
+Every release after this one updates through the TUI as before.
+
+The whole procedure takes about 15 minutes of your attention. Your node is
+offline for a few minutes in the middle — the same as a reboot.
+
+---
+
+## What this migration does NOT touch
+
+Your node's identity and your money live in places the rename never
+visits:
+
+- **Bitcoin chain data** (`/var/lib/bitcoin`) — no re-sync, no re-download
+- **LND wallet, channels, seed, macaroons** (`/var/lib/lnd`) — no channel
+  closes, no force-closes, nothing to move or restore
+- **Tor onion keys** (`/var/lib/tor`) — your onion addresses stay the same
+- **Syncthing data and device pairings** (`/var/lib/syncthing`,
+  `/etc/syncthing`) — paired phones keep working
+- **SSH host keys** — your SSH client sees the same server, no warnings
+
+**You do not need to close channels, move funds, or touch your seed.**
+What happens to LND is a restart — the same thing every reboot already
+does, and channels are built to survive that. Just don't migrate in the
+middle of heavy payment activity: pick a quiet moment, since in-flight
+payments during the downtime resolve by their normal timeout rules.
+
+## Before you begin
+
+- Log in as `ripsline` with your SSH key and **keep that session open for
+  the entire procedure**. Exit the TUI to a shell.
+- Confirm a channel backup exists (skip if you have no channels):
+
+  ```
+  ls -l /var/lib/lnd/data/chain/bitcoin/mainnet/channel.backup
+  ```
+
+  (Use `testnet4` in the path if that's your network.)
+- Know how to reach your VPS provider's console. You should not need it —
+  it's the standard fallback for any change that touches SSH.
+
+## Step 1 — Download and verify the new binary
+
+From your `ripsline` shell (downloads route through Tor, as always):
+
+```
+cd /tmp
+torsocks wget https://github.com/virtualprivatenode/vpn/releases/download/v0.7.0/vpn-0.7.0-amd64.tar.gz
+torsocks wget https://github.com/virtualprivatenode/vpn/releases/download/v0.7.0/SHA256SUMS
+torsocks wget https://github.com/virtualprivatenode/vpn/releases/download/v0.7.0/SHA256SUMS.asc
+```
+
+Import the signing key — the **same key** that signed every rlvpn release:
+
+```
+torsocks wget -O signing-key.asc https://keys.openpgp.org/vks/v1/by-fingerprint/AFA0EBACDC9A4C4AA7B0154AC97CE10F170BA5FE
+gpg --import signing-key.asc
+```
+
+Verify the signature and the checksum:
+
+```
+gpg --verify SHA256SUMS.asc SHA256SUMS
+sha256sum -c SHA256SUMS --ignore-missing
+```
+
+The signature must say **Good signature** with primary key fingerprint
+`AFA0 EBAC DC9A 4C4A A7B0  154A C97C E10F 170B A5FE`, and the checksum
+line must say `vpn-0.7.0-amd64.tar.gz: OK`. If either fails, stop and ask
+before proceeding.
+
+Install the binary:
+
+```
+tar -xzf vpn-0.7.0-amd64.tar.gz
+sudo install -m 755 vpn /usr/local/bin/vpn
+```
+
+## Step 2 — Carry your settings over
+
+Your existing settings file is compatible as-is. Copy it to the new
+location (the installer fixes ownership):
+
+```
+sudo mkdir -p /etc/vpn
+sudo cp /etc/rlvpn/config.json /etc/vpn/config.json
+```
+
+The installer reads this as your previous answers — network, prune size,
+components, auto-unlock — so it won't ask you to re-decide things your
+node already settled.
+
+## Step 3 — Run the installer
+
+```
+sudo vpn install
+```
+
+What you'll see:
+
+- **Environment checks** run first; on a working box they pass silently.
+- **The access step** shows the SSH keys found on the box — including
+  your existing `ripsline` keys, with fingerprints. Confirm to copy them
+  to the new `vpn` user. You'll also set a login password for the `vpn`
+  user (16 characters minimum) as a console fallback.
+- **Component reinstall**: Bitcoin Core and LND are re-downloaded over
+  Tor, re-verified, and reinstalled at the same versions. Services
+  restart briefly — this is the downtime window. Your data directories
+  are not touched.
+- **SSH hardening** is rewritten under the new name. The installer reads
+  your *current effective* SSH settings from the running service first,
+  so whatever you had — including password login disabled, if you
+  disabled it — stays exactly as it was. The old
+  `00-rlvpn-hardening.conf` drop-in is removed automatically.
+
+If the installer fails partway, re-run `sudo vpn install` — it resumes
+from the first incomplete step and re-verifies Tor routing on every pass.
+Nothing about your old setup has been removed, so the box is never
+stranded.
+
+## Step 4 — Verify the new login BEFORE any cleanup
+
+Open a **new** terminal (leave the `ripsline` session open):
+
+```
+ssh vpn@<your-server-ip>
+```
+
+The TUI should launch. Check that your wallet, channels, and onion
+addresses look right. If you don't use auto-unlock, unlock the wallet —
+same as after any restart.
+
+**Do not continue until this login works.** If it doesn't, go back to
+your `ripsline` session (which still has full access) and fix it — or
+ask. Nothing has been lost; the old setup still works at this point.
+
+## Step 5 — Remove the old identity
+
+From the still-open `ripsline` session, one command. It must be a single
+command, in this order, because it removes ripsline's own admin rights
+along the way:
+
+```
+sudo sh -c 'rm -f /usr/local/bin/rlvpn; rm -rf /etc/rlvpn; rm -f /var/log/rlvpn.log; rm -f /etc/sudoers.d/ripsline; userdel -r -f ripsline'
+```
+
+`userdel` will warn that the user is currently logged in — that's
+expected and fine; your session keeps working until you close it. If you
+want to keep the old log for your records, copy `/var/log/rlvpn.log`
+somewhere first.
+
+Then `exit`. The migration is complete.
+
+Your box now has: the `vpn` binary, the `vpn` admin user — which by
+design has **no sudo rights at all** (privileged operations go through
+the node's own root helper) — and no trace of the old name.
+
+## If something goes wrong
+
+Until Step 5, the migration is reversible: the old binary, config, user,
+and admin rights are all still in place, and logging in as `ripsline`
+still works (it will still launch the old TUI). The one thing replaced
+along the way is the SSH hardening file — and its settings are carried
+into the new one, so behavior doesn't change.
+
+The two rules that keep you safe:
+
+1. Keep the `ripsline` session open until Step 4 passes.
+2. Never run Step 5 before Step 4 passes.
+
+## Moving to a different box instead
+
+If you'd rather start on a fresh server, treat it as **moving a
+Lightning node**, not as this upgrade: cooperatively close your channels
+from the old box, wait for settlement, send the funds on-chain to a
+wallet you control, install fresh on the new box, create a **new**
+wallet, and reopen channels.
+
+⚠️ **Do not use the channel backup (SCB) to migrate.** SCB restore is
+disaster recovery, not a moving tool: it force-closes every channel,
+your funds come back only after time-locks expire, and it depends on
+your channel partners' cooperation. Worse, running two nodes from the
+same seed — even briefly, even by accident — can lead to loss of funds.
+If the old box is alive and healthy, close cooperatively; the backup is
+for when it isn't.
+
+## After migration
+
+Routine updates return to the TUI: you'll see the update notice, confirm
+it, and the node downloads and verifies the release itself — same
+signing key, same verification, done for you. Any future release that
+ever requires manual steps will say so clearly in its release notes;
+this rename is expected to be the only one.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Private by default, simple by design. Your keys, your node.
 
 ### Requirements
 
-- Fresh Debian 13+ Box
+- Fresh Debian 13 Box
 - 2 (v)CPU, 4+ GB RAM, 90+ GB SSD
 
 ### Privacy
@@ -51,35 +51,53 @@ Private by default, simple by design. Your keys, your node.
 
 ### Quick Start
 
-SSH into your Server (Box) and run:
+Download the signed `vpn` binary onto your Server (Box), verify
+it, and run the installer:
 
 ```bash
-curl -sL https://raw.githubusercontent.com/ripsline/virtual-private-node/main/virtual-private-node.sh | sudo bash
+cd /tmp
+wget https://github.com/virtualprivatenode/vpn/releases/download/v0.7.0/vpn-0.7.0-amd64.tar.gz
+wget https://github.com/virtualprivatenode/vpn/releases/download/v0.7.0/SHA256SUMS
+wget https://github.com/virtualprivatenode/vpn/releases/download/v0.7.0/SHA256SUMS.asc
+
+wget -O signing-key.asc https://keys.openpgp.org/vks/v1/by-fingerprint/AFA0EBACDC9A4C4AA7B0154AC97CE10F170BA5FE
+gpg --import signing-key.asc
+gpg --verify SHA256SUMS.asc SHA256SUMS
+sha256sum -c SHA256SUMS --ignore-missing
+
+tar -xzf vpn-0.7.0-amd64.tar.gz
+sudo install -m 755 vpn /usr/local/bin/vpn
+sudo vpn install
 ```
 
-> [!NOTE]
-> Some downloads route through Tor and can occasionally fail on the first attempt. The script is idempotent and safe to rerun. If you hit an error, just run the above command again.
-
-The bootstrap prepares the host: it creates a `ripsline` user, copies
-your SSH key across automatically, installs Tor, downloads and
-GPG-verifies the `rlvpn` binary, and hardens the SSH daemon. When you
-SSH in as `ripsline`, the binary takes over and installs Bitcoin Core
-and LND, every download routed through Tor and verified before
-install. Bitcoin Core begins syncing and the TUI opens to the wallet
-creation flow.
+The signature must say **Good signature** with primary key
+fingerprint `AFA0 EBAC DC9A 4C4A A7B0  154A C97C E10F 170B
+A5FE`, and the checksum line must say `vpn-0.7.0-amd64.tar.gz:
+OK`. If either fails, stop.
 
 For testnet4:
 
 ```bash
-curl -sL https://raw.githubusercontent.com/ripsline/virtual-private-node/main/virtual-private-node.sh | sudo bash -s -- --testnet4
+sudo vpn install --testnet4
 ```
 
-**SSH key discovery.** The bootstrap tries several ways to find an
-existing SSH key to copy to the new `ripsline` user: `$SUDO_USER`'s
-`authorized_keys`, then `logname`, then `who`, then `/root/.ssh/`.
-This works for `curl | sudo bash`, `sudo su -` followed by curl, and
-bare-metal root installs. If no key is found, a random password is
-printed at the end and you can add a key later from the TUI.
+The installer checks the environment first and refuses — with a
+full report, before changing anything — if the box is not one it
+can trust. It then walks you through access setup and hardware
+fit, installs Bitcoin Core and LND with every download after Tor
+routed through Tor and verified before install, and drops you
+straight into the node console. If a step fails or you
+interrupt, just run `sudo vpn install` again — it resumes from
+the first incomplete step.
+
+**Access setup.** The installer creates a `vpn` admin user and
+shows every SSH key it finds on the box — with fingerprints and
+comments, and provider control lines excluded — for you to
+confirm, replace, or extend before they are copied. You also set
+a login password (16 characters minimum) as the console
+fallback; whether password login over SSH stays enabled is
+carried over exactly as the installer OBSERVED it on your box —
+installing never silently changes it.
 
 ### Build from Source
 
@@ -94,20 +112,19 @@ echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.profile
 source ~/.profile
 
 cd ~
-git clone https://github.com/ripsline/virtual-private-node.git
-cd virtual-private-node
+git clone https://github.com/virtualprivatenode/vpn.git
+cd vpn
 go mod tidy
-go build -o rlvpn ./cmd/
-sudo install -m 755 ./rlvpn /usr/local/bin/rlvpn
-sudo bash virtual-private-node.sh
+go build -o vpn ./cmd/
+sudo ./vpn install
 ```
 
-The bootstrap script detects that `rlvpn` is already installed and
-skips the download.
+The installer places the binary at `/usr/local/bin/vpn` as its
+first step.
 
 ### Wallet Creation
 
-On first TUI launch after bootstrap, you'll go straight to the wallet
+On first launch of the node console, you go straight to the wallet
 creation flow:
 
 1. Read the privacy and seed warnings, press Proceed
@@ -127,7 +144,7 @@ design — the only way forward is typing the confirmation phrase.
 
 ### Dashboard
 
-Every SSH login as `ripsline` opens a terminal UI with a sidebar of
+Every SSH login as `vpn` opens a terminal UI with a sidebar of
 five sections plus a dark/light theme toggle:
 
 - **Channels** — open channels with coin control; close and manage channels; view your Node Info (pubkey, URIs, QR codes for sharing); channel history
@@ -227,21 +244,21 @@ For the full setup guide, see
 
 ### Security
 
-- TUI runs as unprivileged user with passwordless sudo for system operations
+- TUI runs as the unprivileged `vpn` admin user (passwordless sudo for system operations — scheduled for removal in favor of a root helper)
 - All connections through Tor (SOCKS5 port 9050)
 - IPv6 disabled to prevent Tor bypass
 - Stream isolation (separate circuit per connection)
-- UFW firewall: SSH only (+ 9735, 8080 for hybrid P2P, 22000 for Syncthing)
+- UFW firewall: SSH only, on the port(s) sshd actually listens on (+ 9735, 8080 for hybrid P2P, 22000 for Syncthing)
 - Fail2ban: SSH brute-force protection
-- Root SSH disabled after bootstrap
-- SSH hardening: challenge-response, keyboard-interactive, and X11 forwarding disabled; password auth on by default (toggle from System → SSH Keys once you've verified key auth works); login password changeable from the TUI
+- Root SSH disabled by the installer
+- SSH hardening: challenge-response, keyboard-interactive, and X11 forwarding disabled; password auth carried over exactly as OBSERVED on your box at install (toggle from System → SSH Keys once you've verified key auth works); login password changeable from the TUI
 - Services run as dedicated bitcoin system user
 - GPG signature verification for all software, any bad signature is a hard stop
 - Unattended security upgrades with auto-reboot
-- Base packages upgraded during bootstrap to close CVE windows on stale server images
+- Base packages upgraded during install — behind the firewall, which comes up first — to close CVE windows on stale server images
 - Syncthing backup sync: mutual TLS device approval, web UI only via Tor
 - Bitcoin Core wallet disabled
-- All downloads and apt operations route through Tor after bootstrap
+- All downloads and apt operations route through Tor once Tor is up (verified by a hard gate before any download)
 - Atomic config writes with fsync + rename (prevents corruption on power loss)
 - Secure temp file creation with O_EXCL (prevents symlink attacks)
 - Public IP detection uses kernel routing table (no external network calls)
@@ -250,29 +267,36 @@ For the full setup guide, see
 
 ### Privacy — Network Traffic
 
-The bootstrap script makes two types of network calls:
+Downloading the `vpn` binary and signing key (Quick Start) is
+ordinary clearnet traffic — Tor does not exist on the box yet.
+After that, the installer makes two types of network calls:
 
 **Phase 1 (clearnet, unavoidable):**
 - `apt-get update` — Debian package index refresh
-- `apt-get upgrade` — Debian security updates
-- `apt-get install tor torsocks gnupg sudo wget` — Debian package mirrors
-- NTP time sync enablement — ongoing clock sync queries to the Debian NTP pool (continues after bootstrap)
+- one `apt-get install` — Tor, torsocks, ufw and base tools,
+  from Debian package mirrors
+- `apt-get upgrade` — Debian security updates (runs behind the
+  freshly enabled firewall)
+- NTP time sync enablement — ongoing clock sync queries to the
+  Debian NTP pool (continues after install)
 
-**Phase 2 (all through Tor):**
-- rlvpn binary download from GitHub
-- GPG signing key file download from independent keyserver
+**Phase 2 (all through Tor, hard-gated):**
 - Bitcoin Core and LND downloads
 - Syncthing download (when Syncthing is installed)
 - All subsequent apt operations
 
-After bootstrap, the only ongoing clearnet traffic is NTP clock sync
-(to the Debian NTP pool), Syncthing sync (port 22000) if you install
-it, and LND P2P if you choose hybrid mode. Everything else routes
-through Tor.
+Before the first Phase-2 download, the installer verifies Tor
+routing on Tor's own control port and refuses to continue if it
+cannot confirm it — on every run, including resumes.
+
+After install, the only ongoing clearnet traffic is NTP clock
+sync (to the Debian NTP pool), Syncthing sync (port 22000) if
+you install it, and LND P2P if you choose hybrid mode.
+Everything else routes through Tor.
 
 Verify Tor routing after install:
 ```bash
-grep "Tor" /var/log/rlvpn.log
+grep "Tor" /var/log/vpn.log
 ```
 
 ### Software Verification
@@ -289,17 +313,20 @@ All software is verified with GPG signatures and SHA256 checksums:
   clearsigned by the same key. The installer also writes Syncthing's
   entire configuration itself and refuses to start the daemon if any
   privacy setting does not verify.
-- **rlvpn binary** — signed with a key hosted on an independent
-  keyserver (not GitHub). The bootstrap downloads the key file directly
-  through Tor rather than using keyserver protocols, so compromising
-  one source does not compromise both the binary and the key.
+- **vpn binary** — signed with a key hosted on an independent
+  keyserver (not GitHub). You download and verify it yourself
+  before running it (Quick Start above), and the built-in
+  updater performs the same key and checksum verification for
+  every later release. Hosting the key off GitHub means
+  compromising one source does not compromise both the binary
+  and the key.
 
 Verification failure is a hard stop.
 
 After installation, review the log:
 
 ```bash
-cat /var/log/rlvpn.log
+cat /var/log/vpn.log
 ```
 
 For manual binary verification before installation, see
@@ -312,11 +339,11 @@ For manual binary verification before installation, see
 | /etc/bitcoin/bitcoin.conf | Bitcoin Core configuration |
 | /etc/lnd/lnd.conf | LND configuration |
 | /etc/syncthing/ | Syncthing configuration |
-| /etc/rlvpn/config.json | Install state and credentials |
+| /etc/vpn/config.json | Install state and credentials |
 | /var/lib/bitcoin/ | Blockchain data |
 | /var/lib/lnd/ | LND data and wallet |
 | /var/lib/syncthing/lnd-backup/ | Auto-synced channel.backup |
-| /var/log/rlvpn.log | Application log (install, verification, status) |
+| /var/log/vpn.log | Application log (install, verification, status) |
 
 ## License
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -6,34 +6,131 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/ripsline/virtual-private-node/internal/config"
-	"github.com/ripsline/virtual-private-node/internal/installer"
-	"github.com/ripsline/virtual-private-node/internal/welcome"
+	"github.com/virtualprivatenode/vpn/internal/config"
+	"github.com/virtualprivatenode/vpn/internal/installer"
+	"github.com/virtualprivatenode/vpn/internal/paths"
+	"github.com/virtualprivatenode/vpn/internal/welcome"
 )
 
 var version = "dev"
 
+// Explicit dispatch (IA-1-8's fix): what the binary does is
+// decided by what the operator TYPED, never by sniffing box
+// state. `vpn` is the node console; `sudo vpn install` is the
+// installer; nothing infers one from the other.
 func main() {
 	installer.SetVersion(version)
 
-	if !installer.NeedsInstall() {
-		cfg, err := config.Load()
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: %v\n", err)
-			cfg = config.Default()
-		}
-		welcome.Show(cfg, version)
-		return
+	cmd, opts, err := parseArgs(os.Args[1:])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n\n%s", err, usage())
+		os.Exit(2)
 	}
 
-	// Initial install — runs via sudo from the TUI
-	if err := installer.Run(); err != nil {
-		fmt.Fprintf(os.Stderr, "\n  Failed: %v\n", err)
+	switch cmd {
+	case cmdInstall:
+		if err := installer.RunInstall(opts); err != nil {
+			fmt.Fprintf(os.Stderr, "\n  Failed: %v\n", err)
+			os.Exit(1)
+		}
+	case cmdVersion:
+		fmt.Println(version)
+	case cmdHelp:
+		fmt.Print(usage())
+	case cmdConsole:
+		runConsole()
+	}
+}
+
+// runConsole is the bare `vpn` path: the node console for the
+// admin user. Fail-stop on an unloadable config (IA-1-C1): the
+// error names the file and the reason, and Default() is NEVER
+// substituted — a TUI running on defaults would render a
+// mainnet node's screens over a testnet4 node's services and
+// write the wrong answers back on its first save.
+func runConsole() {
+	if os.Geteuid() == 0 {
+		fmt.Fprintf(os.Stderr,
+			"  The node console runs as the %q user, not root.\n"+
+				"  Connect with: ssh %s@<your-server-ip>\n"+
+				"  (To install or reinstall: sudo vpn install)\n",
+			paths.AdminUser, paths.AdminUser)
 		os.Exit(1)
 	}
+
 	cfg, err := config.Load()
 	if err != nil {
-		cfg = config.Default()
+		if os.IsNotExist(err) {
+			fmt.Fprintf(os.Stderr,
+				"  No configuration found at %s — this node is "+
+					"not installed.\n  To install: sudo vpn install\n",
+				config.DefaultPath)
+		} else {
+			fmt.Fprintf(os.Stderr,
+				"  Cannot start: configuration at %s is "+
+					"unreadable:\n    %v\n"+
+					"  Refusing to run with default settings in its "+
+					"place — fix or restore the file.\n",
+				config.DefaultPath, err)
+		}
+		os.Exit(1)
 	}
 	welcome.Show(cfg, version)
+}
+
+type command int
+
+const (
+	cmdConsole command = iota
+	cmdInstall
+	cmdVersion
+	cmdHelp
+)
+
+// parseArgs maps the command line to a command. Pure —
+// unit-tested.
+func parseArgs(
+	args []string,
+) (command, installer.InstallOptions, error) {
+	var opts installer.InstallOptions
+	if len(args) == 0 {
+		return cmdConsole, opts, nil
+	}
+	switch args[0] {
+	case "install":
+		for _, a := range args[1:] {
+			switch a {
+			case "--testnet4":
+				opts.Network = "testnet4"
+			case "--unattended":
+				opts.Unattended = true
+			case "--until=bake":
+				opts.UntilBake = true
+			default:
+				return 0, opts, fmt.Errorf(
+					"unknown install flag %q", a)
+			}
+		}
+		return cmdInstall, opts, nil
+	case "version", "--version", "-v":
+		return cmdVersion, opts, nil
+	case "help", "--help", "-h":
+		return cmdHelp, opts, nil
+	default:
+		return 0, opts, fmt.Errorf("unknown command %q", args[0])
+	}
+}
+
+func usage() string {
+	return `Virtual Private Node
+
+Usage:
+  vpn                open the node console (run as the ` +
+		paths.AdminUser + ` user)
+  sudo vpn install   install or reinstall the node
+      --testnet4     use testnet4 instead of mainnet
+      --unattended   no prompts (keys auto-copied from the box,
+                     login password generated and printed once)
+  vpn version        print the version
+`
 }

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,0 +1,45 @@
+// cmd/main_test.go
+
+package main
+
+import "testing"
+
+// Explicit dispatch: the command line alone decides the mode.
+func TestParseArgs(t *testing.T) {
+	cmd, _, err := parseArgs(nil)
+	if err != nil || cmd != cmdConsole {
+		t.Errorf("no args: got (%v,%v), want console", cmd, err)
+	}
+
+	cmd, opts, err := parseArgs([]string{"install"})
+	if err != nil || cmd != cmdInstall {
+		t.Fatalf("install: got (%v,%v)", cmd, err)
+	}
+	if opts.Network != "" || opts.Unattended || opts.UntilBake {
+		t.Errorf("install: unexpected opts %+v", opts)
+	}
+
+	cmd, opts, err = parseArgs(
+		[]string{"install", "--testnet4", "--unattended"})
+	if err != nil || cmd != cmdInstall {
+		t.Fatalf("install flags: got (%v,%v)", cmd, err)
+	}
+	if opts.Network != "testnet4" || !opts.Unattended {
+		t.Errorf("install flags: got %+v", opts)
+	}
+
+	if _, _, err := parseArgs(
+		[]string{"install", "--bogus"}); err == nil {
+		t.Error("unknown install flag accepted")
+	}
+	if _, _, err := parseArgs([]string{"bogus"}); err == nil {
+		t.Error("unknown command accepted")
+	}
+
+	for _, v := range []string{"version", "--version", "-v"} {
+		if cmd, _, err := parseArgs([]string{v}); err != nil ||
+			cmd != cmdVersion {
+			t.Errorf("%s: got (%v,%v), want version", v, cmd, err)
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ripsline/virtual-private-node
+module github.com/virtualprivatenode/vpn
 
 go 1.26.1
 

--- a/internal/bitcoin/client.go
+++ b/internal/bitcoin/client.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/ripsline/virtual-private-node/internal/paths"
-	"github.com/ripsline/virtual-private-node/internal/system"
+	"github.com/virtualprivatenode/vpn/internal/paths"
+	"github.com/virtualprivatenode/vpn/internal/system"
 )
 
 type BlockchainInfo struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/ripsline/virtual-private-node/internal/paths"
+	"github.com/virtualprivatenode/vpn/internal/paths"
 )
 
 // Defaults — used by production code
@@ -40,8 +40,34 @@ type AppConfig struct {
 	SyncthingDevices   []SyncthingDevice `json:"syncthing_devices,omitempty"`
 	Theme              string            `json:"theme,omitempty"`
 
+	// DbCache is bitcoind's dbcache in MB, chosen at the
+	// install hardware-fit step (ruling viii) from detected
+	// RAM. Zero means "never set" — DbCacheMB() falls back
+	// to the historical 512 so configs from older installs
+	// keep their exact behavior.
+	DbCache int `json:"dbcache,omitempty"`
+
+	// SSHPorts holds sshd's OBSERVED listening ports,
+	// recorded at install preflight (ruling xvi(b)). The
+	// firewall allow-rules derive from this — never from a
+	// hardcoded 22, which on a nonstandard-port box was a
+	// delayed silent lockout hazard (deny-all enabled with
+	// only 22 open, next connection refused). Empty means
+	// "never observed" (pre-rename configs):
+	// SSHPortsOrDefault falls back to 22, byte-identical to
+	// the old behavior.
+	SSHPorts []int `json:"ssh_ports,omitempty"`
+
+	// KeyVerificationPending is set at install completion
+	// and cleared when the TUI observes a real sshd login
+	// for the admin user (journal evidence). While set, the
+	// TUI shows the first-run banner asking the operator to
+	// verify access from a SECOND terminal before trusting
+	// the in-session handoff console as their only way in.
+	KeyVerificationPending bool `json:"key_verification_pending,omitempty"`
+
 	// SSHPasswordAuthDisabled mirrors the value
-	// 00-rlvpn-hardening.conf writes for sshd's
+	// 00-vpn-hardening.conf writes for sshd's
 	// PasswordAuthentication directive. False = password
 	// auth enabled (matches debian default and the
 	// bootstrap-written drop-in, which is silent on the
@@ -131,12 +157,60 @@ func Load() (*AppConfig, error) {
 	return DefaultStore().Load()
 }
 
+// RawFieldPresent reports whether the config file on disk
+// contains the given JSON key at the top level. Needed where
+// "absent" and "zero value" must be told apart on omitempty
+// fields — the migration rule (commit-6 addendum 2026-07-17):
+// an install seeds a field from observation ONLY when the
+// operator's carried-over config never answered it; a present
+// value is a prior answer and is never clobbered. A missing or
+// unreadable file simply reports absent.
+func RawFieldPresent(key string) bool {
+	data, err := os.ReadFile(DefaultPath)
+	if err != nil {
+		return false
+	}
+	return rawFieldPresent(data, key)
+}
+
+// rawFieldPresent is the pure half of RawFieldPresent —
+// unit-tested.
+func rawFieldPresent(data []byte, key string) bool {
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(data, &m); err != nil {
+		return false
+	}
+	_, ok := m[key]
+	return ok
+}
+
 func Save(cfg *AppConfig) error {
 	return DefaultStore().Save(cfg)
 }
 
 func (c *AppConfig) HasLND() bool {
 	return c.LNDInstalled
+}
+
+// DbCacheMB returns the dbcache value for bitcoin.conf: the
+// hardware-fit choice when one was recorded, else the
+// historical default (512), so configs that predate the
+// hardware-fit step render byte-identical bitcoin.conf.
+func (c *AppConfig) DbCacheMB() int {
+	if c.DbCache > 0 {
+		return c.DbCache
+	}
+	return 512
+}
+
+// SSHPortsOrDefault returns the observed sshd ports for
+// firewall allow-rules, falling back to 22 when no
+// observation was ever recorded (pre-rename configs).
+func (c *AppConfig) SSHPortsOrDefault() []int {
+	if len(c.SSHPorts) > 0 {
+		return c.SSHPorts
+	}
+	return []int{22}
 }
 
 func (c *AppConfig) IsMainnet() bool {

--- a/internal/config/rawfield_test.go
+++ b/internal/config/rawfield_test.go
@@ -1,0 +1,27 @@
+// internal/config/rawfield_test.go
+
+package config
+
+import "testing"
+
+// rawFieldPresent tells "absent" apart from "zero value" on
+// omitempty fields — the migration seed rule's mechanism.
+func TestRawFieldPresent(t *testing.T) {
+	data := []byte(`{
+  "install_complete": true,
+  "ssh_password_auth_disabled": false,
+  "network": "mainnet"
+}`)
+	if !rawFieldPresent(data, "ssh_password_auth_disabled") {
+		t.Error("present false value reported absent")
+	}
+	if rawFieldPresent(data, "dbcache") {
+		t.Error("absent key reported present")
+	}
+	if rawFieldPresent([]byte("not json"), "network") {
+		t.Error("corrupt JSON reported present")
+	}
+	if rawFieldPresent(nil, "network") {
+		t.Error("nil data reported present")
+	}
+}

--- a/internal/installer/bitcoin.go
+++ b/internal/installer/bitcoin.go
@@ -7,9 +7,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/ripsline/virtual-private-node/internal/config"
-	"github.com/ripsline/virtual-private-node/internal/paths"
-	"github.com/ripsline/virtual-private-node/internal/system"
+	"github.com/virtualprivatenode/vpn/internal/config"
+	"github.com/virtualprivatenode/vpn/internal/paths"
+	"github.com/virtualprivatenode/vpn/internal/system"
 )
 
 func downloadBitcoin(version, workDir string) error {
@@ -66,7 +66,7 @@ server=1
 disablewallet=1
 %s
 prune=%d
-dbcache=512
+dbcache=%d
 maxmempool=300
 proxy=127.0.0.1:9050
 listen=1
@@ -79,7 +79,7 @@ rpcport=%d
 rpcallowip=127.0.0.1
 zmqpubrawblock=tcp://127.0.0.1:%d
 zmqpubrawtx=tcp://127.0.0.1:%d
-`, net.BitcoinFlag, pruneMB,
+`, net.BitcoinFlag, pruneMB, cfg.DbCacheMB(),
 			net.RPCPort, net.ZMQBlockPort, net.ZMQTxPort)
 	}
 
@@ -87,7 +87,7 @@ zmqpubrawtx=tcp://127.0.0.1:%d
 server=1
 disablewallet=1
 prune=%d
-dbcache=512
+dbcache=%d
 maxmempool=300
 proxy=127.0.0.1:9050
 listen=1
@@ -99,7 +99,7 @@ rpcport=%d
 rpcallowip=127.0.0.1
 zmqpubrawblock=tcp://127.0.0.1:%d
 zmqpubrawtx=tcp://127.0.0.1:%d
-`, pruneMB,
+`, pruneMB, cfg.DbCacheMB(),
 		net.RPCPort, net.ZMQBlockPort, net.ZMQTxPort)
 }
 

--- a/internal/installer/bitcoin_test.go
+++ b/internal/installer/bitcoin_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ripsline/virtual-private-node/internal/config"
+	"github.com/virtualprivatenode/vpn/internal/config"
 )
 
 func TestBitcoinConfigMainnet(t *testing.T) {

--- a/internal/installer/engine.go
+++ b/internal/installer/engine.go
@@ -5,7 +5,7 @@ package installer
 import (
 	"fmt"
 
-	"github.com/ripsline/virtual-private-node/internal/logger"
+	"github.com/virtualprivatenode/vpn/internal/logger"
 )
 
 // ── Install engine core ──────────────────────────────────
@@ -15,7 +15,7 @@ import (
 // (setup.go) and the unattended runner (below) both drive the
 // same runner, so ledger recording, skip decisions, and the
 // log trail cannot diverge between them, and a failed or
-// interrupted run reaches /var/log/rlvpn.log identically from
+// interrupted run reaches /var/log/vpn.log identically from
 // either.
 //
 // Resume rules (one place, ruled 2026-07-16):
@@ -212,7 +212,7 @@ func newStepRunner(
 
 // runIndex executes one step per the plan. Every path leaves a
 // log line — start, skip, complete, FAILED — so a run's trail
-// in rlvpn.log never just stops (the commit-5 addendum fix,
+// in vpn.log never just stops (the commit-5 addendum fix,
 // once, in the core). The ledger entry is written only after
 // Fn returns nil; a ledger persist failure is logged and does
 // NOT fail the step (this run's authority is its in-process

--- a/internal/installer/engine_test.go
+++ b/internal/installer/engine_test.go
@@ -349,3 +349,33 @@ func TestRunInstallUnattendedFailureStops(t *testing.T) {
 		t.Error("failed gate recorded as done")
 	}
 }
+
+// ── willRun (wizard screen-skip source) ──────────────────
+
+func TestWillRun(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/ledger.json"
+	steps := []InstallStep{
+		{Key: "identity.access", Name: "a", Fn: func() error { return nil }},
+		{Key: "btc.install", Name: "b", Fn: func() error { return nil }},
+	}
+	led := newLedger()
+	led.markDone("identity.access", "1.0")
+	if err := led.save(path); err != nil {
+		t.Fatal(err)
+	}
+	r, err := newStepRunner(steps, "1.0", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.willRun(steps, "identity.access") {
+		t.Error("recorded step reported as will-run")
+	}
+	if !r.willRun(steps, "btc.install") {
+		t.Error("unrecorded step reported as skip")
+	}
+	// Unknown key: conservative side is "will run" (screen shows).
+	if !r.willRun(steps, "no.such.key") {
+		t.Error("unknown key reported as skip")
+	}
+}

--- a/internal/installer/handoff.go
+++ b/internal/installer/handoff.go
@@ -1,0 +1,153 @@
+// internal/installer/handoff.go
+
+package installer
+
+// The in-session root→admin identity drop (ruling xvi, handoff).
+// At install completion the wizard flows straight into the node
+// console: the root install process launches the TUI as the vpn
+// user ON THE SAME TTY via a su-class mechanism, so the operator
+// is never told to disconnect and come back.
+//
+// Mechanism notes for the live-run red-team (env scrub, tty
+// ownership — flagged in ruling xvi):
+//
+//   - `su - vpn -c <binary>` provides the uid/gid/groups switch,
+//     a PAM session, and a LOGIN environment — su's `-` clears
+//     the caller's environment except TERM, which is exactly the
+//     scrub we want (root's env never leaks into the admin
+//     session; TERM survives for the TUI).
+//   - su does NOT reassign tty ownership (login(1) does; su
+//     doesn't). The inherited stdio fds work regardless, but a
+//     fresh open of /dev/tty by the TUI stack would not — so the
+//     handoff chowns the tty to the admin user for the session
+//     and restores the original owner afterward.
+//   - If any part fails at runtime the handoff degrades to
+//     printing the connect instruction — the box is fully
+//     installed at this point; only the convenience is lost. The
+//     DESIGN fallback if the mechanism fails red-team scrutiny is
+//     the watched-handoff screen specified in ruling xvi (swap
+//     costs nothing; not built unless the live run demands it).
+//
+// This file also owns the first-run verification evidence: the
+// TUI's "key verification pending" banner clears only when sshd's
+// journal shows a real accepted login for the admin user — the
+// in-session console is deliberately NOT evidence that SSH access
+// works.
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+
+	"github.com/virtualprivatenode/vpn/internal/logger"
+	"github.com/virtualprivatenode/vpn/internal/paths"
+	"github.com/virtualprivatenode/vpn/internal/system"
+)
+
+// HandoffToAdminConsole drops from root to the admin user on the
+// current tty and runs the TUI there. Returns after the operator
+// leaves the TUI. Never returns an error that should fail the
+// install — the install is already complete; failures degrade to
+// the printed connect line.
+func HandoffToAdminConsole() {
+	tty, restore, err := grantTTY(paths.AdminUser)
+	if err != nil {
+		logger.Install(
+			"handoff: tty ownership not transferable (%v) — "+
+				"printing connect instructions instead", err)
+		printConnectInstructions()
+		return
+	}
+	defer restore()
+
+	logger.Install("handoff: dropping to %s on %s",
+		paths.AdminUser, tty)
+	cmd := exec.Command("su", "-", paths.AdminUser,
+		"-c", paths.BinaryPath)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		logger.Install("handoff: su returned error: %v", err)
+		printConnectInstructions()
+	}
+}
+
+// grantTTY chowns the controlling terminal to the given user for
+// the handoff session and returns a restore function that puts
+// the original owner back.
+func grantTTY(username string) (string, func(), error) {
+	tty, err := os.Readlink("/proc/self/fd/0")
+	if err != nil || !strings.HasPrefix(tty, "/dev/") {
+		return "", nil, fmt.Errorf(
+			"stdin is not a tty (%q, %v)", tty, err)
+	}
+	st, err := os.Stat(tty)
+	if err != nil {
+		return "", nil, err
+	}
+	sys, ok := st.Sys().(*syscall.Stat_t)
+	if !ok {
+		return "", nil, fmt.Errorf("no stat for %s", tty)
+	}
+	origUID, origGID := int(sys.Uid), int(sys.Gid)
+
+	if err := system.SudoRun("chown",
+		username+":tty", tty); err != nil {
+		return "", nil, err
+	}
+	restore := func() {
+		if err := system.SudoRun("chown", fmt.Sprintf(
+			"%d:%d", origUID, origGID), tty); err != nil {
+			logger.Install(
+				"handoff: restoring tty owner failed: %v", err)
+		}
+	}
+	return tty, restore, nil
+}
+
+// printConnectInstructions is the non-interactive completion
+// message (unattended runs, or a degraded interactive handoff).
+func printConnectInstructions() {
+	ip := system.PublicIPv4()
+	target := paths.AdminUser + "@<your-server-ip>"
+	if ip != "" {
+		target = paths.AdminUser + "@" + ip
+	}
+	fmt.Printf("\n  Install complete."+
+		"\n\n  Connect to your node:\n\n    ssh %s\n\n", target)
+}
+
+// AdminLoginObserved reports whether sshd's journal shows an
+// accepted login for the admin user. Evidence for clearing the
+// first-run verification banner: the admin user exists only
+// since this install, so ANY accepted login is a verified,
+// independent way in — no time window needed. Errors (journal
+// unreadable, -g unsupported) report false: the banner stays,
+// which only nags, never locks out.
+func AdminLoginObserved() bool {
+	out, err := system.SudoRunOutput("journalctl",
+		"-u", "ssh", "--no-pager", "-o", "cat",
+		"-g", "Accepted")
+	if err != nil {
+		return false
+	}
+	return journalShowsAdminLogin(out)
+}
+
+// journalShowsAdminLogin scans journal lines for sshd's accepted-
+// login record for the admin user ("Accepted publickey for vpn
+// from …" / "Accepted password for vpn from …"). Pure —
+// unit-tested.
+func journalShowsAdminLogin(journal string) bool {
+	needle := " for " + paths.AdminUser + " from "
+	for _, line := range strings.Split(journal, "\n") {
+		if strings.Contains(line, "Accepted ") &&
+			strings.Contains(line, needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/installer/handoff_test.go
+++ b/internal/installer/handoff_test.go
@@ -1,0 +1,51 @@
+// internal/installer/handoff_test.go
+
+package installer
+
+import "testing"
+
+// ── journalShowsAdminLogin ───────────────────────────────
+
+func TestJournalShowsAdminLogin(t *testing.T) {
+	accepted := []struct {
+		name, journal string
+	}{
+		{"publickey",
+			"Accepted publickey for vpn from 203.0.113.7 " +
+				"port 51234 ssh2: ED25519 SHA256:abc\n"},
+		{"password",
+			"Accepted password for vpn from 203.0.113.7 " +
+				"port 51234 ssh2\n"},
+		{"buried among noise",
+			"Connection closed by 198.51.100.9\n" +
+				"Failed password for vpn from 198.51.100.9 port 1\n" +
+				"Accepted publickey for vpn from 203.0.113.7 " +
+				"port 2 ssh2: ED25519 SHA256:abc\n"},
+	}
+	for _, tt := range accepted {
+		if !journalShowsAdminLogin(tt.journal) {
+			t.Errorf("%s: not detected", tt.name)
+		}
+	}
+
+	rejected := []struct {
+		name, journal string
+	}{
+		{"empty", ""},
+		{"failed attempt only",
+			"Failed password for vpn from 198.51.100.9 port 1\n"},
+		{"different user",
+			"Accepted publickey for root from 203.0.113.7 " +
+				"port 2 ssh2\n"},
+		{"prefix user must not match",
+			"Accepted publickey for vpnadmin from 203.0.113.7 " +
+				"port 2 ssh2\n"},
+		{"invalid user probe",
+			"Invalid user vpn from 198.51.100.9 port 1\n"},
+	}
+	for _, tt := range rejected {
+		if journalShowsAdminLogin(tt.journal) {
+			t.Errorf("%s: false positive", tt.name)
+		}
+	}
+}

--- a/internal/installer/hardware.go
+++ b/internal/installer/hardware.go
@@ -1,0 +1,114 @@
+// internal/installer/hardware.go
+
+package installer
+
+// The hardware-fit install step (ruling viii): detect what the
+// box actually has — RAM from /proc/meminfo, disk from statfs on
+// the data mount, cores — recommend bitcoind settings from it,
+// and let the operator confirm. FIRST-BOOT class (ruling iv):
+// images deploy onto unknown hardware, so this must never run at
+// bake time.
+//
+// Scope now: dbcache sizing off RAM. Prune-vs-full is a separate
+// pending product ruling (LND-on-pruned caveats — owned by the
+// image-track/wizard session); post-IBD dbcache reduction is a
+// later refinement. Post-commit-7 these settings become bounded
+// typed params on the bitcoin config verb (principle 4).
+
+import (
+	"os"
+	"runtime"
+	"strings"
+	"syscall"
+)
+
+// Hardware is the detected machine profile shown to the operator.
+type Hardware struct {
+	RAMMB       int // MemTotal
+	DiskTotalGB int // filesystem holding the data dir
+	DiskFreeGB  int
+	Cores       int
+}
+
+// Product requirements (README): 2 (v)CPU, 4+ GB RAM, 90+ GB SSD.
+// Detected values are compared against these for the fit display —
+// shortfalls WARN, they do not refuse (the operator may know
+// better; a testnet box needs far less disk).
+const (
+	requiredCores  = 2
+	requiredRAMMB  = 3600 // "4 GB" boxes report ~3.8 GiB usable
+	requiredDiskGB = 90
+)
+
+// DetectHardware reads the machine profile. Detection failures
+// yield zero fields — rendered as "unknown", never fatal: the
+// step informs a confirmation, and RecommendDbCache treats
+// unknown RAM conservatively.
+func DetectHardware() Hardware {
+	hw := Hardware{Cores: runtime.NumCPU()}
+
+	if data, err := os.ReadFile("/proc/meminfo"); err == nil {
+		hw.RAMMB = parseMemTotalMB(string(data))
+	}
+
+	// The bitcoin data dir may not exist yet (fresh box) —
+	// statfs the nearest existing ancestor. /var/lib exists on
+	// any Debian system.
+	for _, p := range []string{"/var/lib/bitcoin", "/var/lib", "/"} {
+		var st syscall.Statfs_t
+		if err := syscall.Statfs(p, &st); err == nil {
+			hw.DiskTotalGB = int(uint64(st.Blocks) *
+				uint64(st.Bsize) / 1_000_000_000)
+			hw.DiskFreeGB = int(uint64(st.Bavail) *
+				uint64(st.Bsize) / 1_000_000_000)
+			break
+		}
+	}
+	return hw
+}
+
+// parseMemTotalMB extracts MemTotal from /proc/meminfo content,
+// in MB. Pure — unit-tested. Returns 0 when absent/garbled.
+func parseMemTotalMB(meminfo string) int {
+	for _, line := range strings.Split(meminfo, "\n") {
+		if !strings.HasPrefix(line, "MemTotal:") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			return 0
+		}
+		kb := 0
+		for _, c := range fields[1] {
+			if c < '0' || c > '9' {
+				return 0
+			}
+			kb = kb*10 + int(c-'0')
+		}
+		return kb / 1024
+	}
+	return 0
+}
+
+// RecommendDbCache maps detected RAM to a bitcoind dbcache (MB).
+// Pure — unit-tested. Conservative table, capped at 2048: IBD
+// gains flatten beyond that on a node that also runs LND and Tor,
+// and the box must keep headroom for lnd's own footprint.
+//
+//	unknown / < 3 GB → 512 (the historical hardcode)
+//	≥ 3 GB           → 1024
+//	≥ 6 GB           → 2048
+func RecommendDbCache(ramMB int) int {
+	switch {
+	case ramMB >= 6144:
+		return 2048
+	case ramMB >= 3072:
+		return 1024
+	default:
+		return 512
+	}
+}
+
+// dbCacheChoices are the values the hardware screen cycles
+// through — the recommendation is one of them.
+var dbCacheChoices = []int{512, 1024, 2048}

--- a/internal/installer/hardware_test.go
+++ b/internal/installer/hardware_test.go
@@ -1,0 +1,67 @@
+// internal/installer/hardware_test.go
+
+package installer
+
+import "testing"
+
+// ── parseMemTotalMB ──────────────────────────────────────
+
+func TestParseMemTotalMB(t *testing.T) {
+	meminfo := "MemTotal:        3915776 kB\n" +
+		"MemFree:          123456 kB\n" +
+		"MemAvailable:    2345678 kB\n"
+	if got := parseMemTotalMB(meminfo); got != 3824 {
+		t.Errorf("got %d MB, want 3824", got)
+	}
+	if got := parseMemTotalMB(""); got != 0 {
+		t.Errorf("empty: got %d, want 0", got)
+	}
+	if got := parseMemTotalMB("MemTotal: garbage kB\n"); got != 0 {
+		t.Errorf("garbled: got %d, want 0", got)
+	}
+	if got := parseMemTotalMB("MemTotal:\n"); got != 0 {
+		t.Errorf("missing value: got %d, want 0", got)
+	}
+}
+
+// ── RecommendDbCache ─────────────────────────────────────
+
+func TestRecommendDbCache(t *testing.T) {
+	cases := []struct {
+		ramMB, want int
+	}{
+		{0, 512},    // unknown → the historical hardcode
+		{1024, 512}, // 1 GB
+		{2048, 512}, // 2 GB
+		{3072, 1024},
+		{3824, 1024}, // a nominal "4 GB" box
+		{4096, 1024},
+		{6144, 2048},
+		{7800, 2048}, // a nominal "8 GB" box
+		{16384, 2048},
+	}
+	for _, tt := range cases {
+		if got := RecommendDbCache(tt.ramMB); got != tt.want {
+			t.Errorf("RecommendDbCache(%d) = %d, want %d",
+				tt.ramMB, got, tt.want)
+		}
+	}
+}
+
+// Every recommendation must be selectable on the hardware
+// screen — the recommendation is one of the cycle choices.
+func TestRecommendationsAreChoices(t *testing.T) {
+	for _, ram := range []int{0, 2048, 4096, 8192} {
+		rec := RecommendDbCache(ram)
+		found := false
+		for _, c := range dbCacheChoices {
+			if c == rec {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("recommendation %d for %d MB not in "+
+				"choices %v", rec, ram, dbCacheChoices)
+		}
+	}
+}

--- a/internal/installer/identity.go
+++ b/internal/installer/identity.go
@@ -1,0 +1,343 @@
+// internal/installer/identity.go
+
+package installer
+
+// The identity/access install step (ruling vii + the xvi
+// refinements). Replaces the retired bootstrap script's silent
+// key-guess cascade ($SUDO_USER → logname → who → /root) with an
+// interactive step: enumerate EVERY candidate authorized_keys
+// source on the box, show what was found — fingerprints and
+// comments, with provider decoy lines recognized and excluded
+// rather than copied verbatim — and let the operator confirm the
+// copy or paste a key instead. Keys that already logged into this
+// box are stronger evidence than a fresh paste, so confirmation
+// is by fingerprint, never by re-pasting (ruling xvi).
+//
+// The login password is PROMPTED and non-skippable: with password
+// auth off it is the console-recovery credential, not a network
+// credential — post-commit-7 the admin user is the box's only
+// interactive identity, and no password + broken SSH would leave
+// rescue mode as the only way in. Random generation survives only
+// as the --unattended fallback (the image path; the first-boot
+// wizard replaces it).
+//
+// This file owns enumeration (pure parts unit-tested) and the
+// step's apply function; the wizard screens that collect the
+// operator's decisions live in wizard.go.
+
+import (
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/virtualprivatenode/vpn/internal/logger"
+	"github.com/virtualprivatenode/vpn/internal/paths"
+	"github.com/virtualprivatenode/vpn/internal/system"
+)
+
+// KeySource is one authorized_keys file found on the box.
+type KeySource struct {
+	User     string // owning login ("root", "debian", "ripsline", …)
+	Path     string
+	Keys     []SSHKeyInfo
+	Excluded int // key-bearing lines excluded (options/decoy lines)
+}
+
+// EnumerateKeySources scans every candidate authorized_keys
+// location: /root plus each directory under /home — except the
+// admin user's own (that file is this step's DESTINATION; on a
+// re-run it must not enumerate itself as a source). Unreadable or
+// missing files simply contribute nothing: enumeration informs a
+// decision the operator confirms on screen, so an empty result is
+// visible, not silent.
+func EnumerateKeySources() []KeySource {
+	type candidate struct{ user, path string }
+	cands := []candidate{
+		{"root", "/root/.ssh/authorized_keys"},
+	}
+	if entries, err := os.ReadDir("/home"); err == nil {
+		for _, e := range entries {
+			if !e.IsDir() || e.Name() == paths.AdminUser {
+				continue
+			}
+			cands = append(cands, candidate{
+				e.Name(),
+				filepath.Join("/home", e.Name(),
+					".ssh", "authorized_keys"),
+			})
+		}
+	}
+
+	var sources []KeySource
+	for _, c := range cands {
+		data, err := os.ReadFile(c.path)
+		if err != nil {
+			continue
+		}
+		keys, excluded := classifyAuthorizedKeys(string(data))
+		if len(keys) == 0 && excluded == 0 {
+			continue
+		}
+		sources = append(sources, KeySource{
+			User: c.user, Path: c.path,
+			Keys: keys, Excluded: excluded,
+		})
+	}
+	return sources
+}
+
+// classifyAuthorizedKeys splits authorized_keys content into
+// parseable keys and EXCLUDED key-bearing lines. Pure —
+// unit-tested.
+//
+// An excluded line is one that carries key material but does not
+// parse as a bare "type base64 [comment]" line — i.e. it has an
+// options prefix. The canonical wild instance is the cloud-init
+// forced-command decoy (`no-port-forwarding,...,command="echo
+// 'Please login as ...'" ssh-rsa AAAA...`): copying it verbatim
+// would grant its key access under OUR user with the provider's
+// message semantics stripped of context (the IA-3-E decoy trap).
+// Counting exclusions — instead of dropping them silently — keeps
+// the screen honest about what was on the box.
+func classifyAuthorizedKeys(content string) ([]SSHKeyInfo, int) {
+	var keys []SSHKeyInfo
+	excluded := 0
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		info, err := ParseSSHKey(line)
+		if err == nil {
+			keys = append(keys, info)
+			continue
+		}
+		if lineCarriesKeyMaterial(line) {
+			excluded++
+		}
+	}
+	return keys, excluded
+}
+
+// lineCarriesKeyMaterial reports whether an unparseable
+// authorized_keys line still contains an SSH key (an options
+// prefix ahead of a known key type) as opposed to plain junk.
+// Pure — unit-tested.
+func lineCarriesKeyMaterial(line string) bool {
+	for t := range validKeyTypes {
+		idx := strings.Index(line, t+" ")
+		if idx > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// DedupeKeys flattens sources into a fingerprint-unique key list,
+// preserving first-seen order (root first, then /home in ReadDir
+// order). Pure — unit-tested.
+func DedupeKeys(sources []KeySource) []SSHKeyInfo {
+	seen := map[string]bool{}
+	var out []SSHKeyInfo
+	for _, s := range sources {
+		for _, k := range s.Keys {
+			if seen[k.Fingerprint] {
+				continue
+			}
+			seen[k.Fingerprint] = true
+			out = append(out, k)
+		}
+	}
+	return out
+}
+
+// ── Applying the decisions ───────────────────────────────
+
+// InstallDecisions carries the wizard's answers into the engine
+// steps. Collected before the steps run (interactively or by the
+// unattended defaults) and read by step closures at execution.
+type InstallDecisions struct {
+	// Keys are written to the admin user's authorized_keys.
+	// Empty means password-only access (operator's explicit
+	// choice, or nothing found under --unattended).
+	Keys []SSHKeyInfo
+	// Password is the admin login password (validated at
+	// construction; 16-char minimum from commit 3).
+	Password LoginPassword
+	// GeneratedPassword is set only on the --unattended path
+	// (ruling vii: random generation survives only there);
+	// printed once at the end of the run, never logged.
+	GeneratedPassword string
+	// PasswordApplied is set by the identity step after
+	// chpasswd succeeded. The generated password is printed
+	// ONLY when this is set: on a resume that ledger-skips the
+	// identity step (or an --until=bake run that filters it
+	// out), this pass generated a password that was never
+	// applied — printing it would hand the operator a
+	// credential that does not work.
+	PasswordApplied bool
+	// DbCacheMB is the hardware-fit step's confirmed dbcache
+	// (ruling viii).
+	DbCacheMB int
+	// Obs is the preflight sshd observation (wizard copy +
+	// config seed; the SSH step re-observes before writing).
+	Obs SSHObservation
+}
+
+// applyIdentityAccess is the identity.access step: create the
+// admin user, grant NOPASSWD sudo (commit 7 deletes this — the
+// TUI still runs on sudo until the root helper lands), write the
+// confirmed keys, set the login password, and configure the
+// SSH-login auto-launch. Idempotent — safe to re-run after an
+// interrupt (adduser is guarded, writes overwrite, chpasswd
+// resets to the same password).
+func applyIdentityAccess(dec *InstallDecisions) error {
+	if _, err := user.Lookup(paths.AdminUser); err != nil {
+		if err := system.SudoRun("adduser",
+			"--disabled-password",
+			"--gecos", "Virtual Private Node",
+			paths.AdminUser); err != nil {
+			return fmt.Errorf("create admin user: %w", err)
+		}
+	}
+
+	sudoers := paths.AdminUser + " ALL=(ALL) NOPASSWD:ALL\n"
+	if err := system.SudoWriteFile(
+		paths.AdminSudoers, []byte(sudoers), 0440); err != nil {
+		return fmt.Errorf("write sudoers rule: %w", err)
+	}
+
+	if len(dec.Keys) > 0 {
+		sshDir := paths.AdminHome + "/.ssh"
+		if err := system.SudoRun(
+			"mkdir", "-p", sshDir); err != nil {
+			return fmt.Errorf("mkdir %s: %w", sshDir, err)
+		}
+		var b strings.Builder
+		for _, k := range dec.Keys {
+			b.WriteString(k.RawLine)
+			b.WriteString("\n")
+		}
+		if err := system.SudoWriteFile(paths.AuthorizedKeysFile,
+			[]byte(b.String()), 0600); err != nil {
+			return fmt.Errorf("write authorized_keys: %w", err)
+		}
+		owner := paths.AdminUser + ":" + paths.AdminUser
+		if err := system.SudoRun(
+			"chown", "-R", owner, sshDir); err != nil {
+			return err
+		}
+		if err := system.SudoRun(
+			"chmod", "700", sshDir); err != nil {
+			return err
+		}
+		logger.Install("admin access: %d key(s) written for %s",
+			len(dec.Keys), paths.AdminUser)
+	} else {
+		logger.Install(
+			"admin access: no SSH keys configured (password login)")
+	}
+
+	if err := SetUserPassword(
+		paths.AdminUser, dec.Password); err != nil {
+		return fmt.Errorf("set admin password: %w", err)
+	}
+	dec.PasswordApplied = true
+
+	return writeAdminAutoLaunch()
+}
+
+// writeAdminAutoLaunch installs the .bash_profile that opens the
+// TUI on SSH login — the retired bootstrap's auto-launch,
+// verbatim in behavior: only on SSH sessions with a tty, and
+// .bashrc (where shellenv puts the cli wrappers) is sourced
+// after.
+func writeAdminAutoLaunch() error {
+	profile := `# Virtual Private Node — auto-launch
+if [ -n "$SSH_CONNECTION" ] && [ -t 0 ]; then
+    ` + paths.BinaryPath + `
+fi
+
+# Source .bashrc after the TUI exits (cli wrappers live there)
+[ -f ~/.bashrc ] && source ~/.bashrc
+`
+	if err := system.SudoWriteFile(paths.AdminBashProfile,
+		[]byte(profile), 0644); err != nil {
+		return fmt.Errorf("write .bash_profile: %w", err)
+	}
+	return system.SudoRun("chown",
+		paths.AdminUser+":"+paths.AdminUser,
+		paths.AdminBashProfile)
+}
+
+// installSelfBinary is the binary.install step: place the running
+// executable at paths.BinaryPath if it is not already running
+// from there — the auto-launch profile and the handoff both
+// depend on that path existing. A source build run as
+// `sudo ./vpn install` gets installed; a binary already at the
+// canonical path (the MIGRATION.md flow installs it in step 1)
+// no-ops.
+func installSelfBinary() error {
+	self, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("locate own binary: %w", err)
+	}
+	if resolved, err := filepath.EvalSymlinks(self); err == nil {
+		self = resolved
+	}
+	if self == paths.BinaryPath {
+		return nil
+	}
+	if err := system.SudoRun("install", "-m", "755",
+		self, paths.BinaryPath); err != nil {
+		return fmt.Errorf("install binary: %w", err)
+	}
+	logger.Install("binary installed to %s (from %s)",
+		paths.BinaryPath, self)
+	return nil
+}
+
+// generateAdminPassword returns a random alphanumeric password
+// for the --unattended fallback (ruling vii). 25 characters from
+// a 62-symbol alphabet (~148 bits) — same shape the retired
+// bootstrap printed. Uses rejection sampling for uniformity.
+func generateAdminPassword() (string, error) {
+	const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ" +
+		"abcdefghijklmnopqrstuvwxyz0123456789"
+	const length = 25
+	out := make([]byte, 0, length)
+	buf := make([]byte, 64)
+	for len(out) < length {
+		if _, err := randRead(buf); err != nil {
+			return "", fmt.Errorf("generate password: %w", err)
+		}
+		for _, b := range buf {
+			// Reject bytes that would bias the modulus.
+			if int(b) >= 248 { // 248 = 4*62
+				continue
+			}
+			out = append(out, alphabet[int(b)%62])
+			if len(out) == length {
+				break
+			}
+		}
+	}
+	return string(out), nil
+}
+
+// SortKeySources orders sources root-first then by user name for
+// stable display. Pure — unit-tested.
+func SortKeySources(sources []KeySource) []KeySource {
+	out := make([]KeySource, len(sources))
+	copy(out, sources)
+	sort.SliceStable(out, func(i, j int) bool {
+		if (out[i].User == "root") != (out[j].User == "root") {
+			return out[i].User == "root"
+		}
+		return out[i].User < out[j].User
+	})
+	return out
+}

--- a/internal/installer/identity.go
+++ b/internal/installer/identity.go
@@ -247,6 +247,18 @@ func applyIdentityAccess(dec *InstallDecisions) error {
 	}
 	dec.PasswordApplied = true
 
+	if dec.GeneratedPassword != "" {
+		// Unattended path: the password just applied is machine
+		// generated and will not be printed until the end of the
+		// run. Record that gap durably — if this run dies before
+		// the print, the resuming pass must know a credential is
+		// still owed (see passwordpending.go).
+		if err := markPasswordPending(); err != nil {
+			return fmt.Errorf(
+				"record password-pending marker: %w", err)
+		}
+	}
+
 	return writeAdminAutoLaunch()
 }
 

--- a/internal/installer/identity_test.go
+++ b/internal/installer/identity_test.go
@@ -145,3 +145,21 @@ func TestGenerateAdminPassword(t *testing.T) {
 		t.Error("two generated passwords identical")
 	}
 }
+
+// ── pasteFirstLine ───────────────────────────────────────
+
+func TestPasteFirstLine(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"secret-password", "secret-password"},
+		{"  padded  ", "padded"},
+		{"line1\nline2\n", "line1"},
+		{"key data comment\n", "key data comment"},
+		{"\n", ""},
+	}
+	for _, tt := range cases {
+		if got := pasteFirstLine(tt.in); got != tt.want {
+			t.Errorf("pasteFirstLine(%q) = %q, want %q",
+				tt.in, got, tt.want)
+		}
+	}
+}

--- a/internal/installer/identity_test.go
+++ b/internal/installer/identity_test.go
@@ -1,0 +1,147 @@
+// internal/installer/identity_test.go
+
+package installer
+
+import (
+	"strings"
+	"testing"
+)
+
+const (
+	testKeyA = "ssh-ed25519 QUFBQUFBQUFBQQ== alice@laptop"
+	testKeyB = "ssh-rsa QkJCQkJCQkJCQg== bob@desktop"
+	// The wild cloud-init decoy shape: an options prefix with a
+	// forced command ahead of real key material.
+	testDecoy = `no-port-forwarding,no-agent-forwarding,` +
+		`command="echo 'Please login as the user \"admin\" ` +
+		`rather than the user \"root\".'" ` +
+		`ssh-ed25519 QUFBQUFBQUFBQQ== provisioning`
+)
+
+// ── classifyAuthorizedKeys ───────────────────────────────
+
+func TestClassifyAuthorizedKeysPlain(t *testing.T) {
+	keys, excluded := classifyAuthorizedKeys(
+		testKeyA + "\n" + testKeyB + "\n")
+	if len(keys) != 2 || excluded != 0 {
+		t.Fatalf("got %d keys %d excluded, want 2/0",
+			len(keys), excluded)
+	}
+	if keys[0].Comment != "alice@laptop" {
+		t.Errorf("comment: got %q", keys[0].Comment)
+	}
+}
+
+// The decoy trap (IA-3-E context, ruling vii): a forced-command
+// provider line must be EXCLUDED and COUNTED — never copied
+// verbatim, never silently dropped.
+func TestClassifyAuthorizedKeysExcludesDecoy(t *testing.T) {
+	keys, excluded := classifyAuthorizedKeys(
+		testDecoy + "\n" + testKeyA + "\n")
+	if len(keys) != 1 {
+		t.Fatalf("got %d keys, want 1", len(keys))
+	}
+	if keys[0].Comment != "alice@laptop" {
+		t.Errorf("wrong key survived: %+v", keys[0])
+	}
+	if excluded != 1 {
+		t.Errorf("excluded: got %d, want 1", excluded)
+	}
+}
+
+func TestClassifyAuthorizedKeysSkipsNoise(t *testing.T) {
+	keys, excluded := classifyAuthorizedKeys(
+		"# a comment\n\n   \n" + testKeyA + "\n" +
+			"complete garbage line\n")
+	if len(keys) != 1 {
+		t.Errorf("got %d keys, want 1", len(keys))
+	}
+	// Garbage without key material is noise, not an exclusion —
+	// counting it would overstate what was on the box.
+	if excluded != 0 {
+		t.Errorf("excluded: got %d, want 0", excluded)
+	}
+}
+
+// ── lineCarriesKeyMaterial ───────────────────────────────
+
+func TestLineCarriesKeyMaterial(t *testing.T) {
+	if !lineCarriesKeyMaterial(testDecoy) {
+		t.Error("decoy line: got false, want true")
+	}
+	if lineCarriesKeyMaterial("complete garbage line") {
+		t.Error("garbage line: got true, want false")
+	}
+	// A bare valid key line starts WITH the type (index 0) —
+	// this helper only classifies unparseable lines, which by
+	// construction have a prefix before the type.
+	if lineCarriesKeyMaterial(testKeyA) {
+		t.Error("bare key line: got true, want false")
+	}
+}
+
+// ── DedupeKeys ───────────────────────────────────────────
+
+func TestDedupeKeys(t *testing.T) {
+	a, _ := ParseSSHKey(testKeyA)
+	b, _ := ParseSSHKey(testKeyB)
+	sources := []KeySource{
+		{User: "root", Keys: []SSHKeyInfo{a, b}},
+		{User: "debian", Keys: []SSHKeyInfo{a}}, // duplicate
+	}
+	out := DedupeKeys(sources)
+	if len(out) != 2 {
+		t.Fatalf("got %d keys, want 2", len(out))
+	}
+	if out[0].Fingerprint != a.Fingerprint ||
+		out[1].Fingerprint != b.Fingerprint {
+		t.Error("order not first-seen")
+	}
+}
+
+// ── SortKeySources ───────────────────────────────────────
+
+func TestSortKeySourcesRootFirst(t *testing.T) {
+	in := []KeySource{
+		{User: "debian"}, {User: "admin"}, {User: "root"},
+	}
+	out := SortKeySources(in)
+	if out[0].User != "root" || out[1].User != "admin" ||
+		out[2].User != "debian" {
+		t.Errorf("order: got %v", []string{
+			out[0].User, out[1].User, out[2].User})
+	}
+	// Input untouched.
+	if in[0].User != "debian" {
+		t.Error("input mutated")
+	}
+}
+
+// ── generateAdminPassword ────────────────────────────────
+
+func TestGenerateAdminPassword(t *testing.T) {
+	pw, err := generateAdminPassword()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(pw) != 25 {
+		t.Errorf("length: got %d, want 25", len(pw))
+	}
+	for _, c := range pw {
+		if !strings.ContainsRune(
+			"ABCDEFGHIJKLMNOPQRSTUVWXYZ"+
+				"abcdefghijklmnopqrstuvwxyz0123456789", c) {
+			t.Errorf("character %q outside alphabet", c)
+		}
+	}
+	// The generated fallback must satisfy the same policy the
+	// interactive prompt enforces.
+	if _, err := NewLoginPassword(pw); err != nil {
+		t.Errorf("generated password fails validation: %v", err)
+	}
+	// Two draws must differ (sanity, not a randomness test).
+	pw2, _ := generateAdminPassword()
+	if pw == pw2 {
+		t.Error("two generated passwords identical")
+	}
+}

--- a/internal/installer/ledger.go
+++ b/internal/installer/ledger.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/ripsline/virtual-private-node/internal/logger"
+	"github.com/virtualprivatenode/vpn/internal/logger"
 )
 
 // ── Install ledger ───────────────────────────────────────

--- a/internal/installer/lnd.go
+++ b/internal/installer/lnd.go
@@ -12,10 +12,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ripsline/virtual-private-node/internal/config"
-	"github.com/ripsline/virtual-private-node/internal/logger"
-	"github.com/ripsline/virtual-private-node/internal/paths"
-	"github.com/ripsline/virtual-private-node/internal/system"
+	"github.com/virtualprivatenode/vpn/internal/config"
+	"github.com/virtualprivatenode/vpn/internal/logger"
+	"github.com/virtualprivatenode/vpn/internal/paths"
+	"github.com/virtualprivatenode/vpn/internal/system"
 )
 
 func downloadLND(version, workDir string) error {
@@ -227,7 +227,7 @@ func startLND() error {
 func setupAutoUnlock(password string) error {
 	// Write password to a secure temp file, then sudo move it.
 	// os.CreateTemp uses O_EXCL to prevent symlink attacks.
-	tmpFile, err := os.CreateTemp("", "rlvpn-wallet-pw-")
+	tmpFile, err := os.CreateTemp("", "vpn-wallet-pw-")
 	if err != nil {
 		return fmt.Errorf("create temp: %w", err)
 	}

--- a/internal/installer/observe.go
+++ b/internal/installer/observe.go
@@ -1,0 +1,151 @@
+// internal/installer/observe.go
+
+package installer
+
+// Read-only sshd observation for the install path (ruling
+// xvi(b)). One privileged query answers the two questions the
+// installer must not guess at:
+//
+//   - which port(s) sshd actually listens on — the firewall
+//     allow-rules derive from this. Guessing 22 was the one
+//     real lockout hazard in the old script order: enabling
+//     deny-all with only 22 open while sshd listens elsewhere
+//     is a DELAYED silent lockout (the current connection
+//     survives; the next one is refused).
+//   - whether password authentication is effectively enabled —
+//     the ruling-vii seed for cfg.SSHPasswordAuthDisabled (only
+//     when the field is absent, never clobbering a carried-over
+//     answer), the state-aware wizard copy, and the explicit
+//     PasswordAuthentication directive in the install drop-in
+//     (ruling xvi(a): explicit-from-observed).
+//
+// The observation runs in preflight and REFUSES the install on
+// failure — a running-sshd box always parses, so failure means
+// a broken environment, and there is deliberately no guessing
+// path (xvi(b)). The SSH hardening step re-observes seconds
+// before its write; only THAT later observation may degrade
+// (to directive omission, xvi(a)) because by then refusing
+// would strand a half-installed box.
+//
+// The query simulates a connection as root — the admin user
+// does not exist yet at observation time (the identity step
+// creates it later in this same install), and the question
+// asked here is the box-global one ("is password auth on,
+// today, before we changed anything"), not the per-user
+// question the TUI's EffectiveSSHPasswordAuth answers after
+// install. Same [LIVE]-verified `sshd -T -C` invocation shape
+// as commit 2 (openssh-server 1:10.0p1-7+deb13u4).
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/virtualprivatenode/vpn/internal/system"
+)
+
+// SSHObservation is the read-only snapshot of the running
+// sshd's effective configuration taken before any mutation.
+type SSHObservation struct {
+	// Ports are the listening ports, deduplicated, sorted.
+	Ports []int
+	// PasswordAuth reports whether password authentication is
+	// effectively enabled.
+	PasswordAuth bool
+}
+
+// ObserveSSHState queries the running sshd's effective
+// configuration. Callers on the preflight path treat an error
+// as refuse-to-install; the SSH step treats it as
+// omit-directive-and-warn (ruling xvi(a)/(b) asymmetry).
+func ObserveSSHState() (SSHObservation, error) {
+	out, err := system.SudoRunOutput("sshd", "-T",
+		"-C", "user=root,host=localhost,addr=127.0.0.1")
+	if err != nil {
+		return SSHObservation{}, fmt.Errorf(
+			"query effective sshd config: %w", err)
+	}
+	return parseSSHObservation(out)
+}
+
+// parseSSHObservation extracts ports and password-auth state
+// from sshd -T output (one "keyword value..." pair per line,
+// keywords lowercased by sshd). Pure — unit-tested.
+//
+// Ports are the UNION of every `port` line and every
+// `listenaddress host:port` line: a ListenAddress with an
+// explicit port makes sshd listen there even when it differs
+// from the Port directive. The union direction is fail-safe
+// for a firewall allow-list — allowing a port sshd does not
+// listen on wastes a rule; missing one it does listen on is
+// the lockout.
+func parseSSHObservation(sshdOutput string) (SSHObservation, error) {
+	portSet := map[int]bool{}
+	pwSeen := false
+	pw := false
+
+	for _, line := range strings.Split(sshdOutput, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		switch strings.ToLower(fields[0]) {
+		case "port":
+			if p, err := strconv.Atoi(fields[1]); err == nil &&
+				p > 0 && p < 65536 {
+				portSet[p] = true
+			}
+		case "listenaddress":
+			if p, ok := portFromListenAddress(fields[1]); ok {
+				portSet[p] = true
+			}
+		case "passwordauthentication":
+			// First match wins, like sshd itself.
+			if !pwSeen {
+				pw = strings.EqualFold(fields[1], "yes")
+				pwSeen = true
+			}
+		}
+	}
+
+	if len(portSet) == 0 {
+		return SSHObservation{}, errors.New(
+			"no listening port found in sshd -T output")
+	}
+	if !pwSeen {
+		return SSHObservation{}, errors.New(
+			"passwordauthentication not present in sshd -T output")
+	}
+
+	ports := make([]int, 0, len(portSet))
+	for p := range portSet {
+		ports = append(ports, p)
+	}
+	sort.Ints(ports)
+	return SSHObservation{Ports: ports, PasswordAuth: pw}, nil
+}
+
+// portFromListenAddress extracts the port from a
+// ListenAddress value as printed by sshd -T: "0.0.0.0:22",
+// "[::]:22", or an address with no port (no port to extract).
+// Pure — unit-tested.
+func portFromListenAddress(addr string) (int, bool) {
+	i := strings.LastIndex(addr, ":")
+	if i < 0 || i == len(addr)-1 {
+		return 0, false
+	}
+	// Bare IPv6 without brackets has colons but no port
+	// separator we can trust; only accept a numeric suffix
+	// that follows either a bracket or a dotted/hostname
+	// form ("]:" or a single-colon value).
+	if strings.Count(addr, ":") > 1 && !strings.Contains(addr, "]:") {
+		return 0, false
+	}
+	p, err := strconv.Atoi(addr[i+1:])
+	if err != nil || p <= 0 || p >= 65536 {
+		return 0, false
+	}
+	return p, true
+}

--- a/internal/installer/observe_test.go
+++ b/internal/installer/observe_test.go
@@ -1,0 +1,137 @@
+// internal/installer/observe_test.go
+
+package installer
+
+import (
+	"strings"
+	"testing"
+)
+
+// ── parseSSHObservation ──────────────────────────────────
+
+func TestParseSSHObservationDefaultBox(t *testing.T) {
+	out := "port 22\n" +
+		"addressfamily any\n" +
+		"listenaddress [::]:22\n" +
+		"listenaddress 0.0.0.0:22\n" +
+		"passwordauthentication yes\n" +
+		"permitrootlogin without-password\n"
+	obs, err := parseSSHObservation(out)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(obs.Ports) != 1 || obs.Ports[0] != 22 {
+		t.Errorf("ports: got %v, want [22]", obs.Ports)
+	}
+	if !obs.PasswordAuth {
+		t.Error("password auth: got disabled, want enabled")
+	}
+}
+
+func TestParseSSHObservationNonstandardPort(t *testing.T) {
+	out := "port 2222\n" +
+		"listenaddress [::]:2222\n" +
+		"listenaddress 0.0.0.0:2222\n" +
+		"passwordauthentication no\n"
+	obs, err := parseSSHObservation(out)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(obs.Ports) != 1 || obs.Ports[0] != 2222 {
+		t.Errorf("ports: got %v, want [2222]", obs.Ports)
+	}
+	if obs.PasswordAuth {
+		t.Error("password auth: got enabled, want disabled")
+	}
+}
+
+// A ListenAddress with an explicit port makes sshd listen there
+// even when it differs from the Port directive — the union is
+// what the firewall must allow (the lockout direction).
+func TestParseSSHObservationPortUnion(t *testing.T) {
+	out := "port 22\n" +
+		"listenaddress 0.0.0.0:2222\n" +
+		"passwordauthentication yes\n"
+	obs, err := parseSSHObservation(out)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(obs.Ports) != 2 || obs.Ports[0] != 22 ||
+		obs.Ports[1] != 2222 {
+		t.Errorf("ports: got %v, want [22 2222]", obs.Ports)
+	}
+}
+
+func TestParseSSHObservationMultiplePortLines(t *testing.T) {
+	out := "port 22\nport 2222\npasswordauthentication yes\n"
+	obs, err := parseSSHObservation(out)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(obs.Ports) != 2 {
+		t.Errorf("ports: got %v, want two ports", obs.Ports)
+	}
+}
+
+// First match wins for passwordauthentication, like sshd's own
+// config semantics.
+func TestParseSSHObservationFirstPwAuthWins(t *testing.T) {
+	out := "port 22\n" +
+		"passwordauthentication no\n" +
+		"passwordauthentication yes\n"
+	obs, err := parseSSHObservation(out)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if obs.PasswordAuth {
+		t.Error("first-match: got enabled, want disabled")
+	}
+}
+
+func TestParseSSHObservationRefusals(t *testing.T) {
+	cases := []struct {
+		name, out, wantIn string
+	}{
+		{"no port line",
+			"passwordauthentication yes\n", "no listening port"},
+		{"no passwordauthentication",
+			"port 22\n", "passwordauthentication not present"},
+		{"empty output", "", "no listening port"},
+	}
+	for _, tt := range cases {
+		if _, err := parseSSHObservation(tt.out); err == nil {
+			t.Errorf("%s: accepted, want error", tt.name)
+		} else if !strings.Contains(err.Error(), tt.wantIn) {
+			t.Errorf("%s: error %q does not mention %q",
+				tt.name, err, tt.wantIn)
+		}
+	}
+}
+
+// ── portFromListenAddress ────────────────────────────────
+
+func TestPortFromListenAddress(t *testing.T) {
+	cases := []struct {
+		addr string
+		port int
+		ok   bool
+	}{
+		{"0.0.0.0:22", 22, true},
+		{"[::]:22", 22, true},
+		{"[::]:2222", 2222, true},
+		{"192.168.1.1:2022", 2022, true},
+		{"0.0.0.0", 0, false},        // no port
+		{"0.0.0.0:", 0, false},       // empty port
+		{"0.0.0.0:notnum", 0, false}, // garbage
+		{"0.0.0.0:0", 0, false},      // out of range
+		{"0.0.0.0:70000", 0, false},  // out of range
+		{"::1", 0, false},            // bare IPv6, no bracket
+	}
+	for _, tt := range cases {
+		p, ok := portFromListenAddress(tt.addr)
+		if ok != tt.ok || (ok && p != tt.port) {
+			t.Errorf("portFromListenAddress(%q) = (%d,%v), "+
+				"want (%d,%v)", tt.addr, p, ok, tt.port, tt.ok)
+		}
+	}
+}

--- a/internal/installer/passwordpending.go
+++ b/internal/installer/passwordpending.go
@@ -1,0 +1,82 @@
+// internal/installer/passwordpending.go
+
+package installer
+
+// The password-pending marker closes a fail-then-resume hole on
+// the unattended path (live-run finding): the identity step
+// APPLIES the generated admin password early in the run, but the
+// password is PRINTED only at the very end of a completed run. A
+// run that fails between the two leaves the box holding a
+// recovery password nobody has ever seen — and the resuming pass
+// ledger-skips the identity step, so without outside help it
+// would complete without ever showing a working credential.
+//
+// The marker is that outside help: a root-owned flag file whose
+// presence means "a generated admin password is applied on this
+// box but was never displayed". A completing unattended pass
+// that finds it re-applies its own freshly generated password
+// and prints that one instead. The operator setting a password
+// of their own from the node console clears it too — at that
+// point they hold a credential they chose. The file carries no
+// secret; plaintext passwords exist only in process memory.
+
+import (
+	"os"
+
+	"github.com/virtualprivatenode/vpn/internal/logger"
+	"github.com/virtualprivatenode/vpn/internal/paths"
+	"github.com/virtualprivatenode/vpn/internal/system"
+)
+
+const passwordPendingNote = `An unattended install applied a generated admin login password
+that has not been displayed yet. A completed unattended run
+resolves this automatically; setting a new password from the
+node console also clears it.
+`
+
+// markPasswordPending records that a generated password was
+// applied but not yet displayed. Failure is returned, not
+// swallowed: this marker is what guarantees the credential can
+// still reach the operator if the run dies before the print.
+func markPasswordPending() error {
+	return system.SudoWriteFile(
+		paths.PasswordPendingMarker,
+		[]byte(passwordPendingNote), 0600)
+}
+
+// passwordPending reports whether the marker is present.
+func passwordPending() bool {
+	_, err := os.Stat(paths.PasswordPendingMarker)
+	return err == nil
+}
+
+// ClearPasswordPendingMarker removes the marker. Best-effort by
+// design: it runs at moments when the operator HAS a working
+// credential (it was just printed, or they just chose one), so a
+// failed removal must not fail that operation — the cost of a
+// stale marker is one redundant password re-apply and re-print
+// on a later completing run.
+func ClearPasswordPendingMarker() {
+	if err := os.Remove(paths.PasswordPendingMarker); err != nil &&
+		!os.IsNotExist(err) {
+		logger.Install(
+			"WARNING: could not remove %s (%v) — a later install "+
+				"re-run may re-apply and print a fresh password",
+			paths.PasswordPendingMarker, err)
+	}
+}
+
+// needsPasswordReapply decides whether a completing unattended
+// pass must re-apply its generated password so the printed
+// credential is one that works. True only when this pass
+// generated a password (unattended), the identity step did NOT
+// apply it (ledger-skipped on a resume), and the marker says an
+// earlier pass left one undisplayed. A re-run after a completed
+// install has no marker, so it re-applies and prints nothing —
+// the password the operator saved (or later changed) stands.
+// Pure — unit-tested.
+func needsPasswordReapply(
+	generated string, appliedThisPass, pendingOnDisk bool,
+) bool {
+	return generated != "" && !appliedThisPass && pendingOnDisk
+}

--- a/internal/installer/passwordpending_test.go
+++ b/internal/installer/passwordpending_test.go
@@ -1,0 +1,37 @@
+// internal/installer/passwordpending_test.go
+
+package installer
+
+import "testing"
+
+// The four run shapes that matter, by name. The one that found
+// this (live-run finding): a resume after a mid-run failure must
+// re-apply, because the earlier pass's password was applied but
+// never displayed. The one that must NOT fire: a re-run after a
+// completed install — the operator saved (or later changed) the
+// standing password, and clobbering it would invalidate it.
+func TestNeedsPasswordReapply(t *testing.T) {
+	cases := []struct {
+		name      string
+		generated string
+		applied   bool
+		pending   bool
+		want      bool
+	}{
+		{"fresh unattended run, identity applied this pass",
+			"pw", true, true, false},
+		{"resume after mid-run failure", "pw", false, true, true},
+		{"re-run after completed install", "pw", false, false,
+			false},
+		{"interactive pass generates no password", "", false,
+			true, false},
+	}
+	for _, tt := range cases {
+		got := needsPasswordReapply(
+			tt.generated, tt.applied, tt.pending)
+		if got != tt.want {
+			t.Errorf("%s: got %v, want %v",
+				tt.name, got, tt.want)
+		}
+	}
+}

--- a/internal/installer/preflight.go
+++ b/internal/installer/preflight.go
@@ -8,12 +8,27 @@ package installer
 // checks run and every failure is reported at once, so the operator
 // fixes everything in one round trip.
 //
-// Placement: called at the top of Run(), before the install TUI
-// opens, at the seam the old checkOS() occupied (preflight absorbs
-// it). A refused box is untouched — no user created, no config
-// written, no service restarted. The commit-6 root install re-homes
-// this call under the `vpn install` dispatch; notes for that session
-// are on the individual checks below.
+// Placement: called at the top of RunInstall(), under root dispatch
+// (`sudo vpn install`), before the wizard opens. A refused box is
+// untouched — no user created, no config written, no service
+// restarted.
+//
+// Re-homed under root dispatch (ruling xvi(c)):
+//   - the commit-4 `sudo -n` scaffolding check is DELETED — install
+//     no longer depends on any sudo rule (it IS root), and commit 7
+//     deletes NOPASSWD entirely;
+//   - the torsocks assertion RE-SEQUENCED out of preflight: the
+//     engine installs tor/torsocks itself now, so asserting it here
+//     would refuse every fresh box. The post-Tor-install,
+//     pre-first-download assertion lives in the torgate step
+//     (torgate.go LookPaths torsocks before gating; retires with
+//     the Go-native Tor client, standalone queue #6);
+//   - the sudoers scan reads /etc/sudoers.d directly — root needs
+//     no `sudo find` workaround, and the failed-as-skipped
+//     plumbing that coupled it to the deleted sudo check is gone;
+//   - NEW: read-only sshd port/auth observation (observe.go),
+//     REFUSE on failure — the firewall rules and the drop-in seed
+//     derive from it, and there is deliberately no guessing path.
 
 import (
 	"context"
@@ -21,13 +36,12 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 	"time"
 
-	"github.com/ripsline/virtual-private-node/internal/logger"
-	"github.com/ripsline/virtual-private-node/internal/paths"
-	"github.com/ripsline/virtual-private-node/internal/system"
+	"github.com/virtualprivatenode/vpn/internal/logger"
+	"github.com/virtualprivatenode/vpn/internal/paths"
+	"github.com/virtualprivatenode/vpn/internal/system"
 )
 
 // PreflightResult is one check's outcome. Err == nil means pass.
@@ -39,19 +53,21 @@ type PreflightResult struct {
 // Check names double as report labels — short, present-tense facts.
 const (
 	checkNameDebian    = "Debian version is exactly 13"
-	checkNameSudo      = "passwordless sudo works"
-	checkNameTorsocks  = "torsocks is installed"
 	checkNameIOLogging = "sudo I/O logging is disabled"
 	checkNameDpkg      = "package system is healthy (dpkg --audit)"
 	checkNameUfw       = "ufw is installable"
+	checkNameSSHState  = "ssh daemon state is observable"
 )
 
 // RunPreflight runs every check, prints a full report to stderr on
 // any failure (and mirrors the failures to the log file, so the log
 // trail never just stops), and returns a summary error that aborts
-// the install before its first step.
-func RunPreflight() error {
-	results := runPreflightChecks()
+// the install before its first step. On success it returns the sshd
+// observation for the wizard copy, the firewall rules, and the
+// config seed — observed once, consumed everywhere (the SSH
+// hardening step re-observes seconds before its own write).
+func RunPreflight() (SSHObservation, error) {
+	results, obs := runPreflightChecks()
 
 	failed := 0
 	for _, r := range results {
@@ -62,7 +78,7 @@ func RunPreflight() error {
 	if failed == 0 {
 		logger.Install("Preflight passed (%d/%d checks)",
 			len(results), len(results))
-		return nil
+		return obs, nil
 	}
 
 	fmt.Fprint(os.Stderr, "\n"+FormatPreflightReport(results))
@@ -71,41 +87,25 @@ func RunPreflight() error {
 			logger.Install("Preflight FAIL: %s: %v", r.Name, r.Err)
 		}
 	}
-	return fmt.Errorf(
+	return obs, fmt.Errorf(
 		"preflight: %d of %d checks failed — nothing was changed",
 		failed, len(results))
 }
 
-// runPreflightChecks executes the checks in dependency order. The
-// sudoers scan needs working sudo to read root-owned files, so it is
-// reported as a failure (not silently passed) when the sudo check
-// already failed — fail-safe direction: cannot verify means refuse.
-func runPreflightChecks() []PreflightResult {
+// runPreflightChecks executes the checks in order. All five run
+// unconditionally — root dispatch removed the sudo dependency that
+// used to force failed-as-skipped coupling between checks.
+func runPreflightChecks() ([]PreflightResult, SSHObservation) {
 	results := []PreflightResult{
 		{checkNameDebian, checkDebian13()},
+		{checkNameIOLogging, checkSudoersIOLogging()},
+		{checkNameDpkg, checkDpkgAudit()},
+		{checkNameUfw, checkUfwInstallable()},
 	}
-
-	sudoErr := checkPasswordlessSudo()
-	results = append(results, PreflightResult{checkNameSudo, sudoErr})
+	obs, obsErr := ObserveSSHState()
 	results = append(results,
-		PreflightResult{checkNameTorsocks, checkTorsocks()})
-
-	var ioLogErr error
-	if sudoErr != nil {
-		ioLogErr = errors.New(
-			"skipped — cannot read the sudo configuration " +
-				"while passwordless sudo is not working")
-	} else {
-		ioLogErr = checkSudoersIOLogging()
-	}
-	results = append(results,
-		PreflightResult{checkNameIOLogging, ioLogErr})
-
-	results = append(results,
-		PreflightResult{checkNameDpkg, checkDpkgAudit()})
-	results = append(results,
-		PreflightResult{checkNameUfw, checkUfwInstallable()})
-	return results
+		PreflightResult{checkNameSSHState, obsErr})
+	return results, obs
 }
 
 // ── Check 1: OS ──────────────────────────────────────────
@@ -154,54 +154,20 @@ func checkOSRelease(content string) error {
 	return nil
 }
 
-// ── Check 2: sudo ────────────────────────────────────────
-
-// checkPasswordlessSudo asserts the bootstrap's NOPASSWD rule is
-// actually usable: `sudo -n true` fails instead of prompting when a
-// password would be required. Without this, a half-bootstrapped box
-// dies mid-install with the sudo error buried in whichever step ran
-// first.
-//
-// SCAFFOLDING for the pre-commit-6 world: once `vpn install` runs
-// as root (commit 6) there is no sudo rule to depend on during
-// install, and commit 7 deletes NOPASSWD entirely. The commit-6
-// session deletes this check.
-func checkPasswordlessSudo() error {
-	if _, err := system.RunContext(
-		15*time.Second, "sudo", "-n", "true"); err != nil {
-		return fmt.Errorf(
-			"passwordless sudo is not working (%v) — re-run the "+
-				"bootstrap script or restore /etc/sudoers.d/%s",
-			err, paths.AdminUser)
-	}
-	return nil
-}
-
-// ── Check 3: torsocks ────────────────────────────────────
-
-// checkTorsocks asserts torsocks is on PATH. The bootstrap script
-// installed it before this binary ever ran, so its absence means a
-// tampered or unfinished bootstrap. All downloads route through it
-// (the torgate step re-checks at its own point in the sequence).
-// Retired when the Go-native Tor client lands (standalone queue #6).
-func checkTorsocks() error {
-	if _, err := exec.LookPath("torsocks"); err != nil {
-		return errors.New(
-			"torsocks not found — all downloads must route " +
-				"through Tor; re-run the bootstrap script")
-	}
-	return nil
-}
-
-// ── Check 4: sudo I/O logging (IA-3-H) ───────────────────
+// ── Check 2: sudo I/O logging (IA-3-H) ───────────────────
 
 // checkSudoersIOLogging asserts no sudoers file enables sudo's
-// input/output recording. With log_input set, the moment this app
+// input/output recording. With log_input set, the moment the TUI
 // pipes the admin password to `sudo chpasswd`, sudo would tee the
 // plaintext to /var/log/sudo-io — a passive credential sink. Scope:
 // /etc/sudoers plus every file sudo's @includedir would parse in
 // /etc/sudoers.d. Residual (documented, accepted): a nonstandard
 // @includedir pointing elsewhere is not followed.
+//
+// The install itself runs as root and never trips this — the check
+// protects the ADMIN-USER era that starts at handoff (and it dies
+// with the TUI's sudo use at commit 7, when the root helper takes
+// over).
 func checkSudoersIOLogging() error {
 	files := []string{paths.SudoersFile}
 	dropIns, err := listSudoersDropIns()
@@ -211,7 +177,7 @@ func checkSudoersIOLogging() error {
 	files = append(files, dropIns...)
 
 	for _, f := range files {
-		data, err := system.SudoReadFile(f)
+		data, err := os.ReadFile(f)
 		if err != nil {
 			return fmt.Errorf("cannot read %s: %w", f, err)
 		}
@@ -228,45 +194,32 @@ func checkSudoersIOLogging() error {
 }
 
 // listSudoersDropIns enumerates the files sudo's @includedir would
-// parse. The directory is enumerated THROUGH sudo: /etc/sudoers.d
-// itself is not world-listable on Debian 13 ([LIVE], commit-4 run —
-// an unprivileged os.ReadDir here got permission denied, which
-// would have refused every clean box). find emits regular files
-// only, so a stray subdirectory can never reach the file reads. A
-// missing directory means nothing to scan; any other stat failure
-// refuses (stat needs no permission on the directory itself).
+// parse. Running as root, the directory is read directly — the
+// commit-4 `sudo find` workaround (needed because /etc/sudoers.d
+// is 750 root:root on Debian 13 [LIVE] and the check then ran
+// unprivileged) is gone. A missing directory means nothing to
+// scan; any other failure refuses. Subdirectories are skipped —
+// sudo's includedir reads regular files only.
 func listSudoersDropIns() ([]string, error) {
-	if _, err := os.Stat(paths.SudoersDir); err != nil {
+	entries, err := os.ReadDir(paths.SudoersDir)
+	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
 		}
 		return nil, fmt.Errorf(
-			"cannot stat %s: %w", paths.SudoersDir, err)
-	}
-	out, err := system.SudoRunOutput("find", paths.SudoersDir,
-		"-maxdepth", "1", "-type", "f")
-	if err != nil {
-		return nil, fmt.Errorf(
 			"cannot list %s: %w", paths.SudoersDir, err)
 	}
-	return filterSudoersDropIns(out), nil
-}
-
-// filterSudoersDropIns applies sudo's includedir filename rule to
-// find output (one absolute path per line). Pure — unit-tested.
-func filterSudoersDropIns(findOutput string) []string {
 	var files []string
-	for _, line := range strings.Split(findOutput, "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" {
+	for _, e := range entries {
+		if e.IsDir() {
 			continue
 		}
-		if !sudoersFileIncluded(filepath.Base(line)) {
+		if !sudoersFileIncluded(e.Name()) {
 			continue
 		}
-		files = append(files, line)
+		files = append(files, paths.SudoersDir+"/"+e.Name())
 	}
-	return files
+	return files, nil
 }
 
 // sudoersFileIncluded mirrors sudo's @includedir rule: files whose
@@ -328,7 +281,7 @@ func sudoersEnablesIOLogging(content string) (string, bool) {
 	return "", false
 }
 
-// ── Check 5: dpkg ────────────────────────────────────────
+// ── Check 3: dpkg ────────────────────────────────────────
 
 // checkDpkgAudit asserts the package database has no packages stuck
 // in broken states — a wedged dpkg would otherwise kill the install
@@ -350,23 +303,23 @@ func dpkgAuditVerdict(output string, err error) error {
 		first := strings.SplitN(s, "\n", 2)[0]
 		return fmt.Errorf(
 			"dpkg reports packages in a broken state (%s ...) — "+
-				"fix with: sudo dpkg --configure -a && "+
-				"sudo apt-get -f install", first)
+				"fix with: dpkg --configure -a && "+
+				"apt-get -f install", first)
 	}
 	return nil
 }
 
-// ── Check 6: ufw ─────────────────────────────────────────
+// ── Check 4: ufw ─────────────────────────────────────────
 
 // checkUfwInstallable asserts apt's on-disk package index can
-// deliver ufw when the engine's firewall step apt-installs it
-// mid-sequence. Offline; installs nothing; passes instantly when
-// ufw is already present (re-runs).
+// deliver ufw when the engine's base-package step apt-installs it.
+// Offline; installs nothing; passes instantly when ufw is already
+// present (re-runs, migrated boxes).
 //
-// Today this is nearly redundant — the bootstrap script proved apt
-// working minutes earlier — but it becomes LOAD-BEARING at commit 6
-// when the binary absorbs the script and nothing has pre-proven
-// apt. It lives here so commit 6 inherits it for free.
+// LOAD-BEARING since the script absorption (commit 6): nothing
+// pre-proves apt anymore — the binary's own base-package step is
+// the first apt operation run for us on this box, and the firewall
+// step immediately after it depends on ufw having arrived.
 func checkUfwInstallable() error {
 	if _, err := exec.LookPath("ufw"); err == nil {
 		return nil
@@ -380,7 +333,7 @@ func checkUfwInstallable() error {
 
 // runAptCachePolicy runs `apt-cache policy <pkg>` with LC_ALL=C so
 // the Candidate line is stable across locales. Local exec (not the
-// system wrappers) purely for the env override; no sudo involved.
+// system wrappers) purely for the env override.
 func runAptCachePolicy(
 	pkg string, timeout time.Duration,
 ) (string, error) {
@@ -408,12 +361,12 @@ func ufwCandidateVerdict(output string) error {
 			}
 			return errors.New(
 				"apt has no installable ufw candidate — package " +
-					"lists may be broken; run: sudo apt-get update")
+					"lists may be broken; run: apt-get update")
 		}
 	}
 	return errors.New(
 		"no Candidate line in apt-cache policy output — apt " +
-			"package lists may be missing; run: sudo apt-get update")
+			"package lists may be missing; run: apt-get update")
 }
 
 // ── Report formatting ────────────────────────────────────

--- a/internal/installer/preflight_test.go
+++ b/internal/installer/preflight_test.go
@@ -86,49 +86,18 @@ func TestSudoersFileIncluded(t *testing.T) {
 		name string
 		want bool
 	}{
-		{"ripsline", true},
+		{"vpn", true},
 		{"README", true},
 		{"99-custom", true},
 		{"backup.bak", false},    // contains '.'
 		{"50-cloud.conf", false}, // contains '.'
-		{"ripsline~", false},     // editor backup
+		{"vpn~", false},          // editor backup
 	}
 	for _, tt := range cases {
 		if got := sudoersFileIncluded(tt.name); got != tt.want {
 			t.Errorf("sudoersFileIncluded(%q) = %v, want %v",
 				tt.name, got, tt.want)
 		}
-	}
-}
-
-// ── filterSudoersDropIns ─────────────────────────────────
-
-func TestFilterSudoersDropIns(t *testing.T) {
-	findOutput := "/etc/sudoers.d/ripsline\n" +
-		"/etc/sudoers.d/zz-preflight-test\n" +
-		"/etc/sudoers.d/README\n" +
-		"/etc/sudoers.d/backup.bak\n" +
-		"/etc/sudoers.d/ripsline~\n"
-	got := filterSudoersDropIns(findOutput)
-	want := []string{
-		"/etc/sudoers.d/ripsline",
-		"/etc/sudoers.d/zz-preflight-test",
-		"/etc/sudoers.d/README",
-	}
-	if len(got) != len(want) {
-		t.Fatalf("got %v, want %v", got, want)
-	}
-	for i := range want {
-		if got[i] != want[i] {
-			t.Errorf("entry %d: got %q, want %q",
-				i, got[i], want[i])
-		}
-	}
-	if out := filterSudoersDropIns(""); len(out) != 0 {
-		t.Errorf("empty find output: got %v, want none", out)
-	}
-	if out := filterSudoersDropIns("\n  \n"); len(out) != 0 {
-		t.Errorf("blank lines: got %v, want none", out)
 	}
 }
 
@@ -141,19 +110,19 @@ func TestSudoersIOLoggingDetected(t *testing.T) {
 	}{
 		{"plain log_input", "Defaults log_input\n"},
 		{"plain log_output", "Defaults log_output\n"},
-		{"user-scoped", "Defaults:ripsline log_input\n"},
+		{"user-scoped", "Defaults:vpn log_input\n"},
 		{"comma list", "Defaults env_reset, log_input\n"},
 		{"double negation enables", "Defaults !!log_input\n"},
 		{"tab separated", "Defaults\tlog_output\n"},
 		{"line continuation",
 			"Defaults env_reset, \\\n    log_input\n"},
 		{"LOG_INPUT tag",
-			"ripsline ALL=(ALL) LOG_INPUT: /usr/bin/foo\n"},
+			"vpn ALL=(ALL) LOG_INPUT: /usr/bin/foo\n"},
 		{"LOG_OUTPUT tag",
-			"ripsline ALL=(ALL) NOPASSWD: LOG_OUTPUT: ALL\n"},
+			"vpn ALL=(ALL) NOPASSWD: LOG_OUTPUT: ALL\n"},
 		{"buried among safe lines",
 			"# comment\nDefaults env_reset\n" +
-				"ripsline ALL=(ALL) NOPASSWD:ALL\n" +
+				"vpn ALL=(ALL) NOPASSWD:ALL\n" +
 				"Defaults log_input\n"},
 	}
 	for _, tt := range cases {
@@ -170,7 +139,7 @@ func TestSudoersIOLoggingClean(t *testing.T) {
 	}{
 		{"empty", ""},
 		{"bootstrap rule only",
-			"ripsline ALL=(ALL) NOPASSWD:ALL\n"},
+			"vpn ALL=(ALL) NOPASSWD:ALL\n"},
 		{"stock debian",
 			"Defaults env_reset\n" +
 				"Defaults mail_badpass\n" +
@@ -185,7 +154,7 @@ func TestSudoersIOLoggingClean(t *testing.T) {
 		{"iolog_dir alone does not enable",
 			"Defaults iolog_dir=/var/log/sudo-io\n"},
 		{"NOLOG tags disable",
-			"ripsline ALL=(ALL) NOLOG_INPUT: NOLOG_OUTPUT: ALL\n"},
+			"vpn ALL=(ALL) NOLOG_INPUT: NOLOG_OUTPUT: ALL\n"},
 		{"similar option names",
 			"Defaults log_year\nDefaults logfile=/var/log/sudo\n"},
 	}
@@ -305,8 +274,8 @@ func TestWrapText(t *testing.T) {
 
 func TestPreflightCheckNamesNonEmpty(t *testing.T) {
 	for _, n := range []string{
-		checkNameDebian, checkNameSudo, checkNameTorsocks,
-		checkNameIOLogging, checkNameDpkg, checkNameUfw,
+		checkNameDebian, checkNameIOLogging,
+		checkNameDpkg, checkNameUfw, checkNameSSHState,
 	} {
 		if strings.TrimSpace(n) == "" {
 			t.Error("empty check name")

--- a/internal/installer/setup.go
+++ b/internal/installer/setup.go
@@ -2,6 +2,7 @@ package installer
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -9,14 +10,10 @@ import (
 	"strings"
 	"time"
 
-	tea "charm.land/bubbletea/v2"
-	"charm.land/lipgloss/v2"
-
-	"github.com/ripsline/virtual-private-node/internal/config"
-	"github.com/ripsline/virtual-private-node/internal/logger"
-	"github.com/ripsline/virtual-private-node/internal/paths"
-	"github.com/ripsline/virtual-private-node/internal/system"
-	"github.com/ripsline/virtual-private-node/internal/theme"
+	"github.com/virtualprivatenode/vpn/internal/config"
+	"github.com/virtualprivatenode/vpn/internal/logger"
+	"github.com/virtualprivatenode/vpn/internal/paths"
+	"github.com/virtualprivatenode/vpn/internal/system"
 )
 
 const (
@@ -31,215 +28,140 @@ var appVersion = "dev"
 func SetVersion(v string)   { appVersion = v }
 func LndVersionStr() string { return lndVersion }
 
-func NeedsInstall() bool {
-	cfg, err := config.Load()
-	if err != nil {
-		if system.IsServiceActive("bitcoind") {
-			return false
-		}
-		return true
-	}
-	return !cfg.InstallComplete
-}
-
-// ── Initial-install TUI front-end ────────────────────────
-// The step model (InstallStep, StepStatus, StepKind, Group,
-// Phase), the resume planner, and the step runner live in
-// engine.go; the ledger lives in ledger.go. This file owns
-// the interactive front-end and the step lists. The front-end
-// renders what the runner reports — it makes no skip or
-// record decisions of its own, so the TUI and the unattended
+// ── Main install flow ────────────────────────────────────
+//
+// `vpn install` — explicit dispatch only (IA-1-8's fix): this
+// runs because the operator asked, never because the binary
+// sniffed box state and decided for itself. The old
+// NeedsInstall() config/service-probe is deleted with the old
+// implicit flow.
+//
+// The step model, resume planner, and step runner live in
+// engine.go; the ledger in ledger.go; the interactive front-end
+// (wizard screens + step renderer) in wizard.go. Front-ends are
+// thin: they render what the runner reports and make no skip or
+// record decisions of their own, so the TUI and the unattended
 // runner cannot diverge.
 
-type stepDoneMsg struct {
-	index   int
-	skipped bool
-	err     error
+// InstallOptions carries the `vpn install` command line.
+type InstallOptions struct {
+	// Network from --testnet4 ("" = mainnet, or keep a
+	// pre-existing config's answer).
+	Network string
+	// Unattended runs with no TUI and no prompts (ruling iv/vii:
+	// keys auto-copied from enumeration, password randomly
+	// generated and printed once — the image path's fallback).
+	Unattended bool
+	// UntilBake runs only PhaseBake steps (image build
+	// pipeline, ruling iv). Requires Unattended. The run ends
+	// WITHOUT InstallComplete, without handoff, without the
+	// verification banner — first-boot steps are still owed.
+	UntilBake bool
 }
 
-type installModel struct {
-	steps         []InstallStep
-	runner        *stepRunner
-	current       int
-	done, failed  bool
-	version       string
-	width, height int
-}
+// RunInstall is the `sudo vpn install` entry point.
+func RunInstall(opts InstallOptions) error {
+	if os.Geteuid() != 0 {
+		return errors.New(
+			"the installer must run as root — run: sudo vpn install")
+	}
+	if opts.UntilBake && !opts.Unattended {
+		return errors.New(
+			"--until=bake requires --unattended (image build path)")
+	}
 
-func (m installModel) Init() tea.Cmd { return m.runStep(0) }
+	// Non-interactive package operations for the whole run
+	// (absorbed from the retired bootstrap): debconf prompts
+	// suppressed, needrestart auto-restarts services instead of
+	// showing its dialog mid-upgrade.
+	os.Setenv("DEBIAN_FRONTEND", "noninteractive")
+	os.Setenv("NEEDRESTART_MODE", "a")
 
-func (m installModel) runStep(i int) tea.Cmd {
-	return func() tea.Msg {
-		if i >= len(m.steps) {
-			return stepDoneMsg{index: i}
-		}
-		skipped, err := m.runner.runIndex(i)
-		return stepDoneMsg{index: i, skipped: skipped, err: err}
-	}
-}
-
-func (m installModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	switch msg := msg.(type) {
-	case tea.WindowSizeMsg:
-		m.width = msg.Width
-		m.height = msg.Height
-	case tea.KeyPressMsg:
-		if msg.String() == "enter" && m.done {
-			return m, tea.Quit
-		}
-		if msg.String() == "ctrl+c" {
-			// Quitting is allowed at any instant — an
-			// interrupt is SAFE now (the ledger records a
-			// step only after it verified complete, so any
-			// death leaves a truthful record) — and it is
-			// HONEST: a quit before all steps ran leaves
-			// m.done false, which classifies the run as
-			// interrupted, never complete (IA-1-9).
-			return m, tea.Quit
-		}
-	case stepDoneMsg:
-		if msg.index < len(m.steps) {
-			if msg.err != nil {
-				m.steps[msg.index].Status = StepFailed
-				m.steps[msg.index].Err = msg.err
-				m.failed = true
-				m.done = true
-				return m, nil
-			}
-			if msg.skipped {
-				m.steps[msg.index].Status = StepSkipped
-			} else {
-				m.steps[msg.index].Status = StepDone
-			}
-			next := msg.index + 1
-			if next < len(m.steps) {
-				m.current = next
-				m.steps[next].Status = StepRunning
-				return m, m.runStep(next)
-			}
-			m.done = true
-		}
-	}
-	return m, nil
-}
-
-func (m installModel) View() tea.View {
-	if m.width == 0 {
-		v := tea.NewView("Loading...")
-		v.AltScreen = true
-		return v
-	}
-	bw := min(m.width-4, theme.ContentWidth)
-	var lines []string
-	for i, s := range m.steps {
-		var sty lipgloss.Style
-		var ind string
-		switch s.Status {
-		case StepDone:
-			sty, ind = theme.ProgDone, "[done]"
-		case StepRunning:
-			sty, ind = theme.ProgRunning, "[....]"
-		case StepFailed:
-			sty, ind = theme.ProgFail, "[FAIL]"
-		case StepSkipped:
-			// Resume skip: completed by an earlier run
-			// (per the install ledger).
-			sty, ind = theme.Dim, "[skip]"
-		default:
-			sty, ind = theme.ProgPending, "[wait]"
-		}
-		lines = append(lines, sty.Render(fmt.Sprintf("  %s [%d/%d] %s",
-			ind, i+1, len(m.steps), s.Name)))
-		if s.Status == StepFailed && s.Err != nil {
-			lines = append(lines, theme.ProgFail.Render(
-				fmt.Sprintf("      Error: %v", s.Err)))
-		}
-	}
-	box := theme.ProgBox.Width(bw).Render(strings.Join(lines, "\n"))
-	var footer string
-	if m.done && !m.failed {
-		footer = theme.Success.Render(
-			"  Complete -- press Enter to continue  ")
-	} else if m.failed {
-		footer = theme.ProgFail.Render(
-			"  Failed. Press ctrl+c to exit.  ")
-	} else {
-		footer = theme.Dim.Render("  Installing... please wait  ")
-	}
-	full := lipgloss.JoinVertical(lipgloss.Center,
-		"", box, "", footer)
-	content := lipgloss.Place(m.width, m.height,
-		lipgloss.Center, lipgloss.Center, full)
-	v := tea.NewView(content)
-	v.AltScreen = true
-	return v
-}
-
-// RunInstallTUI runs the initial-install steps under the
-// interactive front-end and reports HOW the run ended —
-// complete, failed, or interrupted — via RunResult. It no
-// longer collapses "the TUI returned" into "the install
-// succeeded": that inference was IA-1-9 (a swallowed ctrl+c
-// returned cleanly and was recorded as a complete install).
-// The caller decides what each outcome means; only
-// RunComplete may reach the InstallComplete write.
-func RunInstallTUI(
-	steps []InstallStep, version string,
-) (RunResult, error) {
-	if len(steps) == 0 {
-		return RunResult{Outcome: RunComplete}, nil
-	}
-	runner, err := newStepRunner(
-		steps, version, paths.InstallStateFile)
-	if err != nil {
-		return RunResult{}, err
-	}
-	steps[0].Status = StepRunning
-	m := installModel{
-		steps: steps, runner: runner, version: version,
-	}
-	p := tea.NewProgram(m)
-	result, err := p.Run()
-	if err != nil {
-		return RunResult{}, err
-	}
-	final := result.(installModel)
-	// done=false here means the render loop was quit before
-	// the last step reported — an interrupt, by any cause.
-	return classifyRun(final.steps,
-		final.done && !final.failed,
-		final.failed, final.current), nil
-}
-
-// ── Main install flow ────────────────────────────────────
-
-func Run() error {
 	// Preflight (principle 3): assert the environment before the
 	// first mutation; refuses with a full report on any failure.
-	// Absorbs the old checkOS(). See preflight.go.
-	if err := RunPreflight(); err != nil {
+	// Returns the sshd observation (ruling xvi(b)) consumed by
+	// the firewall rules, the wizard copy, and the config seed.
+	obs, err := RunPreflight()
+	if err != nil {
 		return err
 	}
 
+	// A pre-existing loadable config is the operator's prior
+	// answers (migration requirement 1, ruling xv): a migrated
+	// box pre-creates /etc/vpn/config.json by copy. Values it
+	// carries are never clobbered; only ABSENT fields are
+	// seeded. install_complete:true with an empty ledger is NOT
+	// refused — explicit dispatch means the operator asked.
 	cfg := config.Default()
-	if preCfg, err := config.Load(); err == nil {
-		cfg = preCfg
+	preExisting := false
+	if pre, loadErr := config.Load(); loadErr == nil {
+		cfg = pre
+		preExisting = true
+	} else if !os.IsNotExist(loadErr) {
+		// An unloadable (present but corrupt) config is a
+		// fail-stop, same direction as the TUI path (IA-1-C1):
+		// silently installing over the operator's carried
+		// answers would destroy them.
+		return fmt.Errorf(
+			"cannot read %s: %v — fix or remove the file, "+
+				"then re-run", config.DefaultPath, loadErr)
 	}
 
+	if opts.Network != "" {
+		if preExisting && cfg.Network != opts.Network {
+			return fmt.Errorf(
+				"--%s conflicts with network %q already set in %s "+
+					"— drop the flag to keep the existing answer",
+				opts.Network, cfg.Network, config.DefaultPath)
+		}
+		cfg.Network = opts.Network
+	}
+
+	// Seed from observation ONLY where the config never
+	// answered (on a migrated box the two agree anyway: the
+	// observation runs while the old drop-in still stands).
+	if !config.RawFieldPresent("ssh_password_auth_disabled") {
+		cfg.SSHPasswordAuthDisabled = !obs.PasswordAuth
+	}
+	// Observed ports are a recorded observation, not an
+	// operator answer — a fresh observation always wins.
+	cfg.SSHPorts = obs.Ports
+
 	// LND is installed during initial setup (Tor-only default).
-	// These fields are set IN MEMORY before buildSteps because
-	// the steps read them (Tor config and firewall rules include
-	// LND hidden services and ports) — but they are PERSISTED
-	// only on a complete run, below. A failed or interrupted run
-	// must not record intent as fact (IA-1-9: Gate 0 observed
-	// lnd_installed:true on disk for software never downloaded).
+	// These fields are set IN MEMORY before the steps are built
+	// because steps read them (Tor config and firewall rules
+	// include LND hidden services and ports) — but they are
+	// PERSISTED only on a complete run, below. A failed or
+	// interrupted run must not record intent as fact (IA-1-9).
 	cfg.P2PMode = "tor"
 	cfg.LNDInstalled = true
 	cfg.Components = "bitcoin+lnd"
 
-	steps := buildSteps(cfg)
+	// The ledger lives in the config dir; the dir must exist
+	// before the first step completes. Root-owned during the
+	// install; ownership of the dir and config.json passes to
+	// the admin user at completion (migration requirement 2).
+	if err := os.MkdirAll(paths.ConfigDir, 0750); err != nil {
+		return fmt.Errorf("create %s: %w", paths.ConfigDir, err)
+	}
 
-	res, err := RunInstallTUI(steps, appVersion)
+	dec := &InstallDecisions{Obs: obs}
+	steps := buildInstallSteps(cfg, dec)
+	if opts.UntilBake {
+		steps = FilterPhase(steps, PhaseBake)
+	}
+
+	var res RunResult
+	if opts.Unattended {
+		if err := fillUnattendedDecisions(dec); err != nil {
+			return err
+		}
+		fmt.Printf("\n  Virtual Private Node — unattended install\n\n")
+		res, err = RunInstallUnattended(
+			steps, appVersion, paths.InstallStateFile)
+	} else {
+		res, err = runInstallWizard(cfg, steps, dec, appVersion)
+	}
 	if err != nil {
 		return err
 	}
@@ -249,9 +171,8 @@ func Run() error {
 		// error surfaces to stderr via main.
 		return fmt.Errorf("%s: %w", res.StepName, res.Err)
 	case RunInterrupted:
-		// The log trail must not just stop (commit-5
-		// addendum): record how far the run got, and that a
-		// re-run resumes.
+		// The log trail must not just stop (commit-5 addendum):
+		// record how far the run got, and that a re-run resumes.
 		logger.Install(
 			"install INTERRUPTED at step %d/%d: %s — "+
 				"run again to resume", res.StepNum, res.Total,
@@ -262,6 +183,17 @@ func Run() error {
 			res.StepName)
 	}
 
+	if opts.UntilBake {
+		// The bake slice completing is not the install
+		// completing: first-boot steps (identity, hardware fit,
+		// SSH hardening) are still owed on the deployed box.
+		logger.Install(
+			"bake phase complete (%d steps) — install NOT marked "+
+				"complete; first-boot steps pending", res.Total)
+		fmt.Printf("\n  Bake phase complete (%d steps).\n", res.Total)
+		return nil
+	}
+
 	// Every step verified complete this run — only now may the
 	// durable record say so. InstallComplete is DERIVED from
 	// per-step results, never from a front-end returning
@@ -270,27 +202,194 @@ func Run() error {
 	logger.Install("all %d install steps complete", res.Total)
 	cfg.InstallComplete = true
 	cfg.InstallVersion = appVersion
-	return config.Save(cfg)
+	if dec.DbCacheMB > 0 {
+		cfg.DbCache = dec.DbCacheMB
+	}
+	// First-run verification: the in-session handoff console is
+	// NOT evidence SSH access works; the TUI banner asks for a
+	// second-terminal login and clears on journal evidence
+	// (ruling xvi).
+	cfg.KeyVerificationPending = true
+	if err := config.Save(cfg); err != nil {
+		return err
+	}
+	finalizeOwnership()
+
+	if dec.GeneratedPassword != "" && dec.PasswordApplied {
+		// Unattended fallback only (ruling vii), and only when
+		// the identity step actually applied it this pass (a
+		// ledger-skip means an older password stands). Printed
+		// once, never logged.
+		fmt.Printf("\n  Login password for %q (SAVE IT — it will "+
+			"not be shown again):\n\n    %s\n",
+			paths.AdminUser, dec.GeneratedPassword)
+	}
+
+	if opts.Unattended {
+		printConnectInstructions()
+		return nil
+	}
+	// In-session identity drop: the wizard flows into the node
+	// console as the admin user on this same terminal (ruling
+	// xvi). Degrades to printed instructions, never to an error
+	// — the install is already complete.
+	HandoffToAdminConsole()
+	return nil
 }
 
-// buildSteps returns the initial-install step list. Every step
-// carries a stable Key (the ledger identity — versionless, so
-// "which work is done" survives version bumps in display
-// names), a Kind (gates re-run every pass), and a Group where
-// steps hand ephemeral material to each other (see engine.go).
-// Phase is provisionally Bake throughout — the phase map is
-// ratified by the image-track session (ruling xiv / iv).
-func buildSteps(cfg *config.AppConfig) []InstallStep {
+// finalizeOwnership hands the admin user the files it owns in
+// the post-install world: the config dir + config.json
+// (migration requirement 2 — a migrated box pre-created them
+// root-owned via cp) and the log file (the TUI appends to it).
+// The install ledger deliberately stays root-owned (ruling xiv).
+// Failures are logged, not fatal: the install is complete; a
+// wrong owner surfaces as a TUI config error the operator can
+// fix, and the log names the fix.
+func finalizeOwnership() {
+	owner := paths.AdminUser + ":" + paths.AdminUser
+	for _, p := range []string{
+		paths.ConfigDir, paths.ConfigFile, paths.LogFile,
+	} {
+		if err := system.SudoRun("chown", owner, p); err != nil {
+			logger.Install(
+				"WARNING: chown %s to %s failed (%v) — fix with: "+
+					"chown %s %s", p, owner, err, owner, p)
+		}
+	}
+}
+
+// fillUnattendedDecisions supplies the wizard answers for
+// --unattended: every enumerated (non-decoy) key is copied — the
+// spiritual successor of the script's cascade, from enumeration
+// instead of guessing — and the password is randomly generated
+// (ruling vii: random survives ONLY here) and printed at the
+// end. dbcache takes the hardware recommendation.
+func fillUnattendedDecisions(dec *InstallDecisions) error {
+	dec.Keys = DedupeKeys(EnumerateKeySources())
+	gen, err := generateAdminPassword()
+	if err != nil {
+		return err
+	}
+	pw, err := NewLoginPassword(gen)
+	if err != nil {
+		return err
+	}
+	dec.Password = pw
+	dec.GeneratedPassword = gen
+	dec.DbCacheMB = RecommendDbCache(DetectHardware().RAMMB)
+	return nil
+}
+
+// ── Absorbed bootstrap steps (script Phase 1) ────────────
+
+// installBasePackages is the SINGLE clearnet apt operation
+// (IA-2-L disclosure: op count unchanged from the script; ufw
+// joined its package list per ruling xvi(b) so the firewall can
+// come up immediately after). On a migrated box the old
+// install's apt Tor proxy is still configured, so even this op
+// routes through Tor there.
+func installBasePackages() error {
+	if err := system.SudoRun("apt-get", "update", "-qq"); err != nil {
+		return err
+	}
+	return system.SudoRun("apt-get", "install", "-y", "-qq",
+		"sudo", "gnupg", "tor", "torsocks", "wget", "ufw")
+}
+
+// upgradeBasePackages brings the base image current (fresh VPS
+// images are often weeks old with unpatched CVEs). Runs AFTER
+// the firewall step per ruling xvi(b): default-deny now covers
+// the longest pre-Tor phase instead of following it. confdef +
+// confold keep existing config files on conflict — the safe
+// default on a fresh image.
+func upgradeBasePackages() error {
+	return system.SudoRun("apt-get", "upgrade", "-y", "-qq",
+		"-o", "Dpkg::Options::=--force-confdef",
+		"-o", "Dpkg::Options::=--force-confold")
+}
+
+// prepareHost absorbs the script's host fixes: hostname
+// resolution (prevents sudo delays) and NTP clock sync (Bitcoin
+// Core and LND depend on accurate time for block timestamps,
+// HTLC timeouts, and macaroon expiry; systemd-timesyncd uses the
+// Debian pool, UTC).
+func prepareHost() error {
+	if name, err := os.Hostname(); err == nil && name != "" {
+		if err := system.RunSilent(
+			"getent", "hosts", name); err != nil {
+			hosts, readErr := os.ReadFile("/etc/hosts")
+			if readErr == nil {
+				content := string(hosts)
+				if !strings.HasSuffix(content, "\n") {
+					content += "\n"
+				}
+				content += "127.0.0.1 " + name + "\n"
+				if err := system.SudoWriteFile("/etc/hosts",
+					[]byte(content), 0644); err != nil {
+					return fmt.Errorf(
+						"fix hostname resolution: %w", err)
+				}
+				logger.Install("hostname resolution fixed (%s)", name)
+			}
+		}
+	}
+	// Best-effort, like the script's `|| true`: a box without
+	// timedatectl still installs; the clock-sync gap is logged.
+	if err := system.SudoRunSilent(
+		"timedatectl", "set-ntp", "true"); err != nil {
+		logger.Install(
+			"WARNING: could not enable NTP sync (%v)", err)
+	}
+	return nil
+}
+
+// buildInstallSteps returns the initial-install step list. Every
+// step carries a stable Key (the ledger identity — versionless),
+// a Kind (gates re-run every pass), a Group where steps hand
+// ephemeral material to each other (see engine.go), and a Phase
+// (bake vs first-boot, ruling iv — assignments provisional until
+// the image-track session ratifies the map; identity/SSH steps
+// are first-boot per rulings vii/viii: they apply observed,
+// per-box state that an image build box cannot know).
+//
+// Order (ruling xvi(b)): the firewall step sits immediately
+// after the single clearnet apt op — default-deny lands before
+// the base upgrade, the longest pre-Tor phase. Outbound stays
+// default-allow so Tor can bootstrap behind it; established SSH
+// sessions are unaffected by `ufw enable`.
+func buildInstallSteps(
+	cfg *config.AppConfig, dec *InstallDecisions,
+) []InstallStep {
 	// Pipeline working directories — created in each pipeline's
 	// first step, captured by closures, cleaned up in the final
-	// step. Random paths via os.MkdirTemp prevent symlink attacks.
-	// NOTE these closures are exactly why the btc/lnd triplets
-	// are resume-atomic Groups: the workdir path lives only in
-	// this process, so a resumed process can never re-enter a
-	// pipeline midway.
+	// step. Random paths via os.MkdirTemp prevent symlink
+	// attacks. NOTE these closures are exactly why the btc/lnd
+	// triplets are resume-atomic Groups: the workdir path lives
+	// only in this process, so a resumed process can never
+	// re-enter a pipeline midway.
 	var btcWork, lndWork string
 
 	return []InstallStep{
+		{Key: "binary.install",
+			Name: "Installing the vpn binary",
+			Fn:   installSelfBinary},
+		{Key: "apt.base",
+			Name: "Installing base packages",
+			Fn:   installBasePackages},
+		{Key: "firewall", Name: "Configuring firewall",
+			Fn: func() error { return configureFirewall(cfg) }},
+		{Key: "base.upgrade",
+			Name: "Upgrading base packages",
+			Fn:   upgradeBasePackages},
+		{Key: "host.prep",
+			Name: "Configuring hostname and clock sync",
+			Fn:   prepareHost},
+		{Key: "identity.access", Phase: PhaseFirstBoot,
+			Name: "Creating the admin user (" +
+				paths.AdminUser + ")",
+			Fn: func() error {
+				return applyIdentityAccess(dec)
+			}},
 		{Key: "user.create",
 			Name: "Creating system user and directories",
 			Fn: func() error {
@@ -301,11 +400,8 @@ func buildSteps(cfg *config.AppConfig) []InstallStep {
 			}},
 		{Key: "ipv6.disable", Name: "Disabling IPv6",
 			Fn: disableIPv6},
-		{Key: "tor.install", Name: "Installing Tor",
+		{Key: "tor.configure", Name: "Configuring Tor",
 			Fn: func() error {
-				if err := installTor(); err != nil {
-					return err
-				}
 				if err := RebuildTorConfig(cfg); err != nil {
 					return err
 				}
@@ -319,7 +415,10 @@ func buildSteps(cfg *config.AppConfig) []InstallStep {
 		// runs unless Tor routing is verified. See torgate.go.
 		// StepGate: re-verified on EVERY pass including resumes —
 		// no download step can execute in a pass whose Tor routing
-		// was not verified in that same pass.
+		// was not verified in that same pass. The torsocks-present
+		// assertion re-homed here from preflight (ruling xvi(c))
+		// also lives inside this step: post-Tor-install,
+		// pre-first-download.
 		{Key: "tor.gate", Name: "Verifying Tor routing",
 			Kind: StepGate, Fn: verifyTorRouting},
 		{Key: "apt.torproxy", Name: "Configuring apt for Tor",
@@ -329,13 +428,11 @@ func buildSteps(cfg *config.AppConfig) []InstallStep {
 				}
 				return ensureGPG()
 			}},
-		{Key: "firewall", Name: "Configuring firewall",
-			Fn: func() error { return configureFirewall(cfg) }},
 		{Key: "btc.download", Group: "btc",
 			Name: "Downloading Bitcoin Core " + bitcoinVersion,
 			Fn: func() error {
 				var err error
-				btcWork, err = os.MkdirTemp("", "rlvpn-btc-")
+				btcWork, err = os.MkdirTemp("", "vpn-btc-")
 				if err != nil {
 					return fmt.Errorf("create work dir: %w", err)
 				}
@@ -384,7 +481,7 @@ func buildSteps(cfg *config.AppConfig) []InstallStep {
 			Name: "Downloading LND",
 			Fn: func() error {
 				var err error
-				lndWork, err = os.MkdirTemp("", "rlvpn-lnd-")
+				lndWork, err = os.MkdirTemp("", "vpn-lnd-")
 				if err != nil {
 					return fmt.Errorf("create work dir: %w", err)
 				}
@@ -423,6 +520,16 @@ func buildSteps(cfg *config.AppConfig) []InstallStep {
 				return restartTor()
 			}},
 		{Key: "lnd.start", Name: "Starting LND", Fn: startLND},
+		// The initial drop-in write + stale-drop-in deletion,
+		// with the ruling-xv binding order inside (observe →
+		// write new → delete old → validate → restart). Late in
+		// the list, matching the script's placement: everything
+		// the box needs to be reachable already ran.
+		{Key: "ssh.harden", Phase: PhaseFirstBoot,
+			Name: "Hardening SSH",
+			Fn: func() error {
+				return installSSHHardening(cfg)
+			}},
 		// Formerly a post-TUI special case that warned but
 		// completed anyway (IA-1-16). As a real step it
 		// inherits the ledger, the completion gate, failure
@@ -493,7 +600,7 @@ func SyncthingInstallSteps(
 		{Name: "Downloading Syncthing " + syncthingVersion,
 			Fn: func() error {
 				var err error
-				syncWork, err = os.MkdirTemp("", "rlvpn-sync-")
+				syncWork, err = os.MkdirTemp("", "vpn-sync-")
 				if err != nil {
 					return fmt.Errorf("create work dir: %w", err)
 				}
@@ -551,14 +658,14 @@ type githubRelease struct {
 }
 
 // SelfUpdateSteps returns the install steps for updating
-// the rlvpn binary to newVersion. Steps are idempotent —
+// the vpn binary to newVersion. Steps are idempotent —
 // no rollback needed on failure. No config save on
 // success (binary replaced, takes effect on next SSH login).
 func SelfUpdateSteps(newVersion string) []InstallStep {
 	baseURL := fmt.Sprintf(
-		"https://github.com/ripsline/virtual-private-node/releases/download/v%s",
+		"https://github.com/virtualprivatenode/vpn/releases/download/v%s",
 		newVersion)
-	tarball := fmt.Sprintf("rlvpn-%s-amd64.tar.gz",
+	tarball := fmt.Sprintf("vpn-%s-amd64.tar.gz",
 		newVersion)
 
 	var workDir string
@@ -568,7 +675,7 @@ func SelfUpdateSteps(newVersion string) []InstallStep {
 			Fn: func() error {
 				var err error
 				workDir, err = os.MkdirTemp("",
-					"rlvpn-update-")
+					"vpn-update-")
 				if err != nil {
 					return fmt.Errorf(
 						"create work dir: %w", err)
@@ -616,8 +723,8 @@ func SelfUpdateSteps(newVersion string) []InstallStep {
 				}
 				if err := system.SudoRun("install",
 					"-m", "755",
-					filepath.Join(workDir, "rlvpn"),
-					"/usr/local/bin/rlvpn"); err != nil {
+					filepath.Join(workDir, "vpn"),
+					"/usr/local/bin/vpn"); err != nil {
 					return err
 				}
 				os.RemoveAll(workDir)
@@ -638,7 +745,7 @@ func CheckLatestVersion() string {
 	}
 	output, err := system.RunContext(10*time.Second,
 		"torsocks", "curl", "-sL",
-		"https://api.github.com/repos/ripsline/virtual-private-node/releases/latest")
+		"https://api.github.com/repos/virtualprivatenode/vpn/releases/latest")
 	if err != nil {
 		return ""
 	}

--- a/internal/installer/setup.go
+++ b/internal/installer/setup.go
@@ -241,16 +241,49 @@ func RunInstall(opts InstallOptions) error {
 		if err := completeInstall(); err != nil {
 			return err
 		}
+		if needsPasswordReapply(dec.GeneratedPassword,
+			dec.PasswordApplied, passwordPending()) {
+			// Fail-then-resume (live-run finding): an earlier
+			// unattended pass applied a generated password and
+			// died before the end-of-run print, so nobody has
+			// ever seen a working credential — and this pass
+			// ledger-skipped the identity step. Re-apply THIS
+			// pass's generated password now, so the line printed
+			// below is one that works.
+			if err := SetUserPassword(
+				paths.AdminUser, dec.Password); err != nil {
+				return fmt.Errorf(
+					"re-apply admin password: %w", err)
+			}
+			dec.PasswordApplied = true
+			logger.Install("admin password re-applied at " +
+				"completion — an earlier pass applied one that " +
+				"was never displayed")
+		}
 	}
 
 	if dec.GeneratedPassword != "" && dec.PasswordApplied {
 		// Unattended fallback only (ruling vii), and only when
-		// the identity step actually applied it this pass (a
-		// ledger-skip means an older password stands). Printed
-		// once, never logged.
+		// this pass actually applied it (a ledger-skip with no
+		// pending marker means an older, already-shown password
+		// stands). Printed once, never logged.
 		fmt.Printf("\n  Login password for %q (SAVE IT — it will "+
 			"not be shown again):\n\n    %s\n",
 			paths.AdminUser, dec.GeneratedPassword)
+		ClearPasswordPendingMarker()
+	}
+
+	if !opts.Unattended && passwordPending() {
+		// Mixed-mode resume: an earlier unattended pass applied a
+		// generated password that was never displayed, and this
+		// interactive completion had no password screen to
+		// replace it (the identity step was ledger-skipped).
+		// Nothing here can recover it — say so and name the
+		// remedy. The marker stays until the operator acts.
+		fmt.Printf("\n  NOTE: an earlier unattended run set a "+
+			"login password for %q that was never displayed.\n"+
+			"  Set a new one from the node console: System → "+
+			"SSH Keys → Change Password.\n", paths.AdminUser)
 	}
 
 	if opts.Unattended {

--- a/internal/installer/setup.go
+++ b/internal/installer/setup.go
@@ -151,6 +151,40 @@ func RunInstall(opts InstallOptions) error {
 		steps = FilterPhase(steps, PhaseBake)
 	}
 
+	// completeInstall writes the durable completion record.
+	// Every step verified complete this pass — only then may
+	// the record say so: InstallComplete is DERIVED from
+	// per-step results, never from a front-end returning
+	// (IA-1-9); the intent fields set above reach disk only
+	// through here. On the interactive path this runs the
+	// moment the last step verifies, BEFORE the done screen
+	// waits for the operator (live-run finding: the old
+	// after-the-TUI order left completion unpersisted while
+	// the done screen sat unattended). Idempotent.
+	completeInstall := func() error {
+		logger.Install(
+			"all %d install steps complete", len(steps))
+		cfg.InstallComplete = true
+		cfg.InstallVersion = appVersion
+		if dec.DbCacheMB > 0 {
+			cfg.DbCache = dec.DbCacheMB
+		}
+		// First-run verification banner: armed ONLY when the
+		// identity step actually ran this pass (same gating
+		// shape as the generated-password print) — a resume
+		// or re-run on a finished box must not re-arm a
+		// banner whose evidence was already observed.
+		if dec.PasswordApplied {
+			cfg.KeyVerificationPending = true
+		}
+		if err := config.Save(cfg); err != nil {
+			return fmt.Errorf(
+				"write %s: %w", config.DefaultPath, err)
+		}
+		finalizeOwnership()
+		return nil
+	}
+
 	var res RunResult
 	if opts.Unattended {
 		if err := fillUnattendedDecisions(dec); err != nil {
@@ -160,7 +194,8 @@ func RunInstall(opts InstallOptions) error {
 		res, err = RunInstallUnattended(
 			steps, appVersion, paths.InstallStateFile)
 	} else {
-		res, err = runInstallWizard(cfg, steps, dec, appVersion)
+		res, err = runInstallWizard(
+			cfg, steps, dec, appVersion, completeInstall)
 	}
 	if err != nil {
 		return err
@@ -194,26 +229,13 @@ func RunInstall(opts InstallOptions) error {
 		return nil
 	}
 
-	// Every step verified complete this run — only now may the
-	// durable record say so. InstallComplete is DERIVED from
-	// per-step results, never from a front-end returning
-	// (IA-1-9); the intent fields set above reach disk only on
-	// this path.
-	logger.Install("all %d install steps complete", res.Total)
-	cfg.InstallComplete = true
-	cfg.InstallVersion = appVersion
-	if dec.DbCacheMB > 0 {
-		cfg.DbCache = dec.DbCacheMB
+	if opts.Unattended {
+		// The unattended runner has no wait-for-input gap; the
+		// record is written here, right after the last step.
+		if err := completeInstall(); err != nil {
+			return err
+		}
 	}
-	// First-run verification: the in-session handoff console is
-	// NOT evidence SSH access works; the TUI banner asks for a
-	// second-terminal login and clears on journal evidence
-	// (ruling xvi).
-	cfg.KeyVerificationPending = true
-	if err := config.Save(cfg); err != nil {
-		return err
-	}
-	finalizeOwnership()
 
 	if dec.GeneratedPassword != "" && dec.PasswordApplied {
 		// Unattended fallback only (ruling vii), and only when

--- a/internal/installer/setup.go
+++ b/internal/installer/setup.go
@@ -186,6 +186,7 @@ func RunInstall(opts InstallOptions) error {
 	}
 
 	var res RunResult
+	openConsole := false
 	if opts.Unattended {
 		if err := fillUnattendedDecisions(dec); err != nil {
 			return err
@@ -194,7 +195,7 @@ func RunInstall(opts InstallOptions) error {
 		res, err = RunInstallUnattended(
 			steps, appVersion, paths.InstallStateFile)
 	} else {
-		res, err = runInstallWizard(
+		res, openConsole, err = runInstallWizard(
 			cfg, steps, dec, appVersion, completeInstall)
 	}
 	if err != nil {
@@ -251,11 +252,17 @@ func RunInstall(opts InstallOptions) error {
 		printConnectInstructions()
 		return nil
 	}
-	// In-session identity drop: the wizard flows into the node
-	// console as the admin user on this same terminal (ruling
-	// xvi). Degrades to printed instructions, never to an error
-	// — the install is already complete.
-	HandoffToAdminConsole()
+	// The done screen offered a real choice (live-run fix):
+	// Enter opens the node console here via the identity drop;
+	// ctrl+c means exit, so exit — just leave the connect
+	// command behind. The handoff degrades to printed
+	// instructions, never to an error; the install is already
+	// recorded either way.
+	if openConsole {
+		HandoffToAdminConsole()
+	} else {
+		printConnectInstructions()
+	}
 	return nil
 }
 

--- a/internal/installer/setup.go
+++ b/internal/installer/setup.go
@@ -169,12 +169,17 @@ func RunInstall(opts InstallOptions) error {
 		if dec.DbCacheMB > 0 {
 			cfg.DbCache = dec.DbCacheMB
 		}
-		// First-run verification banner: armed ONLY when the
-		// identity step actually ran this pass (same gating
-		// shape as the generated-password print) — a resume
-		// or re-run on a finished box must not re-arm a
-		// banner whose evidence was already observed.
-		if dec.PasswordApplied {
+		// First-run verification banner: armed when the ledger
+		// shows this install lifecycle set up the admin user AND
+		// the journal shows no admin login yet. Keyed on the
+		// LEDGER, not on this pass (live-run finding: a run that
+		// failed after the identity step and then resumed to
+		// completion lost the banner, because the completing
+		// pass ledger-skipped identity). The journal check keeps
+		// the original guarantee too: a re-run after a verified
+		// login never re-arms a stale banner.
+		if loadLedger(paths.InstallStateFile).
+			done("identity.access") && !AdminLoginObserved() {
 			cfg.KeyVerificationPending = true
 		}
 		if err := config.Save(cfg); err != nil {

--- a/internal/installer/setup_test.go
+++ b/internal/installer/setup_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ripsline/virtual-private-node/internal/paths"
+	"github.com/virtualprivatenode/vpn/internal/paths"
 )
 
 func TestVersionConstants(t *testing.T) {
@@ -45,14 +45,6 @@ func TestLndVersionStr(t *testing.T) {
 	}
 	if v != lndVersion {
 		t.Errorf("got %q, want %q", v, lndVersion)
-	}
-}
-
-func TestNeedsInstallNoConfig(t *testing.T) {
-	// No config file exists on dev machine, so install is needed
-	result := NeedsInstall()
-	if !result {
-		t.Error("NeedsInstall should return true when config is missing")
 	}
 }
 
@@ -94,7 +86,7 @@ func TestWriteAndReadVersionCache(t *testing.T) {
 }
 
 func TestVersionCacheDirConsistency(t *testing.T) {
-	if !strings.HasSuffix(paths.VersionCacheDir, ".cache/rlvpn") {
+	if !strings.HasSuffix(paths.VersionCacheDir, ".cache/vpn") {
 		t.Errorf("VersionCacheDir unexpected suffix: %s",
 			paths.VersionCacheDir)
 	}
@@ -112,3 +104,5 @@ func TestVersionCacheFileConsistency(t *testing.T) {
 
 // The checkOS tests formerly here moved to preflight_test.go
 // (TestCheckOSRelease*), against the preflight's exactly-13 rule.
+// The NeedsInstall tests died with NeedsInstall itself: commit 6
+// replaced state-sniffing with explicit dispatch (IA-1-8).

--- a/internal/installer/sshd.go
+++ b/internal/installer/sshd.go
@@ -8,13 +8,13 @@ import (
 	"os"
 	"strings"
 
-	"github.com/ripsline/virtual-private-node/internal/config"
-	"github.com/ripsline/virtual-private-node/internal/paths"
-	"github.com/ripsline/virtual-private-node/internal/system"
+	"github.com/virtualprivatenode/vpn/internal/config"
+	"github.com/virtualprivatenode/vpn/internal/paths"
+	"github.com/virtualprivatenode/vpn/internal/system"
 )
 
 // BuildSSHHardeningConfig generates the complete contents
-// of /etc/ssh/sshd_config.d/00-rlvpn-hardening.conf from
+// of /etc/ssh/sshd_config.d/00-vpn-hardening.conf from
 // AppConfig. Pure function — no side effects. (The 00-
 // prefix is load-bearing: sshd applies the first match
 // per directive, so this drop-in must sort before a
@@ -22,27 +22,39 @@ import (
 // directives. paths.SSHDDropIn is the single source of
 // truth for the name.)
 //
-// Bootstrap writes the same static lines minus the
-// PasswordAuthentication directive (it's intentionally
-// silent so the user isn't locked out before logging in
-// via TUI). Once the TUI's SSH Password Auth screen runs,
-// this function takes over and the drop-in becomes the
-// authoritative source for password auth state.
+// The installer writes the initial drop-in with the
+// PasswordAuthentication value EXPLICIT-from-observed
+// (ruling xvi(a); see sshstep.go) — "no flip at install"
+// holds by identity, not omission. Once the TUI's SSH
+// Password Auth screen runs, this function takes over and
+// the drop-in stays the authoritative source for password
+// auth state.
 func BuildSSHHardeningConfig(cfg *config.AppConfig) string {
 	passwordAuth := "yes"
 	if cfg.SSHPasswordAuthDisabled {
 		passwordAuth = "no"
 	}
+	return buildHardeningDropIn(passwordAuth)
+}
 
-	return fmt.Sprintf(`# Virtual Private Node — SSH hardening
-# Managed by the rlvpn TUI. Do not edit by hand.
+// buildHardeningDropIn renders the drop-in body.
+// passwordAuth is "yes", "no", or "" — empty OMITS the
+// directive entirely (the install step's degraded mode when
+// the sshd observation failed: asserting nothing beats
+// asserting a guess, ruling xvi(a)). Pure — unit-tested.
+func buildHardeningDropIn(passwordAuth string) string {
+	base := `# Virtual Private Node — SSH hardening
+# Managed by the vpn TUI. Do not edit by hand.
 PermitRootLogin no
 PubkeyAuthentication yes
 ChallengeResponseAuthentication no
 KbdInteractiveAuthentication no
 X11Forwarding no
-PasswordAuthentication %s
-`, passwordAuth)
+`
+	if passwordAuth == "" {
+		return base
+	}
+	return base + "PasswordAuthentication " + passwordAuth + "\n"
 }
 
 // RebuildSSHHardeningConfig writes the drop-in to disk and

--- a/internal/installer/sshd_test.go
+++ b/internal/installer/sshd_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ripsline/virtual-private-node/internal/config"
+	"github.com/virtualprivatenode/vpn/internal/config"
 )
 
 // realistic excerpt of sshd -T output: lowercase keywords,
@@ -148,5 +148,59 @@ func TestBuildSSHHardeningConfig(t *testing.T) {
 
 	if !strings.HasSuffix(disabled, "\n") {
 		t.Fatal("config must end with a newline")
+	}
+}
+
+// ── buildHardeningDropIn (the shared builder) ────────────
+
+func TestBuildHardeningDropInExplicit(t *testing.T) {
+	yes := buildHardeningDropIn("yes")
+	if !strings.Contains(yes, "PasswordAuthentication yes\n") {
+		t.Errorf("explicit yes missing:\n%s", yes)
+	}
+	no := buildHardeningDropIn("no")
+	if !strings.Contains(no, "PasswordAuthentication no\n") {
+		t.Errorf("explicit no missing:\n%s", no)
+	}
+}
+
+// The degraded mode (ruling xvi(a)): observation failed →
+// directive OMITTED, the script's documented semantics. The
+// static hardening still applies.
+func TestBuildHardeningDropInOmission(t *testing.T) {
+	out := buildHardeningDropIn("")
+	if strings.Contains(out, "PasswordAuthentication") {
+		t.Errorf("omission mode still emits the directive:\n%s",
+			out)
+	}
+	for _, line := range []string{
+		"PermitRootLogin no",
+		"PubkeyAuthentication yes",
+		"ChallengeResponseAuthentication no",
+		"KbdInteractiveAuthentication no",
+		"X11Forwarding no",
+	} {
+		if !strings.Contains(out, line) {
+			t.Errorf("static line %q missing in omission mode",
+				line)
+		}
+	}
+	if !strings.HasSuffix(out, "\n") {
+		t.Error("drop-in must end with a newline")
+	}
+}
+
+// The TUI-era builder and the install builder must render the
+// SAME body for the same auth state — a migrated box's later
+// TUI rebuild may not churn the file.
+func TestBuildersAgree(t *testing.T) {
+	cfg := config.Default()
+	cfg.SSHPasswordAuthDisabled = true
+	if BuildSSHHardeningConfig(cfg) != buildHardeningDropIn("no") {
+		t.Error("builders disagree for disabled state")
+	}
+	cfg.SSHPasswordAuthDisabled = false
+	if BuildSSHHardeningConfig(cfg) != buildHardeningDropIn("yes") {
+		t.Error("builders disagree for enabled state")
 	}
 }

--- a/internal/installer/sshkeys.go
+++ b/internal/installer/sshkeys.go
@@ -10,8 +10,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/ripsline/virtual-private-node/internal/paths"
-	"github.com/ripsline/virtual-private-node/internal/system"
+	"github.com/virtualprivatenode/vpn/internal/paths"
+	"github.com/virtualprivatenode/vpn/internal/system"
 )
 
 // SSHKeyInfo holds parsed metadata for a single authorized key.
@@ -91,7 +91,7 @@ func ValidateSSHKey(line string) error {
 }
 
 // ListAuthorizedKeys reads and parses all keys from the
-// ripsline user's authorized_keys file. Returns an empty
+// admin user's authorized_keys file. Returns an empty
 // slice (not an error) if the file does not exist.
 func ListAuthorizedKeys() ([]SSHKeyInfo, error) {
 	data, err := system.SudoReadFile(

--- a/internal/installer/sshstep.go
+++ b/internal/installer/sshstep.go
@@ -1,0 +1,192 @@
+// internal/installer/sshstep.go
+
+package installer
+
+// The install-path SSH hardening step (ruling xvi(a) + ruling
+// xv's binding order). What the retired bootstrap script did with
+// a heredoc, done with the observation discipline the sprint
+// built:
+//
+//	observe → write new drop-in → delete old drop-in →
+//	validate → restart
+//
+// The order is BINDING. On a migrated box, a TUI-disabled
+// PasswordAuthentication lives in the OLD drop-in
+// (00-rlvpn-hardening.conf) — deleting it before the observed
+// value is captured into the new file would re-manufacture the
+// day-one cfg lie in reverse (ruling xv). And because the old
+// name sorts before the new one (r < v, first-match-wins), the
+// brief window where both files exist is safe precisely because
+// the new file carries the observed — that is, identical —
+// value.
+//
+// Directive election (ruling xvi(a)): the new drop-in writes
+// PasswordAuthentication EXPLICITLY with the value observed
+// seconds before, in the same process. Explicit-from-observed is
+// STRONGER than the script's omission: our 00- file owns the
+// setting from here on, so later provider/cloud-init drift
+// cannot silently re-enable password auth. Only if the
+// observation itself fails does the step degrade to the script's
+// omission semantics, with a logged warning — preflight already
+// proved sshd observable, so this failing mid-install means the
+// environment regressed, and asserting nothing beats asserting a
+// guess.
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/virtualprivatenode/vpn/internal/config"
+	"github.com/virtualprivatenode/vpn/internal/logger"
+	"github.com/virtualprivatenode/vpn/internal/paths"
+	"github.com/virtualprivatenode/vpn/internal/system"
+)
+
+// installSSHHardening is the ssh.harden step.
+func installSSHHardening(cfg *config.AppConfig) error {
+	// 1. Observe — seconds before the write, same process.
+	passwordAuth := ""
+	obs, err := ObserveSSHState()
+	if err != nil {
+		logger.Install(
+			"WARNING: sshd observation failed at the SSH step "+
+				"(%v) — writing the drop-in WITHOUT a "+
+				"PasswordAuthentication directive (script "+
+				"omission semantics); password auth state is "+
+				"whatever the rest of the sshd config elects", err)
+	} else {
+		if obs.PasswordAuth {
+			passwordAuth = "yes"
+		} else {
+			passwordAuth = "no"
+		}
+		// Reality wins over any carried-over claim: on a
+		// migrated box the two agree by construction (the old
+		// drop-in still stands at observation time); if they
+		// ever disagree, the cfg was the lie — correct it and
+		// say so.
+		disabled := !obs.PasswordAuth
+		if cfg.SSHPasswordAuthDisabled != disabled {
+			logger.Install(
+				"config said ssh_password_auth_disabled=%v but "+
+					"sshd's effective state is %v — config corrected "+
+					"from observation",
+				cfg.SSHPasswordAuthDisabled, disabled)
+			cfg.SSHPasswordAuthDisabled = disabled
+		}
+	}
+
+	// Capture both files' prior state so a failed validation
+	// restores the box byte-for-byte: the new-name drop-in
+	// (usually absent) and the old-name drop-in (present only
+	// on migrated boxes).
+	prevNew, prevNewExists, err := readDropIn(paths.SSHDDropIn)
+	if err != nil {
+		return fmt.Errorf("read current sshd drop-in: %w", err)
+	}
+	prevOld, prevOldExists, err := readDropIn(paths.OldSSHDDropIn)
+	if err != nil {
+		return fmt.Errorf("read old sshd drop-in: %w", err)
+	}
+
+	// 2. Write the new drop-in.
+	content := buildHardeningDropIn(passwordAuth)
+	if err := system.SudoWriteFile(
+		paths.SSHDDropIn, []byte(content), 0644); err != nil {
+		return fmt.Errorf("write sshd drop-in: %w", err)
+	}
+
+	// 3. Delete the old-name drop-in (the rename's ONLY
+	// old-artifact removal — ruling xv).
+	if prevOldExists {
+		if err := system.SudoRun(
+			"rm", "-f", paths.OldSSHDDropIn); err != nil {
+			return fmt.Errorf(
+				"remove old drop-in %s: %w",
+				paths.OldSSHDDropIn, err)
+		}
+		logger.Install("removed stale drop-in %s (rename)",
+			paths.OldSSHDDropIn)
+	}
+
+	// 4. Validate the merged config BEFORE any restart; restore
+	// both files on rejection, so sshd keeps running its
+	// current, valid config.
+	if out, err := system.SudoRunCombinedOutput(
+		"sshd", "-t"); err != nil {
+		detail := strings.TrimSpace(out)
+		restoreErr := restoreDropIns(
+			prevNew, prevNewExists, prevOld, prevOldExists)
+		if restoreErr != nil {
+			return fmt.Errorf(
+				"sshd rejected the new config (%s) and restoring "+
+					"the previous drop-ins also failed (%v) — sshd "+
+					"was NOT restarted and keeps running its current "+
+					"config; inspect %s before restarting sshd",
+				detail, restoreErr, paths.SSHDDropIn)
+		}
+		return fmt.Errorf(
+			"sshd rejected the new config, previous drop-ins "+
+				"restored, sshd not restarted: %s", detail)
+	}
+
+	// 5. Restart.
+	if err := restartSSHD(); err != nil {
+		return err
+	}
+	if passwordAuth == "" {
+		logger.Install("SSH hardening applied (root login " +
+			"disabled; PasswordAuthentication directive omitted — " +
+			"degraded mode)")
+	} else {
+		logger.Install("SSH hardening applied (root login "+
+			"disabled; PasswordAuthentication %s, from observation)",
+			passwordAuth)
+	}
+	return nil
+}
+
+// readDropIn reads a drop-in, distinguishing absent (fine) from
+// unreadable (abort — an unreadable prior state could not be
+// restored after a failed validation).
+func readDropIn(path string) ([]byte, bool, error) {
+	data, err := system.SudoReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) ||
+			strings.Contains(err.Error(), "No such file") {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	return data, true, nil
+}
+
+// restoreDropIns puts both drop-in files back to their captured
+// pre-step state.
+func restoreDropIns(
+	prevNew []byte, newExisted bool,
+	prevOld []byte, oldExisted bool,
+) error {
+	var firstErr error
+	if newExisted {
+		if err := system.SudoWriteFile(
+			paths.SSHDDropIn, prevNew, 0644); err != nil {
+			firstErr = err
+		}
+	} else {
+		if err := system.SudoRun(
+			"rm", "-f", paths.SSHDDropIn); err != nil &&
+			firstErr == nil {
+			firstErr = err
+		}
+	}
+	if oldExisted {
+		if err := system.SudoWriteFile(
+			paths.OldSSHDDropIn, prevOld, 0644); err != nil &&
+			firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}

--- a/internal/installer/syncthing.go
+++ b/internal/installer/syncthing.go
@@ -13,10 +13,10 @@ import (
 
 	"golang.org/x/crypto/bcrypt"
 
-	"github.com/ripsline/virtual-private-node/internal/config"
-	"github.com/ripsline/virtual-private-node/internal/logger"
-	"github.com/ripsline/virtual-private-node/internal/paths"
-	"github.com/ripsline/virtual-private-node/internal/system"
+	"github.com/virtualprivatenode/vpn/internal/config"
+	"github.com/virtualprivatenode/vpn/internal/logger"
+	"github.com/virtualprivatenode/vpn/internal/paths"
+	"github.com/virtualprivatenode/vpn/internal/system"
 )
 
 // downloadSyncthing fetches the pinned release tarball and its

--- a/internal/installer/system.go
+++ b/internal/installer/system.go
@@ -8,9 +8,9 @@ import (
 	"os/user"
 	"strings"
 
-	"github.com/ripsline/virtual-private-node/internal/config"
-	"github.com/ripsline/virtual-private-node/internal/paths"
-	"github.com/ripsline/virtual-private-node/internal/system"
+	"github.com/virtualprivatenode/vpn/internal/config"
+	"github.com/virtualprivatenode/vpn/internal/paths"
+	"github.com/virtualprivatenode/vpn/internal/system"
 )
 
 // The OS check formerly here (checkOS, Debian 13-or-newer) is
@@ -65,6 +65,18 @@ net.ipv6.conf.lo.disable_ipv6 = 1
 	return system.SudoRunSilent("sysctl", "--system")
 }
 
+// configureFirewall applies the full cfg-derived rule set —
+// idempotent, called at install and again by every TUI flow that
+// changes the port surface (P2P upgrade, Syncthing). Outbound
+// stays default-allow so Tor bootstraps behind default-deny.
+//
+// SSH allow-rules come from cfg.SSHPortsOrDefault() — seeded at
+// install from the preflight sshd observation (ruling xvi(b)).
+// The previous hardcoded 22 was the one real lockout hazard on
+// nonstandard-port boxes: deny-all with only 22 open while sshd
+// listens elsewhere is a DELAYED silent lockout (this session
+// survives; the next connection is refused). A normal box
+// observes {22} and gets byte-identical behavior.
 func configureFirewall(cfg *config.AppConfig) error {
 	if err := system.SudoRun("apt-get", "install",
 		"-y", "-qq", "ufw"); err != nil {
@@ -82,7 +94,11 @@ func configureFirewall(cfg *config.AppConfig) error {
 	commands := [][]string{
 		{"ufw", "default", "deny", "incoming"},
 		{"ufw", "default", "allow", "outgoing"},
-		{"ufw", "allow", "22/tcp"},
+	}
+	for _, p := range cfg.SSHPortsOrDefault() {
+		commands = append(commands,
+			[]string{"ufw", "allow",
+				fmt.Sprintf("%d/tcp", p)})
 	}
 
 	if cfg.HasLND() && cfg.P2PMode == "hybrid" {

--- a/internal/installer/tor.go
+++ b/internal/installer/tor.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/ripsline/virtual-private-node/internal/config"
-	"github.com/ripsline/virtual-private-node/internal/paths"
-	"github.com/ripsline/virtual-private-node/internal/system"
+	"github.com/virtualprivatenode/vpn/internal/config"
+	"github.com/virtualprivatenode/vpn/internal/paths"
+	"github.com/virtualprivatenode/vpn/internal/system"
 )
 
 func installTor() error {

--- a/internal/installer/tor_test.go
+++ b/internal/installer/tor_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ripsline/virtual-private-node/internal/config"
+	"github.com/virtualprivatenode/vpn/internal/config"
 )
 
 func TestTorConfigBitcoinOnly(t *testing.T) {

--- a/internal/installer/torgate.go
+++ b/internal/installer/torgate.go
@@ -39,8 +39,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ripsline/virtual-private-node/internal/logger"
-	"github.com/ripsline/virtual-private-node/internal/system"
+	"github.com/virtualprivatenode/vpn/internal/logger"
+	"github.com/virtualprivatenode/vpn/internal/system"
 )
 
 // Tor runtime constants. These are Tor-owned values, not Go logic

--- a/internal/installer/torgate.go
+++ b/internal/installer/torgate.go
@@ -54,7 +54,18 @@ const (
 	torControlAddr = "127.0.0.1:9051"
 	torCookiePath  = "/run/tor/control.authcookie"
 
-	torBootstrapTimeout = 90 * time.Second
+	// Stall clock and ceiling (operator ruling at the commit-6
+	// live run, replacing the original flat 90s deadline). The
+	// flat deadline dated from when the bootstrap script gave
+	// Tor a warm-up minute plus an SSH round trip before this
+	// gate ever ran; with the script absorbed, the gate fires
+	// seconds after Tor first starts, and a healthy slow box
+	// was failed at 65% while still advancing. Now: fail only
+	// when bootstrap PROGRESS has not moved for the stall
+	// window; the ceiling bounds the step against pathological
+	// crawl (a bounded install step must end).
+	torStallWindow      = 90 * time.Second
+	torBootstrapCeiling = 10 * time.Minute
 	torBootstrapPoll    = 3 * time.Second
 
 	torProbeURL      = "https://check.torproject.org/api/ip"
@@ -68,7 +79,8 @@ func verifyTorRouting() error {
 			"all downloads must route through Tor")
 	}
 
-	if err := waitForTorBootstrap(torBootstrapTimeout); err != nil {
+	if err := waitForTorBootstrap(
+		torStallWindow, torBootstrapCeiling); err != nil {
 		return err
 	}
 	logger.Install("Tor bootstrap 100%% CONFIRMED (via control port)")
@@ -77,11 +89,19 @@ func verifyTorRouting() error {
 }
 
 // waitForTorBootstrap polls Tor's control port until it reports
-// bootstrap PROGRESS=100 or the deadline passes. Poll errors are
-// retried silently until the deadline — immediately after restartTor
-// the control port may not be listening yet.
-func waitForTorBootstrap(timeout time.Duration) error {
-	deadline := time.Now().Add(timeout)
+// bootstrap PROGRESS=100, failing on STALL (no progress change
+// for the stall window) or on the absolute ceiling. Any change
+// in reported progress resets the stall clock — including a
+// drop, because Tor resets its counter to zero when it restarts
+// mid-bootstrap, and rebootstrapping is activity, not a stall.
+// Poll errors are retried silently within the same clocks —
+// immediately after restartTor the control port may not be
+// listening yet.
+func waitForTorBootstrap(
+	stallWindow, ceiling time.Duration,
+) error {
+	start := time.Now()
+	lastAdvance := start
 	lastProgress := -1
 	var lastErr error
 
@@ -94,25 +114,50 @@ func waitForTorBootstrap(timeout time.Duration) error {
 			if progress != lastProgress {
 				logger.Install("Tor bootstrapping: %d%%", progress)
 				lastProgress = progress
+				lastAdvance = time.Now()
 			}
 		} else {
 			lastErr = err
 		}
 
-		if time.Now().After(deadline) {
+		if !keepWaitingForTor(time.Now(), start, lastAdvance,
+			stallWindow, ceiling) {
 			break
 		}
 		time.Sleep(torBootstrapPoll)
 	}
 
-	detail := fmt.Sprintf("last progress %d%%", lastProgress)
 	if lastProgress < 0 && lastErr != nil {
-		detail = fmt.Sprintf("control port never answered: %v "+
-			"(is ControlPort 9051 enabled in torrc?)", lastErr)
+		return fmt.Errorf("Tor bootstrap check failed within %s "+
+			"(control port never answered: %v — is ControlPort "+
+			"9051 enabled in torrc?) — check: systemctl status "+
+			"tor; journalctl -u tor", stallWindow, lastErr)
 	}
-	return fmt.Errorf("Tor did not finish bootstrapping within %s (%s) — "+
+	if time.Since(start) >= ceiling {
+		return fmt.Errorf("Tor did not finish bootstrapping "+
+			"within %s (last progress %d%%) — check: systemctl "+
+			"status tor; journalctl -u tor", ceiling, lastProgress)
+	}
+	return fmt.Errorf("Tor bootstrap STALLED at %d%% for %s — "+
 		"check: systemctl status tor; journalctl -u tor",
-		timeout, detail)
+		lastProgress, stallWindow)
+}
+
+// keepWaitingForTor is the gate's clock rule as a pure function
+// (unit-tested): keep waiting while the stall window has not
+// elapsed since the last progress change AND the absolute
+// ceiling has not elapsed since the step started.
+func keepWaitingForTor(
+	now, start, lastAdvance time.Time,
+	stallWindow, ceiling time.Duration,
+) bool {
+	if now.Sub(lastAdvance) >= stallWindow {
+		return false
+	}
+	if now.Sub(start) >= ceiling {
+		return false
+	}
+	return true
 }
 
 // queryTorBootstrapProgress performs one control-port round trip:

--- a/internal/installer/torgate_test.go
+++ b/internal/installer/torgate_test.go
@@ -5,6 +5,7 @@ package installer
 import (
 	"errors"
 	"testing"
+	"time"
 )
 
 func TestParseBootstrapProgress(t *testing.T) {
@@ -60,6 +61,45 @@ func TestTorProbeVerdict(t *testing.T) {
 		if got := torProbeVerdict(c.output, c.err); got != c.want {
 			t.Errorf("%s: torProbeVerdict(%q, %v) = %v, want %v",
 				c.name, c.output, c.err, got, c.want)
+		}
+	}
+}
+
+// ── keepWaitingForTor (the stall/ceiling clock rule) ─────
+
+func TestKeepWaitingForTor(t *testing.T) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	stall := 90 * time.Second
+	ceiling := 10 * time.Minute
+
+	cases := []struct {
+		name        string
+		sinceStart  time.Duration
+		sinceMove   time.Duration
+		keepWaiting bool
+	}{
+		{"fresh start", 0, 0, true},
+		{"advancing slowly, well under both",
+			5 * time.Minute, 10 * time.Second, true},
+		{"just under the stall window",
+			2 * time.Minute, 89 * time.Second, true},
+		{"stalled exactly at the window",
+			2 * time.Minute, 90 * time.Second, false},
+		{"stalled past the window",
+			2 * time.Minute, 3 * time.Minute, false},
+		{"ceiling reached while still advancing",
+			10 * time.Minute, 5 * time.Second, false},
+		{"past the ceiling",
+			11 * time.Minute, 5 * time.Second, false},
+	}
+	for _, tt := range cases {
+		now := base.Add(tt.sinceStart)
+		lastAdvance := now.Add(-tt.sinceMove)
+		got := keepWaitingForTor(now, base, lastAdvance,
+			stall, ceiling)
+		if got != tt.keepWaiting {
+			t.Errorf("%s: got %v, want %v",
+				tt.name, got, tt.keepWaiting)
 		}
 	}
 }

--- a/internal/installer/userpassword.go
+++ b/internal/installer/userpassword.go
@@ -5,8 +5,9 @@ package installer
 import (
 	"errors"
 	"fmt"
-	"os/exec"
 	"strings"
+
+	"github.com/virtualprivatenode/vpn/internal/system"
 )
 
 // MinLoginPasswordLen is the minimum length for the admin
@@ -61,9 +62,10 @@ func (LoginPassword) String() string { return "[redacted]" }
 func (LoginPassword) GoString() string { return "[redacted]" }
 
 // SetUserPassword changes the given user's login password
-// via `sudo chpasswd`. The password is piped to chpasswd's
-// stdin so it never appears in argv (which would leak via
-// /proc/*/cmdline or `ps`).
+// via chpasswd (root-privileged through the system seam).
+// The password is piped to chpasswd's stdin so it never
+// appears in argv (which would leak via /proc/*/cmdline or
+// `ps`).
 //
 // The password arrives as a LoginPassword, so validation
 // has already happened at construction; the zero-value
@@ -84,16 +86,13 @@ func SetUserPassword(
 				"(zero LoginPassword)")
 	}
 
-	cmd := exec.Command("sudo", "chpasswd")
-	cmd.Stdin = strings.NewReader(
-		username + ":" + password.v + "\n")
-	out, err := cmd.CombinedOutput()
+	out, err := system.SudoRunStdin(
+		username+":"+password.v+"\n", "chpasswd")
 	if err != nil {
-		msg := strings.TrimSpace(string(out))
-		if msg == "" {
+		if out == "" {
 			return fmt.Errorf("chpasswd: %w", err)
 		}
-		return fmt.Errorf("chpasswd: %s", msg)
+		return fmt.Errorf("chpasswd: %s", out)
 	}
 	return nil
 }

--- a/internal/installer/verify.go
+++ b/internal/installer/verify.go
@@ -12,7 +12,7 @@
 // GPG exit code is never trusted.
 //
 // Four callers use verifyIsolated:
-//   - verifySelfUpdate:      threshold 1 vs the rlvpn release key
+//   - verifySelfUpdate:      threshold 1 vs the vpn release key
 //   - verifyBitcoinCoreSigs: threshold 2 distinct builder fingerprints
 //   - verifyLNDSig:          threshold 1 vs roasbeef's fingerprint
 //   - verifySyncthingSig:    threshold 1 vs the Syncthing release key
@@ -27,8 +27,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/ripsline/virtual-private-node/internal/logger"
-	"github.com/ripsline/virtual-private-node/internal/system"
+	"github.com/virtualprivatenode/vpn/internal/logger"
+	"github.com/virtualprivatenode/vpn/internal/system"
 )
 
 // ── Trust anchors ───────────────────────────────────────
@@ -38,12 +38,13 @@ import (
 // into an ephemeral keyring, and confirm the fingerprint with
 // gpg --with-colons --list-keys.
 
-// rlvpnReleaseFP is the primary fingerprint of the rlvpn
+// vpnReleaseFP is the primary fingerprint of the vpn
 // release signing key.
 // Source: generated locally; public key hosted at
-// keys.openpgp.org. Cross-check: SIGNING_KEY_FP in
-// virtual-private-node.sh (line 24).
-const rlvpnReleaseFP = "AFA0EBACDC9A4C4AA7B0154AC97CE10F170BA5FE"
+// keys.openpgp.org. Cross-check: the fingerprint in
+// MIGRATION.md (Step 1) — the SAME key signed every release
+// under the old name.
+const vpnReleaseFP = "AFA0EBACDC9A4C4AA7B0154AC97CE10F170BA5FE"
 
 // bitcoinCoreSigners are the trusted Bitcoin Core builder keys.
 // Source: github.com/bitcoin-core/guix.sigs/tree/main/builder-keys
@@ -160,7 +161,7 @@ func verifyIsolated(
 	pinnedFPs map[string]bool,
 ) (distinctValidSigners int, badSig bool, err error) {
 	// Ephemeral GPG home — 0700, random path, cleaned up on return.
-	gpgHome, err := os.MkdirTemp("", "rlvpn-gpg-")
+	gpgHome, err := os.MkdirTemp("", "vpn-gpg-")
 	if err != nil {
 		return 0, false, fmt.Errorf(
 			"create ephemeral gpg home: %w", err)
@@ -500,7 +501,7 @@ func verifySelfUpdate(workDir string) error {
 	keyFile := filepath.Join(workDir, "release-key.asc")
 	keyURL := fmt.Sprintf(
 		"https://keys.openpgp.org/vks/v1/by-fingerprint/%s",
-		rlvpnReleaseFP)
+		vpnReleaseFP)
 	if err := system.DownloadRequireTor(
 		keyURL, keyFile); err != nil {
 		logger.Verify(
@@ -509,7 +510,7 @@ func verifySelfUpdate(workDir string) error {
 			"download release signing key: %w", err)
 	}
 
-	pinnedFPs := map[string]bool{rlvpnReleaseFP: true}
+	pinnedFPs := map[string]bool{vpnReleaseFP: true}
 
 	distinct, hasBadSig, err := verifyIsolated(
 		[]string{keyFile}, sigFile, sumsFile, pinnedFPs)

--- a/internal/installer/verify_test.go
+++ b/internal/installer/verify_test.go
@@ -172,7 +172,7 @@ func TestVerifyIsolated(t *testing.T) {
 
 	// Set up a key-generation homedir with two distinct keys
 	// and one subkey-only key.
-	genHome, err := os.MkdirTemp("", "rlvpn-test-gen-")
+	genHome, err := os.MkdirTemp("", "vpn-test-gen-")
 	if err != nil {
 		t.Fatalf("create gen home: %v", err)
 	}
@@ -183,7 +183,7 @@ func TestVerifyIsolated(t *testing.T) {
 	fpSubkey := testGenKey(t, genHome, "SubkeySigner", true)
 
 	// Create test data file.
-	dataDir, err := os.MkdirTemp("", "rlvpn-test-data-")
+	dataDir, err := os.MkdirTemp("", "vpn-test-data-")
 	if err != nil {
 		t.Fatalf("create data dir: %v", err)
 	}
@@ -373,7 +373,7 @@ func TestVerifyIsolatedClearsign(t *testing.T) {
 		t.Skip("gpg not available — skipping")
 	}
 
-	genHome, err := os.MkdirTemp("", "rlvpn-test-gen-")
+	genHome, err := os.MkdirTemp("", "vpn-test-gen-")
 	if err != nil {
 		t.Fatalf("create gen home: %v", err)
 	}
@@ -382,7 +382,7 @@ func TestVerifyIsolatedClearsign(t *testing.T) {
 	fpAlpha := testGenKey(t, genHome, "ClearAlpha", false)
 	fpBeta := testGenKey(t, genHome, "ClearBeta", false)
 
-	dataDir, err := os.MkdirTemp("", "rlvpn-test-data-")
+	dataDir, err := os.MkdirTemp("", "vpn-test-data-")
 	if err != nil {
 		t.Fatalf("create data dir: %v", err)
 	}
@@ -514,16 +514,16 @@ func TestSignerFingerprints(t *testing.T) {
 }
 
 func TestReleaseKeyFingerprint(t *testing.T) {
-	if len(rlvpnReleaseFP) != 40 {
+	if len(vpnReleaseFP) != 40 {
 		t.Errorf("release key fingerprint length %d, want 40",
-			len(rlvpnReleaseFP))
+			len(vpnReleaseFP))
 	}
 
 	// Cross-check: must match the value baked into
-	// virtual-private-node.sh SIGNING_KEY_FP (line 24).
+	// the fingerprint published in MIGRATION.md (Step 1).
 	expected := "AFA0EBACDC9A4C4AA7B0154AC97CE10F170BA5FE"
-	if rlvpnReleaseFP != expected {
+	if vpnReleaseFP != expected {
 		t.Errorf("release FP = %s, want %s",
-			rlvpnReleaseFP, expected)
+			vpnReleaseFP, expected)
 	}
 }

--- a/internal/installer/wizard.go
+++ b/internal/installer/wizard.go
@@ -110,6 +110,13 @@ type wizardModel struct {
 	// Steps
 	current           int
 	stepsDone, failed bool
+
+	// openConsole records the operator's CHOICE on the done
+	// screen: Enter = open the node console (handoff), ctrl+c
+	// = just exit. The live run caught the two paths behaving
+	// identically — the hint promised an exit that handed off
+	// anyway.
+	openConsole bool
 }
 
 func newWizardModel(
@@ -260,6 +267,7 @@ func (m wizardModel) Update(
 		case wzDone:
 			if msg.String() == "enter" && !m.failed &&
 				m.completeErr == "" {
+				m.openConsole = true
 				return m, tea.Quit
 			}
 		}
@@ -895,8 +903,9 @@ func (m wizardModel) viewDone(p *wizPane) {
 		"command above from a SECOND terminal first to " +
 		"verify your access.")
 	p.blank()
-	p.hint("enter: open the node console   ctrl+c: exit " +
-		"(the install is already recorded)")
+	p.hint("enter: open the node console   ctrl+c: exit to " +
+		"your shell (your install is saved; connect any time " +
+		"with the command above)")
 }
 
 // ── View plumbing ────────────────────────────────────────
@@ -1020,11 +1029,11 @@ func runInstallWizard(
 	cfg *config.AppConfig, steps []InstallStep,
 	dec *InstallDecisions, version string,
 	onComplete func() error,
-) (RunResult, error) {
+) (RunResult, bool, error) {
 	runner, err := newStepRunner(
 		steps, version, paths.InstallStateFile)
 	if err != nil {
-		return RunResult{}, err
+		return RunResult{}, false, err
 	}
 	theme.Init(cfg.Theme != "light")
 	m := newWizardModel(cfg, steps, runner, dec, version,
@@ -1032,16 +1041,16 @@ func runInstallWizard(
 	p := tea.NewProgram(m)
 	result, err := p.Run()
 	if err != nil {
-		return RunResult{}, err
+		return RunResult{}, false, err
 	}
 	final := result.(wizardModel)
 	if final.completeErr != "" {
-		return RunResult{}, fmt.Errorf(
+		return RunResult{}, false, fmt.Errorf(
 			"install steps complete but the completion record "+
 				"failed: %s — run sudo vpn install again to retry",
 			final.completeErr)
 	}
 	return classifyRun(final.steps,
 		final.stepsDone && !final.failed,
-		final.failed, final.current), nil
+		final.failed, final.current), final.openConsole, nil
 }

--- a/internal/installer/wizard.go
+++ b/internal/installer/wizard.go
@@ -1,0 +1,829 @@
+// internal/installer/wizard.go
+
+package installer
+
+// The interactive `vpn install` front-end: the ruling-vii
+// identity/access screen, the ruling-viii hardware-fit screen,
+// and the step-progress renderer, flowing into the completion
+// handoff. Born in the unified chrome (ruling xvi(d)): theme
+// styles and the step-renderer visual language of the post-
+// install TUI — but chrome only, NO ScreenContext/lifecycle
+// adoption (the C′ boundary holds; this front-end stays a thin
+// driver of the commit-5 engine, making no skip or record
+// decisions of its own).
+//
+// Step-render semantics (ratified, xvi(d)): DIM rows are
+// believed-from-ledger (a prior pass completed them — [skip]);
+// BRIGHT rows executed or verified THIS pass. Gates always
+// re-run, so gates are always bright.
+
+import (
+	"fmt"
+	"strings"
+
+	"charm.land/bubbles/v2/textinput"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	"github.com/virtualprivatenode/vpn/internal/config"
+	"github.com/virtualprivatenode/vpn/internal/paths"
+	"github.com/virtualprivatenode/vpn/internal/theme"
+)
+
+type wizardPhase int
+
+const (
+	wzAccess wizardPhase = iota
+	wzPaste
+	wzPassword
+	wzHardware
+	wzSteps
+	wzDone
+)
+
+type wizardStepDoneMsg struct {
+	index   int
+	skipped bool
+	err     error
+}
+
+type wizardModel struct {
+	cfg     *config.AppConfig
+	dec     *InstallDecisions
+	steps   []InstallStep
+	runner  *stepRunner
+	version string
+
+	phase         wizardPhase
+	width, height int
+
+	needIdentity bool
+	needHardware bool
+
+	// Access screen
+	sources  []KeySource
+	keys     []SSHKeyInfo
+	selected []bool
+	cursor   int // 0..len(keys)-1 = key rows; len(keys) = button row
+	btnIdx   int // 0 = Continue, 1 = Paste a key
+	accErr   string
+
+	// Paste screen
+	pasteInput textinput.Model
+	pasteErr   string
+
+	// Password screen
+	pwInput   textinput.Model
+	pwConfirm textinput.Model
+	pwFocus   int // 0 = new, 1 = confirm, 2 = button
+	pwErr     string
+
+	// Hardware screen
+	hw    Hardware
+	dbIdx int
+
+	// Steps
+	current           int
+	stepsDone, failed bool
+	stepsStarted      bool
+}
+
+func newWizardModel(
+	cfg *config.AppConfig, steps []InstallStep,
+	runner *stepRunner, dec *InstallDecisions, version string,
+) wizardModel {
+	m := wizardModel{
+		cfg: cfg, dec: dec, steps: steps,
+		runner: runner, version: version,
+	}
+
+	// Resume-aware screen skipping: a screen exists to collect
+	// decisions for a step; if the ledger says that step is
+	// complete, re-asking would collect answers nothing will
+	// apply. (Residual, accepted: an interrupted run that
+	// resumes past the btc group keeps bitcoin.conf from the
+	// earlier pass while dbcache is re-persisted only at
+	// completion — present-correctness is the doctor check's
+	// question, not resume's.)
+	m.needIdentity = runner.willRun(steps, "identity.access")
+	m.needHardware = runner.willRun(steps, "btc.install")
+
+	m.sources = SortKeySources(EnumerateKeySources())
+	m.keys = DedupeKeys(m.sources)
+	m.selected = make([]bool, len(m.keys))
+	for i := range m.selected {
+		m.selected[i] = true
+	}
+
+	m.pasteInput = newWizardInput(
+		"ssh-ed25519 AAAA... comment", 1000, 56)
+	m.pwInput = newWizardPasswordInput()
+	m.pwConfirm = newWizardPasswordInput()
+
+	m.hw = DetectHardware()
+	rec := RecommendDbCache(m.hw.RAMMB)
+	for i, v := range dbCacheChoices {
+		if v == rec {
+			m.dbIdx = i
+		}
+	}
+
+	switch {
+	case m.needIdentity:
+		m.phase = wzAccess
+	case m.needHardware:
+		m.phase = wzHardware
+	default:
+		m.phase = wzSteps
+	}
+	return m
+}
+
+func newWizardInput(
+	placeholder string, limit, width int,
+) textinput.Model {
+	ti := textinput.New()
+	ti.Placeholder = placeholder
+	ti.CharLimit = limit
+	ti.SetWidth(width)
+	ti.Prompt = "  "
+	s := textinput.DefaultStyles(theme.IsDark())
+	ti.SetStyles(s)
+	return ti
+}
+
+func newWizardPasswordInput() textinput.Model {
+	ti := newWizardInput("", 128, 40)
+	ti.EchoMode = textinput.EchoPassword
+	return ti
+}
+
+// ── tea.Model ────────────────────────────────────────────
+
+func (m wizardModel) Init() tea.Cmd {
+	if m.phase == wzSteps {
+		return m.startSteps()
+	}
+	if m.phase == wzAccess {
+		return nil
+	}
+	return nil
+}
+
+func (m wizardModel) startSteps() tea.Cmd {
+	if len(m.steps) == 0 {
+		return tea.Quit
+	}
+	m.steps[0].Status = StepRunning
+	return m.runStep(0)
+}
+
+func (m wizardModel) runStep(i int) tea.Cmd {
+	return func() tea.Msg {
+		if i >= len(m.steps) {
+			return wizardStepDoneMsg{index: i}
+		}
+		skipped, err := m.runner.runIndex(i)
+		return wizardStepDoneMsg{
+			index: i, skipped: skipped, err: err}
+	}
+}
+
+func (m wizardModel) Update(
+	msg tea.Msg,
+) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		return m, nil
+
+	case wizardStepDoneMsg:
+		return m.updateSteps(msg)
+
+	case tea.KeyPressMsg:
+		// Quitting is allowed at any instant — an interrupt is
+		// SAFE (the ledger records a step only after it
+		// verified complete) and HONEST (a quit before all
+		// steps ran classifies as interrupted, never complete —
+		// IA-1-9).
+		if msg.String() == "ctrl+c" {
+			return m, tea.Quit
+		}
+		switch m.phase {
+		case wzAccess:
+			return m.updateAccess(msg)
+		case wzPaste:
+			return m.updatePaste(msg)
+		case wzPassword:
+			return m.updatePassword(msg)
+		case wzHardware:
+			return m.updateHardware(msg)
+		case wzDone:
+			if msg.String() == "enter" && !m.failed {
+				return m, tea.Quit
+			}
+		}
+	}
+	return m, nil
+}
+
+// ── Access screen ────────────────────────────────────────
+
+func (m wizardModel) updateAccess(
+	msg tea.KeyPressMsg,
+) (tea.Model, tea.Cmd) {
+	last := len(m.keys) // index of the button row
+	switch msg.String() {
+	case "up":
+		if m.cursor > 0 {
+			m.cursor--
+		}
+	case "down", "tab":
+		if m.cursor < last {
+			m.cursor++
+		}
+	case "left":
+		if m.cursor == last && m.btnIdx > 0 {
+			m.btnIdx--
+		}
+	case "right":
+		if m.cursor == last && m.btnIdx < 1 {
+			m.btnIdx++
+		}
+	case "space":
+		if m.cursor < len(m.keys) {
+			m.selected[m.cursor] = !m.selected[m.cursor]
+			m.accErr = ""
+		}
+	case "enter":
+		if m.cursor < len(m.keys) {
+			m.selected[m.cursor] = !m.selected[m.cursor]
+			m.accErr = ""
+			return m, nil
+		}
+		if m.btnIdx == 1 {
+			m.pasteErr = ""
+			m.pasteInput.SetValue("")
+			m.pasteInput.Focus()
+			m.phase = wzPaste
+			return m, nil
+		}
+		// Continue: collect selection; refuse a zero-auth
+		// outcome (no keys AND password auth observed off —
+		// the drop-in will carry that "off" forward, so the
+		// admin user would have no network way in at all).
+		var chosen []SSHKeyInfo
+		for i, k := range m.keys {
+			if m.selected[i] {
+				chosen = append(chosen, k)
+			}
+		}
+		if len(chosen) == 0 && !m.dec.Obs.PasswordAuth {
+			m.accErr = "Password login is disabled on this " +
+				"box — select or paste at least one key, or " +
+				"the " + paths.AdminUser +
+				" user would have no way in over SSH."
+			return m, nil
+		}
+		m.dec.Keys = chosen
+		m.pwFocus = 0
+		m.pwInput.Focus()
+		m.pwConfirm.Blur()
+		m.phase = wzPassword
+		return m, nil
+	}
+	return m, nil
+}
+
+func (m wizardModel) viewAccess(p *wizPane) {
+	p.header("Identity and access")
+	p.blank()
+	p.text("This node's admin user is '" + paths.AdminUser +
+		"'. Every SSH login as " + paths.AdminUser +
+		" opens the node console.")
+	p.blank()
+
+	if len(m.keys) == 0 {
+		p.text("No SSH keys were found on this box.")
+	} else {
+		p.text("SSH keys found on this box (space toggles; " +
+			"confirmed keys are copied to " +
+			paths.AdminUser + "):")
+	}
+	p.blank()
+
+	for i, k := range m.keys {
+		mark := "[ ]"
+		if m.selected[i] {
+			mark = "[x]"
+		}
+		cur := "  "
+		if m.cursor == i {
+			cur = "> "
+		}
+		line := fmt.Sprintf("%s%s %s", cur, mark, k.Fingerprint)
+		sty := theme.Value
+		if m.cursor == i {
+			sty = theme.Action
+		}
+		p.line(" " + sty.Render(line))
+		detail := "      " + k.Type
+		if k.Comment != "" {
+			detail += " — " + k.Comment
+		}
+		detail += "  (" + m.keySourceNames(k.Fingerprint) + ")"
+		p.dim(detail)
+	}
+	for _, s := range m.sources {
+		if s.Excluded > 0 {
+			p.dim(fmt.Sprintf(
+				"   %d provider control line(s) in %s excluded"+
+					" — not copied", s.Excluded, s.Path))
+		}
+	}
+	if m.accErr != "" {
+		p.blank()
+		p.warn(m.accErr)
+	}
+	p.blank()
+	p.buttons([]string{"Continue", "Paste a key"},
+		m.btnIdx, m.cursor == len(m.keys))
+}
+
+// keySourceNames lists which enumerated files carried this
+// fingerprint (e.g. "root, debian").
+func (m wizardModel) keySourceNames(fingerprint string) string {
+	var names []string
+	for _, s := range m.sources {
+		for _, k := range s.Keys {
+			if k.Fingerprint == fingerprint {
+				names = append(names, s.User)
+				break
+			}
+		}
+	}
+	if len(names) == 0 {
+		return "pasted"
+	}
+	return strings.Join(names, ", ")
+}
+
+// ── Paste screen ─────────────────────────────────────────
+
+func (m wizardModel) updatePaste(
+	msg tea.KeyPressMsg,
+) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc", "escape":
+		m.phase = wzAccess
+		return m, nil
+	case "enter":
+		line := strings.TrimSpace(m.pasteInput.Value())
+		info, err := ParseSSHKey(line)
+		if err != nil {
+			m.pasteErr = "Not a valid public key line: " +
+				err.Error()
+			return m, nil
+		}
+		for i, k := range m.keys {
+			if k.Fingerprint == info.Fingerprint {
+				m.selected[i] = true
+				m.phase = wzAccess
+				return m, nil
+			}
+		}
+		m.keys = append(m.keys, info)
+		m.selected = append(m.selected, true)
+		m.phase = wzAccess
+		m.cursor = len(m.keys) - 1
+		return m, nil
+	default:
+		var cmd tea.Cmd
+		m.pasteInput, cmd = m.pasteInput.Update(tea.Msg(msg))
+		return m, cmd
+	}
+}
+
+func (m wizardModel) viewPaste(p *wizPane) {
+	p.header("Paste a public key")
+	p.blank()
+	p.text("Paste one authorized_keys line (type, key data, " +
+		"optional comment). It is validated before use.")
+	p.blank()
+	p.line(" " + m.pasteInput.View())
+	if m.pasteErr != "" {
+		p.blank()
+		p.warn(m.pasteErr)
+	}
+	p.blank()
+	p.dim("enter: add key    esc: back")
+}
+
+// ── Password screen ──────────────────────────────────────
+
+func (m wizardModel) updatePassword(
+	msg tea.KeyPressMsg,
+) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "up", "shift+tab":
+		if m.pwFocus > 0 {
+			m.pwFocus--
+			m.syncPwFocus()
+		}
+		return m, nil
+	case "down", "tab":
+		if m.pwFocus < 2 {
+			m.pwFocus++
+			m.syncPwFocus()
+		}
+		return m, nil
+	case "enter":
+		if m.pwFocus < 2 {
+			m.pwFocus++
+			m.syncPwFocus()
+			return m, nil
+		}
+		// Submit. Non-skippable by construction: the only
+		// button is Continue and it validates.
+		if m.pwInput.Value() != m.pwConfirm.Value() {
+			m.pwErr = "Passwords do not match."
+			return m, nil
+		}
+		pw, err := NewLoginPassword(m.pwInput.Value())
+		if err != nil {
+			m.pwErr = err.Error() + "."
+			return m, nil
+		}
+		m.dec.Password = pw
+		m.pwErr = ""
+		if m.needHardware {
+			m.phase = wzHardware
+			return m, nil
+		}
+		m.phase = wzSteps
+		return m, m.startSteps()
+	default:
+		var cmd tea.Cmd
+		switch m.pwFocus {
+		case 0:
+			m.pwInput, cmd = m.pwInput.Update(tea.Msg(msg))
+		case 1:
+			m.pwConfirm, cmd = m.pwConfirm.Update(tea.Msg(msg))
+		}
+		return m, cmd
+	}
+}
+
+func (m *wizardModel) syncPwFocus() {
+	m.pwInput.Blur()
+	m.pwConfirm.Blur()
+	switch m.pwFocus {
+	case 0:
+		m.pwInput.Focus()
+	case 1:
+		m.pwConfirm.Focus()
+	}
+}
+
+func (m wizardModel) viewPassword(p *wizPane) {
+	p.header("Login password")
+	p.blank()
+	// State-aware copy from the preflight observation (ruling
+	// xvi, vii refinement): say what this credential IS on this
+	// box — never assert what cannot be verified (ruling-xi
+	// discipline). The prompt is NON-SKIPPABLE: post-commit-7
+	// the admin user is the box's only interactive identity,
+	// and without a password a broken SSH setup leaves only
+	// rescue mode.
+	if m.dec.Obs.PasswordAuth {
+		p.text("Set the login password for '" +
+			paths.AdminUser + "'. Password login over SSH is " +
+			"currently enabled on this box, so this password " +
+			"works over the network; once you have verified " +
+			"key login, you can disable password auth from " +
+			"System → SSH Keys.")
+	} else {
+		p.text("Set the recovery password for '" +
+			paths.AdminUser + "'. Password login over SSH is " +
+			"disabled on this box, so this password works " +
+			"ONLY at your provider's console — it is the " +
+			"fallback when SSH is broken.")
+	}
+	p.blank()
+	p.text("Use a password manager: generate it, store it " +
+		"there first. Minimum " +
+		fmt.Sprintf("%d", MinLoginPasswordLen) + " characters.")
+	p.blank()
+
+	p.input("Password:", m.pwInput.View(), m.pwFocus == 0)
+	if n := len(m.pwInput.Value()); n > 0 {
+		p.dim(fmt.Sprintf("   (%d chars)", n))
+	}
+	p.input("Confirm: ", m.pwConfirm.View(), m.pwFocus == 1)
+	if n := len(m.pwConfirm.Value()); n > 0 {
+		p.dim(fmt.Sprintf("   (%d chars)", n))
+	}
+	if m.pwErr != "" {
+		p.blank()
+		p.warn(m.pwErr)
+	}
+	p.blank()
+	p.buttons([]string{"Continue"}, 0, m.pwFocus == 2)
+}
+
+// ── Hardware screen ──────────────────────────────────────
+
+func (m wizardModel) updateHardware(
+	msg tea.KeyPressMsg,
+) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "left":
+		if m.dbIdx > 0 {
+			m.dbIdx--
+		}
+	case "right":
+		if m.dbIdx < len(dbCacheChoices)-1 {
+			m.dbIdx++
+		}
+	case "enter":
+		m.dec.DbCacheMB = dbCacheChoices[m.dbIdx]
+		m.cfg.DbCache = m.dec.DbCacheMB
+		m.phase = wzSteps
+		return m, m.startSteps()
+	}
+	return m, nil
+}
+
+func fitMark(ok bool) string {
+	if ok {
+		return "ok"
+	}
+	return "below recommended"
+}
+
+func (m wizardModel) viewHardware(p *wizPane) {
+	p.header("Hardware fit")
+	p.blank()
+	p.text("Detected on this box (recommended: 2 CPU cores, " +
+		"4+ GB RAM, 90+ GB disk):")
+	p.blank()
+
+	ram := "unknown"
+	if m.hw.RAMMB > 0 {
+		ram = fmt.Sprintf("%.1f GB — %s",
+			float64(m.hw.RAMMB)/1024,
+			fitMark(m.hw.RAMMB >= requiredRAMMB))
+	}
+	disk := "unknown"
+	if m.hw.DiskTotalGB > 0 {
+		disk = fmt.Sprintf("%d GB total, %d GB free — %s",
+			m.hw.DiskTotalGB, m.hw.DiskFreeGB,
+			fitMark(m.hw.DiskTotalGB >= requiredDiskGB))
+	}
+	p.kv("Memory", ram)
+	p.kv("Disk", disk)
+	p.kv("CPU", fmt.Sprintf("%d cores — %s", m.hw.Cores,
+		fitMark(m.hw.Cores >= requiredCores)))
+	p.blank()
+
+	rec := RecommendDbCache(m.hw.RAMMB)
+	p.text("Bitcoin Core database cache (dbcache). Larger is " +
+		"faster for the initial sync; it must leave room for " +
+		"LND and Tor.")
+	p.blank()
+	choice := fmt.Sprintf("  ◂ %4d MB ▸", dbCacheChoices[m.dbIdx])
+	p.line(" " + theme.Action.Render(choice) + theme.Dim.Render(
+		fmt.Sprintf("   (recommended for this box: %d MB)", rec)))
+	p.blank()
+	p.buttons([]string{"Start install"}, 0, true)
+}
+
+// ── Steps phase ──────────────────────────────────────────
+
+func (m wizardModel) updateSteps(
+	msg wizardStepDoneMsg,
+) (tea.Model, tea.Cmd) {
+	m.stepsStarted = true
+	if msg.index >= len(m.steps) {
+		return m, nil
+	}
+	if msg.err != nil {
+		m.steps[msg.index].Status = StepFailed
+		m.steps[msg.index].Err = msg.err
+		m.failed = true
+		m.stepsDone = true
+		m.phase = wzDone
+		return m, nil
+	}
+	if msg.skipped {
+		m.steps[msg.index].Status = StepSkipped
+	} else {
+		m.steps[msg.index].Status = StepDone
+	}
+	next := msg.index + 1
+	if next < len(m.steps) {
+		m.current = next
+		m.steps[next].Status = StepRunning
+		return m, m.runStep(next)
+	}
+	m.stepsDone = true
+	m.phase = wzDone
+	return m, nil
+}
+
+// renderStepRows renders the step list in the ratified
+// dim/bright language. Shared shape with the post-install TUI's
+// step renderer: dim = believed-from-ledger, bright = this pass,
+// gates always bright (they always run).
+func renderStepRows(p *wizPane, steps []InstallStep) {
+	total := len(steps)
+	for i, s := range steps {
+		var sty lipgloss.Style
+		var ind string
+		switch s.Status {
+		case StepDone:
+			sty, ind = theme.Value, "[done]"
+		case StepRunning:
+			sty, ind = theme.Action, "[....]"
+		case StepFailed:
+			sty, ind = theme.Warning, "[FAIL]"
+		case StepSkipped:
+			// Believed-from-ledger: completed by an earlier
+			// pass, not executed now.
+			sty, ind = theme.Dim, "[skip]"
+		default:
+			sty, ind = theme.Grayed, "[wait]"
+		}
+		p.line(" " + sty.Render(fmt.Sprintf(
+			"%s [%2d/%d] %s", ind, i+1, total, s.Name)))
+		if s.Status == StepFailed && s.Err != nil {
+			p.warn("    Error: " + s.Err.Error())
+		}
+	}
+}
+
+func (m wizardModel) viewSteps(p *wizPane) {
+	p.header("Installing")
+	p.blank()
+	renderStepRows(p, m.steps)
+	p.blank()
+	p.dim("Installing... do not close the terminal. " +
+		"(ctrl+c interrupts; a re-run resumes)")
+}
+
+func (m wizardModel) viewDone(p *wizPane) {
+	if m.failed {
+		p.header("Install failed")
+		p.blank()
+		renderStepRows(p, m.steps)
+		p.blank()
+		p.warn("The install failed. Nothing needs undoing — " +
+			"fix the reported problem and run " +
+			"'sudo vpn install' again; it resumes from the " +
+			"first incomplete step.")
+		p.blank()
+		p.dim("ctrl+c: exit")
+		return
+	}
+	p.header("Install complete")
+	p.blank()
+	renderStepRows(p, m.steps)
+	p.blank()
+	p.text("Press Enter to open the node console as user '" +
+		paths.AdminUser + "' on this terminal.")
+	p.blank()
+	p.dim("First-run note: verify SSH access from a SECOND " +
+		"terminal before closing this one.")
+}
+
+// ── View plumbing ────────────────────────────────────────
+
+// wizPane is a minimal line collector in the welcome pane
+// idiom — chrome, not machinery (no ScreenContext).
+type wizPane struct {
+	width int
+	lines []string
+}
+
+func (p *wizPane) line(s string) { p.lines = append(p.lines, s) }
+func (p *wizPane) blank()        { p.line("") }
+func (p *wizPane) header(s string) {
+	p.line(" " + theme.Header.Render(s))
+}
+func (p *wizPane) dim(s string) {
+	for _, l := range wrapText(s, p.width-4) {
+		p.line(" " + theme.Dim.Render(l))
+	}
+}
+func (p *wizPane) warn(s string) {
+	for _, l := range wrapText(s, p.width-4) {
+		p.line(" " + theme.Warning.Render(l))
+	}
+}
+func (p *wizPane) text(s string) {
+	for _, l := range wrapText(s, p.width-4) {
+		p.line(" " + theme.Label.Render(l))
+	}
+}
+func (p *wizPane) kv(k, v string) {
+	p.line(" " + theme.Label.Render(fmt.Sprintf("  %-8s", k+":")) +
+		theme.Value.Render(" "+v))
+}
+func (p *wizPane) input(label, view string, focused bool) {
+	sty := theme.Label
+	if focused {
+		sty = theme.Action
+	}
+	p.line(" " + sty.Render("  "+label) + view)
+}
+func (p *wizPane) buttons(labels []string, idx int, focused bool) {
+	var parts []string
+	for i, l := range labels {
+		if i == idx && focused {
+			parts = append(parts, theme.BtnFocused.Render(l))
+		} else {
+			parts = append(parts, theme.BtnNormal.Render(l))
+		}
+	}
+	p.line(" " + strings.Join(parts, "  "))
+}
+
+func (m wizardModel) View() tea.View {
+	if m.width == 0 {
+		v := tea.NewView("Loading...")
+		v.AltScreen = true
+		return v
+	}
+	bw := min(m.width-4, theme.ContentWidth)
+	p := &wizPane{width: bw}
+
+	switch m.phase {
+	case wzAccess:
+		m.viewAccess(p)
+	case wzPaste:
+		m.viewPaste(p)
+	case wzPassword:
+		m.viewPassword(p)
+	case wzHardware:
+		m.viewHardware(p)
+	case wzSteps:
+		m.viewSteps(p)
+	case wzDone:
+		m.viewDone(p)
+	}
+
+	title := theme.Title.Render(
+		"Virtual Private Node — Install")
+	box := theme.Box.Width(bw).Render(
+		strings.Join(p.lines, "\n"))
+	full := lipgloss.JoinVertical(lipgloss.Center,
+		"", title, box)
+	content := lipgloss.Place(m.width, m.height,
+		lipgloss.Center, lipgloss.Center, full)
+	v := tea.NewView(content)
+	v.AltScreen = true
+	v.WindowTitle = "Virtual Private Node"
+	return v
+}
+
+// willRun reports whether the planner will execute the step with
+// the given key this pass (false = ledger-skip; true also when
+// the key is absent from the list, the conservative side for
+// screen-skipping).
+func (r *stepRunner) willRun(
+	steps []InstallStep, key string,
+) bool {
+	for i, s := range steps {
+		if s.Key == key {
+			return r.plan[i].Run
+		}
+	}
+	return true
+}
+
+// runInstallWizard drives the interactive install: wizard
+// screens, then the engine steps, reporting HOW the run ended via
+// RunResult (only RunComplete may reach the InstallComplete
+// write — IA-1-9).
+func runInstallWizard(
+	cfg *config.AppConfig, steps []InstallStep,
+	dec *InstallDecisions, version string,
+) (RunResult, error) {
+	runner, err := newStepRunner(
+		steps, version, paths.InstallStateFile)
+	if err != nil {
+		return RunResult{}, err
+	}
+	theme.Init(cfg.Theme != "light")
+	m := newWizardModel(cfg, steps, runner, dec, version)
+	p := tea.NewProgram(m)
+	result, err := p.Run()
+	if err != nil {
+		return RunResult{}, err
+	}
+	final := result.(wizardModel)
+	return classifyRun(final.steps,
+		final.stepsDone && !final.failed,
+		final.failed, final.current), nil
+}

--- a/internal/installer/wizard.go
+++ b/internal/installer/wizard.go
@@ -16,6 +16,18 @@ package installer
 // believed-from-ledger (a prior pass completed them — [skip]);
 // BRIGHT rows executed or verified THIS pass. Gates always
 // re-run, so gates are always bright.
+//
+// Navigation is buttons-over-keys (operator ruling at the
+// commit-6 live run): every screen that can go back has a Back
+// button; no esc bindings (esc is unmapped in the rest of the
+// TUI); each screen carries a dim hint line naming its keys.
+//
+// Completion is PERSISTED the moment the last step verifies —
+// before the done screen waits for Enter (live-run finding: the
+// old order left install_complete unwritten while the done
+// screen sat unattended; a dropped connection then meant a
+// complete install with no durable completion record until the
+// next re-run).
 
 import (
 	"fmt"
@@ -27,6 +39,7 @@ import (
 
 	"github.com/virtualprivatenode/vpn/internal/config"
 	"github.com/virtualprivatenode/vpn/internal/paths"
+	"github.com/virtualprivatenode/vpn/internal/system"
 	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
@@ -54,6 +67,13 @@ type wizardModel struct {
 	runner  *stepRunner
 	version string
 
+	// onComplete persists the completion record; runs once,
+	// as soon as the last step verifies (before the done
+	// screen). Its error renders on the done screen and fails
+	// the run.
+	onComplete  func() error
+	completeErr string
+
 	phase         wizardPhase
 	width, height int
 
@@ -70,31 +90,37 @@ type wizardModel struct {
 
 	// Paste screen
 	pasteInput textinput.Model
+	pasteFocus int // 0 = input, 1 = buttons
+	pasteBtn   int // 0 = Back, 1 = Add key
 	pasteErr   string
 
 	// Password screen
 	pwInput   textinput.Model
 	pwConfirm textinput.Model
-	pwFocus   int // 0 = new, 1 = confirm, 2 = button
+	pwFocus   int // 0 = new, 1 = confirm, 2 = buttons
+	pwBtn     int // 0 = Back, 1 = Continue
 	pwErr     string
 
 	// Hardware screen
-	hw    Hardware
-	dbIdx int
+	hw      Hardware
+	dbIdx   int
+	hwFocus int // 0 = dbcache selector, 1 = buttons
+	hwBtn   int // index into hwButtons()
 
 	// Steps
 	current           int
 	stepsDone, failed bool
-	stepsStarted      bool
 }
 
 func newWizardModel(
 	cfg *config.AppConfig, steps []InstallStep,
 	runner *stepRunner, dec *InstallDecisions, version string,
+	onComplete func() error,
 ) wizardModel {
 	m := wizardModel{
 		cfg: cfg, dec: dec, steps: steps,
 		runner: runner, version: version,
+		onComplete: onComplete,
 	}
 
 	// Resume-aware screen skipping: a screen exists to collect
@@ -158,14 +184,20 @@ func newWizardPasswordInput() textinput.Model {
 	return ti
 }
 
+// pasteFirstLine normalizes pasted text for a single-line
+// input: first line only, trimmed. Pure — unit-tested.
+func pasteFirstLine(content string) string {
+	if idx := strings.IndexByte(content, '\n'); idx >= 0 {
+		content = content[:idx]
+	}
+	return strings.TrimSpace(content)
+}
+
 // ── tea.Model ────────────────────────────────────────────
 
 func (m wizardModel) Init() tea.Cmd {
 	if m.phase == wzSteps {
 		return m.startSteps()
-	}
-	if m.phase == wzAccess {
-		return nil
 	}
 	return nil
 }
@@ -201,6 +233,12 @@ func (m wizardModel) Update(
 	case wizardStepDoneMsg:
 		return m.updateSteps(msg)
 
+	case tea.PasteMsg:
+		// Terminal paste — routed to the focused input (the
+		// live-run finding: keypress-only routing silently
+		// dropped pasted keys and passwords).
+		return m.handlePaste(msg)
+
 	case tea.KeyPressMsg:
 		// Quitting is allowed at any instant — an interrupt is
 		// SAFE (the ledger records a step only after it
@@ -220,10 +258,29 @@ func (m wizardModel) Update(
 		case wzHardware:
 			return m.updateHardware(msg)
 		case wzDone:
-			if msg.String() == "enter" && !m.failed {
+			if msg.String() == "enter" && !m.failed &&
+				m.completeErr == "" {
 				return m, tea.Quit
 			}
 		}
+	}
+	return m, nil
+}
+
+func (m wizardModel) handlePaste(
+	msg tea.PasteMsg,
+) (tea.Model, tea.Cmd) {
+	line := pasteFirstLine(msg.Content)
+	switch {
+	case m.phase == wzPaste && m.pasteFocus == 0:
+		m.pasteInput.SetValue(line)
+		m.pasteErr = ""
+	case m.phase == wzPassword && m.pwFocus == 0:
+		m.pwInput.SetValue(line)
+		m.pwErr = ""
+	case m.phase == wzPassword && m.pwFocus == 1:
+		m.pwConfirm.SetValue(line)
+		m.pwErr = ""
 	}
 	return m, nil
 }
@@ -235,7 +292,7 @@ func (m wizardModel) updateAccess(
 ) (tea.Model, tea.Cmd) {
 	last := len(m.keys) // index of the button row
 	switch msg.String() {
-	case "up":
+	case "up", "shift+tab":
 		if m.cursor > 0 {
 			m.cursor--
 		}
@@ -265,6 +322,8 @@ func (m wizardModel) updateAccess(
 		if m.btnIdx == 1 {
 			m.pasteErr = ""
 			m.pasteInput.SetValue("")
+			m.pasteFocus = 0
+			m.pasteBtn = 1
 			m.pasteInput.Focus()
 			m.phase = wzPaste
 			return m, nil
@@ -281,19 +340,25 @@ func (m wizardModel) updateAccess(
 		}
 		if len(chosen) == 0 && !m.dec.Obs.PasswordAuth {
 			m.accErr = "Password login is disabled on this " +
-				"box — select or paste at least one key, or " +
+				"box. Select or paste at least one key, or " +
 				"the " + paths.AdminUser +
 				" user would have no way in over SSH."
 			return m, nil
 		}
 		m.dec.Keys = chosen
-		m.pwFocus = 0
-		m.pwInput.Focus()
-		m.pwConfirm.Blur()
-		m.phase = wzPassword
+		m.enterPasswordScreen()
 		return m, nil
 	}
 	return m, nil
+}
+
+func (m *wizardModel) enterPasswordScreen() {
+	m.pwFocus = 0
+	m.pwBtn = 1
+	m.pwErr = ""
+	m.pwInput.Focus()
+	m.pwConfirm.Blur()
+	m.phase = wzPassword
 }
 
 func (m wizardModel) viewAccess(p *wizPane) {
@@ -307,9 +372,8 @@ func (m wizardModel) viewAccess(p *wizPane) {
 	if len(m.keys) == 0 {
 		p.text("No SSH keys were found on this box.")
 	} else {
-		p.text("SSH keys found on this box (space toggles; " +
-			"confirmed keys are copied to " +
-			paths.AdminUser + "):")
+		p.text("SSH keys found on this box. Confirmed keys " +
+			"are copied to " + paths.AdminUser + ":")
 	}
 	p.blank()
 
@@ -330,16 +394,16 @@ func (m wizardModel) viewAccess(p *wizPane) {
 		p.line(" " + sty.Render(line))
 		detail := "      " + k.Type
 		if k.Comment != "" {
-			detail += " — " + k.Comment
+			detail += " (" + k.Comment + ")"
 		}
-		detail += "  (" + m.keySourceNames(k.Fingerprint) + ")"
+		detail += "  [" + m.keySourceNames(k.Fingerprint) + "]"
 		p.dim(detail)
 	}
 	for _, s := range m.sources {
 		if s.Excluded > 0 {
 			p.dim(fmt.Sprintf(
-				"   %d provider control line(s) in %s excluded"+
-					" — not copied", s.Excluded, s.Path))
+				"   %d provider control line(s) in %s excluded,"+
+					" not copied", s.Excluded, s.Path))
 		}
 	}
 	if m.accErr != "" {
@@ -349,6 +413,9 @@ func (m wizardModel) viewAccess(p *wizPane) {
 	p.blank()
 	p.buttons([]string{"Continue", "Paste a key"},
 		m.btnIdx, m.cursor == len(m.keys))
+	p.blank()
+	p.hint("up/down: move   space: toggle key   " +
+		"left/right: choose button   enter: select")
 }
 
 // keySourceNames lists which enumerated files carried this
@@ -375,10 +442,35 @@ func (m wizardModel) updatePaste(
 	msg tea.KeyPressMsg,
 ) (tea.Model, tea.Cmd) {
 	switch msg.String() {
-	case "esc", "escape":
-		m.phase = wzAccess
+	case "up", "shift+tab":
+		if m.pasteFocus == 1 {
+			m.pasteFocus = 0
+			m.pasteInput.Focus()
+		}
 		return m, nil
+	case "down", "tab":
+		if m.pasteFocus == 0 {
+			m.pasteFocus = 1
+			m.pasteInput.Blur()
+		}
+		return m, nil
+	case "left":
+		if m.pasteFocus == 1 && m.pasteBtn > 0 {
+			m.pasteBtn--
+			return m, nil
+		}
+	case "right":
+		if m.pasteFocus == 1 && m.pasteBtn < 1 {
+			m.pasteBtn++
+			return m, nil
+		}
 	case "enter":
+		if m.pasteFocus == 1 && m.pasteBtn == 0 {
+			// Back — nothing kept.
+			m.phase = wzAccess
+			return m, nil
+		}
+		// Add key (from the button, or enter in the input).
 		line := strings.TrimSpace(m.pasteInput.Value())
 		info, err := ParseSSHKey(line)
 		if err != nil {
@@ -398,11 +490,13 @@ func (m wizardModel) updatePaste(
 		m.phase = wzAccess
 		m.cursor = len(m.keys) - 1
 		return m, nil
-	default:
+	}
+	if m.pasteFocus == 0 {
 		var cmd tea.Cmd
 		m.pasteInput, cmd = m.pasteInput.Update(tea.Msg(msg))
 		return m, cmd
 	}
+	return m, nil
 }
 
 func (m wizardModel) viewPaste(p *wizPane) {
@@ -417,7 +511,11 @@ func (m wizardModel) viewPaste(p *wizPane) {
 		p.warn(m.pasteErr)
 	}
 	p.blank()
-	p.dim("enter: add key    esc: back")
+	p.buttons([]string{"Back", "Add key"},
+		m.pasteBtn, m.pasteFocus == 1)
+	p.blank()
+	p.hint("up/down: input or buttons   " +
+		"left/right: choose button   enter: select")
 }
 
 // ── Password screen ──────────────────────────────────────
@@ -438,14 +536,29 @@ func (m wizardModel) updatePassword(
 			m.syncPwFocus()
 		}
 		return m, nil
+	case "left":
+		if m.pwFocus == 2 && m.pwBtn > 0 {
+			m.pwBtn--
+			return m, nil
+		}
+	case "right":
+		if m.pwFocus == 2 && m.pwBtn < 1 {
+			m.pwBtn++
+			return m, nil
+		}
 	case "enter":
 		if m.pwFocus < 2 {
 			m.pwFocus++
 			m.syncPwFocus()
 			return m, nil
 		}
-		// Submit. Non-skippable by construction: the only
-		// button is Continue and it validates.
+		if m.pwBtn == 0 {
+			// Back to the access screen (selections kept).
+			m.phase = wzAccess
+			return m, nil
+		}
+		// Continue. Non-skippable by construction: the only
+		// forward button validates.
 		if m.pwInput.Value() != m.pwConfirm.Value() {
 			m.pwErr = "Passwords do not match."
 			return m, nil
@@ -458,12 +571,15 @@ func (m wizardModel) updatePassword(
 		m.dec.Password = pw
 		m.pwErr = ""
 		if m.needHardware {
+			m.hwFocus = 1
+			m.hwBtn = len(m.hwButtons()) - 1
 			m.phase = wzHardware
 			return m, nil
 		}
 		m.phase = wzSteps
 		return m, m.startSteps()
-	default:
+	}
+	if m.pwFocus < 2 {
 		var cmd tea.Cmd
 		switch m.pwFocus {
 		case 0:
@@ -473,6 +589,7 @@ func (m wizardModel) updatePassword(
 		}
 		return m, cmd
 	}
+	return m, nil
 }
 
 func (m *wizardModel) syncPwFocus() {
@@ -491,7 +608,7 @@ func (m wizardModel) viewPassword(p *wizPane) {
 	p.blank()
 	// State-aware copy from the preflight observation (ruling
 	// xvi, vii refinement): say what this credential IS on this
-	// box — never assert what cannot be verified (ruling-xi
+	// box; never assert what cannot be verified (ruling-xi
 	// discipline). The prompt is NON-SKIPPABLE: post-commit-7
 	// the admin user is the box's only interactive identity,
 	// and without a password a broken SSH setup leaves only
@@ -502,13 +619,15 @@ func (m wizardModel) viewPassword(p *wizPane) {
 			"currently enabled on this box, so this password " +
 			"works over the network; once you have verified " +
 			"key login, you can disable password auth from " +
-			"System → SSH Keys.")
+			"System, SSH Keys.")
 	} else {
 		p.text("Set the recovery password for '" +
 			paths.AdminUser + "'. Password login over SSH is " +
 			"disabled on this box, so this password works " +
-			"ONLY at your provider's console — it is the " +
-			"fallback when SSH is broken.")
+			"ONLY at the machine's own login console: your " +
+			"provider's console page, or a keyboard on the " +
+			"box itself. It is the fallback when SSH is " +
+			"broken.")
 	}
 	p.blank()
 	p.text("Use a password manager: generate it, store it " +
@@ -529,24 +648,64 @@ func (m wizardModel) viewPassword(p *wizPane) {
 		p.warn(m.pwErr)
 	}
 	p.blank()
-	p.buttons([]string{"Continue"}, 0, m.pwFocus == 2)
+	p.buttons([]string{"Back", "Continue"},
+		m.pwBtn, m.pwFocus == 2)
+	p.blank()
+	p.hint("up/down: move   left/right: choose button   " +
+		"enter: select   paste works in both fields")
 }
 
 // ── Hardware screen ──────────────────────────────────────
 
+// hwButtons: Back only exists when the identity flow ran ahead
+// of this screen (otherwise this is the first screen and there
+// is nothing to go back to).
+func (m wizardModel) hwButtons() []string {
+	if m.needIdentity {
+		return []string{"Back", "Start install"}
+	}
+	return []string{"Start install"}
+}
+
 func (m wizardModel) updateHardware(
 	msg tea.KeyPressMsg,
 ) (tea.Model, tea.Cmd) {
+	btns := m.hwButtons()
 	switch msg.String() {
+	case "up", "shift+tab":
+		if m.hwFocus == 1 {
+			m.hwFocus = 0
+		}
+	case "down", "tab":
+		if m.hwFocus == 0 {
+			m.hwFocus = 1
+			m.hwBtn = len(btns) - 1
+		}
 	case "left":
-		if m.dbIdx > 0 {
+		if m.hwFocus == 0 && m.dbIdx > 0 {
 			m.dbIdx--
 		}
+		if m.hwFocus == 1 && m.hwBtn > 0 {
+			m.hwBtn--
+		}
 	case "right":
-		if m.dbIdx < len(dbCacheChoices)-1 {
+		if m.hwFocus == 0 && m.dbIdx < len(dbCacheChoices)-1 {
 			m.dbIdx++
 		}
+		if m.hwFocus == 1 && m.hwBtn < len(btns)-1 {
+			m.hwBtn++
+		}
 	case "enter":
+		if m.hwFocus == 0 {
+			m.hwFocus = 1
+			m.hwBtn = len(btns) - 1
+			return m, nil
+		}
+		if len(btns) == 2 && m.hwBtn == 0 {
+			// Back to the password screen.
+			m.enterPasswordScreen()
+			return m, nil
+		}
 		m.dec.DbCacheMB = dbCacheChoices[m.dbIdx]
 		m.cfg.DbCache = m.dec.DbCacheMB
 		m.phase = wzSteps
@@ -565,25 +724,27 @@ func fitMark(ok bool) string {
 func (m wizardModel) viewHardware(p *wizPane) {
 	p.header("Hardware fit")
 	p.blank()
-	p.text("Detected on this box (recommended: 2 CPU cores, " +
-		"4+ GB RAM, 90+ GB disk):")
+	p.text("What this box has, next to the recommended " +
+		"minimums for a node (2 CPU cores, 4+ GB RAM, " +
+		"90+ GB disk). Short of a minimum is a warning, " +
+		"not a refusal.")
 	p.blank()
 
 	ram := "unknown"
 	if m.hw.RAMMB > 0 {
-		ram = fmt.Sprintf("%.1f GB — %s",
+		ram = fmt.Sprintf("%.1f GB, %s",
 			float64(m.hw.RAMMB)/1024,
 			fitMark(m.hw.RAMMB >= requiredRAMMB))
 	}
 	disk := "unknown"
 	if m.hw.DiskTotalGB > 0 {
-		disk = fmt.Sprintf("%d GB total, %d GB free — %s",
+		disk = fmt.Sprintf("%d GB total, %d GB free, %s",
 			m.hw.DiskTotalGB, m.hw.DiskFreeGB,
 			fitMark(m.hw.DiskTotalGB >= requiredDiskGB))
 	}
-	p.kv("Memory", ram)
+	p.kv("Memory (RAM)", ram)
 	p.kv("Disk", disk)
-	p.kv("CPU", fmt.Sprintf("%d cores — %s", m.hw.Cores,
+	p.kv("CPU", fmt.Sprintf("%d cores, %s", m.hw.Cores,
 		fitMark(m.hw.Cores >= requiredCores)))
 	p.blank()
 
@@ -593,10 +754,17 @@ func (m wizardModel) viewHardware(p *wizPane) {
 		"LND and Tor.")
 	p.blank()
 	choice := fmt.Sprintf("  ◂ %4d MB ▸", dbCacheChoices[m.dbIdx])
-	p.line(" " + theme.Action.Render(choice) + theme.Dim.Render(
+	sty := theme.Value
+	if m.hwFocus == 0 {
+		sty = theme.Action
+	}
+	p.line(" " + sty.Render(choice) + theme.Dim.Render(
 		fmt.Sprintf("   (recommended for this box: %d MB)", rec)))
 	p.blank()
-	p.buttons([]string{"Start install"}, 0, true)
+	p.buttons(m.hwButtons(), m.hwBtn, m.hwFocus == 1)
+	p.blank()
+	p.hint("up/down: cache size or buttons   left/right: " +
+		"adjust or choose   enter: select")
 }
 
 // ── Steps phase ──────────────────────────────────────────
@@ -604,7 +772,6 @@ func (m wizardModel) viewHardware(p *wizPane) {
 func (m wizardModel) updateSteps(
 	msg wizardStepDoneMsg,
 ) (tea.Model, tea.Cmd) {
-	m.stepsStarted = true
 	if msg.index >= len(m.steps) {
 		return m, nil
 	}
@@ -627,7 +794,15 @@ func (m wizardModel) updateSteps(
 		m.steps[next].Status = StepRunning
 		return m, m.runStep(next)
 	}
+	// Last step verified — persist completion NOW, before the
+	// done screen waits for the operator (who may be away for
+	// minutes, or whose connection may drop).
 	m.stepsDone = true
+	if m.onComplete != nil {
+		if err := m.onComplete(); err != nil {
+			m.completeErr = err.Error()
+		}
+	}
 	m.phase = wzDone
 	return m, nil
 }
@@ -668,8 +843,17 @@ func (m wizardModel) viewSteps(p *wizPane) {
 	p.blank()
 	renderStepRows(p, m.steps)
 	p.blank()
-	p.dim("Installing... do not close the terminal. " +
+	p.hint("installing, do not close the terminal " +
 		"(ctrl+c interrupts; a re-run resumes)")
+}
+
+// sshTarget renders the everyday login command with the box's
+// address when it is known.
+func sshTarget() string {
+	if ip := system.PublicIPv4(); ip != "" {
+		return "ssh " + paths.AdminUser + "@" + ip
+	}
+	return "ssh " + paths.AdminUser + "@<your-server-ip>"
 }
 
 func (m wizardModel) viewDone(p *wizPane) {
@@ -678,23 +862,41 @@ func (m wizardModel) viewDone(p *wizPane) {
 		p.blank()
 		renderStepRows(p, m.steps)
 		p.blank()
-		p.warn("The install failed. Nothing needs undoing — " +
+		p.warn("The install failed. Nothing needs undoing: " +
 			"fix the reported problem and run " +
 			"'sudo vpn install' again; it resumes from the " +
 			"first incomplete step.")
 		p.blank()
-		p.dim("ctrl+c: exit")
+		p.hint("ctrl+c: exit")
+		return
+	}
+	if m.completeErr != "" {
+		p.header("Install steps complete, but not recorded")
+		p.blank()
+		p.warn("Every step finished, but writing the " +
+			"completion record failed: " + m.completeErr)
+		p.blank()
+		p.warn("Run 'sudo vpn install' again; it will skip " +
+			"all finished steps and retry the record.")
+		p.blank()
+		p.hint("ctrl+c: exit")
 		return
 	}
 	p.header("Install complete")
 	p.blank()
 	renderStepRows(p, m.steps)
 	p.blank()
-	p.text("Press Enter to open the node console as user '" +
-		paths.AdminUser + "' on this terminal.")
+	p.text("Your everyday way into the node, from any " +
+		"terminal:")
+	p.line(" " + theme.Action.Render("   "+sshTarget()))
 	p.blank()
-	p.dim("First-run note: verify SSH access from a SECOND " +
-		"terminal before closing this one.")
+	p.text("Press Enter to open the node console as user '" +
+		paths.AdminUser + "' on this terminal, or run the " +
+		"command above from a SECOND terminal first to " +
+		"verify your access.")
+	p.blank()
+	p.hint("enter: open the node console   ctrl+c: exit " +
+		"(the install is already recorded)")
 }
 
 // ── View plumbing ────────────────────────────────────────
@@ -716,6 +918,11 @@ func (p *wizPane) dim(s string) {
 		p.line(" " + theme.Dim.Render(l))
 	}
 }
+func (p *wizPane) hint(s string) {
+	for _, l := range wrapText(s, p.width-4) {
+		p.line(" " + theme.Grayed.Render(l))
+	}
+}
 func (p *wizPane) warn(s string) {
 	for _, l := range wrapText(s, p.width-4) {
 		p.line(" " + theme.Warning.Render(l))
@@ -727,7 +934,8 @@ func (p *wizPane) text(s string) {
 	}
 }
 func (p *wizPane) kv(k, v string) {
-	p.line(" " + theme.Label.Render(fmt.Sprintf("  %-8s", k+":")) +
+	p.line(" " + theme.Label.Render(
+		fmt.Sprintf("  %-14s", k+":")) +
 		theme.Value.Render(" "+v))
 }
 func (p *wizPane) input(label, view string, focused bool) {
@@ -805,10 +1013,13 @@ func (r *stepRunner) willRun(
 // runInstallWizard drives the interactive install: wizard
 // screens, then the engine steps, reporting HOW the run ended via
 // RunResult (only RunComplete may reach the InstallComplete
-// write — IA-1-9).
+// write — IA-1-9). onComplete is invoked exactly once, when the
+// last step verifies, BEFORE the done screen blocks on input; a
+// persist failure is surfaced as the run's error.
 func runInstallWizard(
 	cfg *config.AppConfig, steps []InstallStep,
 	dec *InstallDecisions, version string,
+	onComplete func() error,
 ) (RunResult, error) {
 	runner, err := newStepRunner(
 		steps, version, paths.InstallStateFile)
@@ -816,13 +1027,20 @@ func runInstallWizard(
 		return RunResult{}, err
 	}
 	theme.Init(cfg.Theme != "light")
-	m := newWizardModel(cfg, steps, runner, dec, version)
+	m := newWizardModel(cfg, steps, runner, dec, version,
+		onComplete)
 	p := tea.NewProgram(m)
 	result, err := p.Run()
 	if err != nil {
 		return RunResult{}, err
 	}
 	final := result.(wizardModel)
+	if final.completeErr != "" {
+		return RunResult{}, fmt.Errorf(
+			"install steps complete but the completion record "+
+				"failed: %s — run sudo vpn install again to retry",
+			final.completeErr)
+	}
 	return classifyRun(final.steps,
 		final.stepsDone && !final.failed,
 		final.failed, final.current), nil

--- a/internal/lndrpc/client.go
+++ b/internal/lndrpc/client.go
@@ -30,9 +30,9 @@ import (
 
 	"github.com/lightningnetwork/lnd/lnrpc"
 
-	"github.com/ripsline/virtual-private-node/internal/logger"
-	"github.com/ripsline/virtual-private-node/internal/paths"
-	"github.com/ripsline/virtual-private-node/internal/system"
+	"github.com/virtualprivatenode/vpn/internal/logger"
+	"github.com/virtualprivatenode/vpn/internal/paths"
+	"github.com/virtualprivatenode/vpn/internal/system"
 )
 
 // Client wraps an LND gRPC connection with macaroon authentication.

--- a/internal/lndrpc/payments.go
+++ b/internal/lndrpc/payments.go
@@ -8,7 +8,7 @@ import (
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/routerrpc"
 
-	"github.com/ripsline/virtual-private-node/internal/logger"
+	"github.com/virtualprivatenode/vpn/internal/logger"
 )
 
 // SendPaymentResult holds the outcome of a payment attempt.

--- a/internal/lndrpc/queries.go
+++ b/internal/lndrpc/queries.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/lightningnetwork/lnd/lnrpc"
-	"github.com/ripsline/virtual-private-node/internal/logger"
+	"github.com/virtualprivatenode/vpn/internal/logger"
 )
 
 const defaultTimeout = 30 * time.Second

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,8 +1,8 @@
 // internal/logger/logger.go
 
-// Package logger provides structured logging for the rlvpn application.
+// Package logger provides structured logging for the vpn application.
 //
-// Log file: /var/log/rlvpn.log (created during bootstrap, owned by ripsline)
+// Log file: /var/log/vpn.log (created by the installer; owned by the admin user)
 //
 // Log format:
 //
@@ -26,7 +26,7 @@ import (
 	"time"
 )
 
-const LogPath = "/var/log/rlvpn.log"
+const LogPath = "/var/log/vpn.log"
 
 var (
 	mu   sync.Mutex

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -1,6 +1,6 @@
 // internal/paths/paths.go
 
-// Package paths centralizes all filesystem paths used by rlvpn.
+// Package paths centralizes all filesystem paths used by vpn.
 // Every hardcoded path in the project should be defined here.
 package paths
 
@@ -9,8 +9,8 @@ import "fmt"
 // ── Configuration ────────────────────────────────────────
 
 const (
-	ConfigDir  = "/etc/rlvpn"
-	ConfigFile = "/etc/rlvpn/config.json"
+	ConfigDir  = "/etc/vpn"
+	ConfigFile = "/etc/vpn/config.json"
 
 	// InstallStateFile is the per-step install ledger: which
 	// install steps have completed, keyed by stable step key
@@ -18,7 +18,7 @@ const (
 	// so a config load failure cannot erase install history,
 	// and so its ownership flips to root with root-dispatched
 	// install without touching config's story.
-	InstallStateFile = "/etc/rlvpn/install-state.json"
+	InstallStateFile = "/etc/vpn/install-state.json"
 
 	BitcoinConf = "/etc/bitcoin/bitcoin.conf"
 	BitcoinDir  = "/etc/bitcoin"
@@ -87,7 +87,7 @@ const (
 // ── Logs ─────────────────────────────────────────────────
 
 const (
-	LogFile = "/var/log/rlvpn.log"
+	LogFile = "/var/log/vpn.log"
 )
 
 // ── System ───────────────────────────────────────────────
@@ -105,7 +105,22 @@ const (
 	// declares PasswordAuthentication yes on cloud
 	// images). sshd's first-match-wins semantics mean
 	// loading first = winning.
-	SSHDDropIn         = "/etc/ssh/sshd_config.d/00-rlvpn-hardening.conf"
+	SSHDDropIn = "/etc/ssh/sshd_config.d/00-vpn-hardening.conf"
+
+	// OldSSHDDropIn is the drop-in filename from before the
+	// rlvpn → vpn rename. On a migrated box the stale file
+	// would sort BEFORE SSHDDropIn (r < v) and win every
+	// contested directive under first-match-wins, so the
+	// install SSH step deletes it — the ONLY old-name
+	// artifact the installer removes (ruling xv: everything
+	// else old survives until the operator's verified
+	// teardown). Ordering is binding: observe → write new →
+	// delete old → validate → restart, because a
+	// TUI-disabled PasswordAuthentication lives in THIS
+	// file until the observed value is carried into the
+	// new one.
+	OldSSHDDropIn = "/etc/ssh/sshd_config.d/00-rlvpn-hardening.conf"
+
 	Fail2banJail       = "/etc/fail2ban/jail.local"
 	AutoUpgrades       = "/etc/apt/apt.conf.d/20auto-upgrades"
 	UnattendedUpgrades = "/etc/apt/apt.conf.d/50unattended-upgrades"
@@ -115,14 +130,30 @@ const (
 // ── User ─────────────────────────────────────────────────
 
 const (
-	AdminUser          = "ripsline"
-	AdminBashrc        = "/home/ripsline/.bashrc"
-	AuthorizedKeysFile = "/home/" + AdminUser + "/.ssh/authorized_keys"
+	// AdminUser is the node's admin login — same name as the
+	// binary, one name to know (ruling vi: clean break from
+	// the old ripsline user; migrated boxes retire the old
+	// user via MIGRATION.md's operator-run teardown, never
+	// via this binary).
+	AdminUser          = "vpn"
+	AdminHome          = "/home/" + AdminUser
+	AdminBashrc        = AdminHome + "/.bashrc"
+	AdminBashProfile   = AdminHome + "/.bash_profile"
+	AuthorizedKeysFile = AdminHome + "/.ssh/authorized_keys"
+
+	// AdminSudoers is the NOPASSWD rule the installer writes
+	// for the admin user. Commit 7 (root helper) deletes it —
+	// nothing replaces it (ruling iii: zero sudoers residue).
+	AdminSudoers = "/etc/sudoers.d/" + AdminUser
+
+	// BinaryPath is where the installer places the running
+	// binary (and where self-update installs new ones).
+	BinaryPath = "/usr/local/bin/vpn"
 )
 
 // ── Cache ────────────────────────────────────────────────
 
 const (
-	VersionCacheDir  = "/home/ripsline/.cache/rlvpn"
-	VersionCacheFile = "/home/ripsline/.cache/rlvpn/latest-version"
+	VersionCacheDir  = AdminHome + "/.cache/vpn"
+	VersionCacheFile = VersionCacheDir + "/latest-version"
 )

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -20,6 +20,17 @@ const (
 	// install without touching config's story.
 	InstallStateFile = "/etc/vpn/install-state.json"
 
+	// PasswordPendingMarker exists while an unattended install
+	// has applied a generated admin password that was never
+	// displayed (the identity step applies early; the print
+	// happens only at the end of a completed run — a failure in
+	// between would otherwise strand a credential nobody has
+	// seen). Written by the identity step on the unattended
+	// path; cleared when the password is finally printed, or
+	// when the operator sets a password of their own from the
+	// node console. Holds no secret — its presence is the fact.
+	PasswordPendingMarker = "/etc/vpn/password-pending"
+
 	BitcoinConf = "/etc/bitcoin/bitcoin.conf"
 	BitcoinDir  = "/etc/bitcoin"
 

--- a/internal/system/exec.go
+++ b/internal/system/exec.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ripsline/virtual-private-node/internal/logger"
+	"github.com/virtualprivatenode/vpn/internal/logger"
 )
 
 // Run executes a command and returns an error with output on failure.
@@ -23,10 +23,38 @@ func Run(name string, args ...string) error {
 	return nil
 }
 
-// SudoRun executes a command via sudo.
+// maybeSudo prepends sudo to a command line unless the process
+// already runs as root. `vpn install` runs under root dispatch
+// (commit 6), where a sudo prefix would be pointless AND would
+// make the install depend on sudo being installed before the
+// base-package step has run; the TUI runs as the unprivileged
+// admin user, where the sudo prefix is load-bearing (until the
+// commit-7 root helper replaces this seam entirely).
+func maybeSudo(name string, args []string) (string, []string) {
+	if os.Geteuid() == 0 {
+		return name, args
+	}
+	return "sudo", append([]string{name}, args...)
+}
+
+// SudoRun executes a command with root privilege: via sudo when
+// unprivileged, directly when already root.
 func SudoRun(name string, args ...string) error {
-	sudoArgs := append([]string{name}, args...)
-	return Run("sudo", sudoArgs...)
+	n, a := maybeSudo(name, args)
+	return Run(n, a...)
+}
+
+// SudoRunStdin executes a command with root privilege, feeding
+// stdin from the given string. The payload never appears in argv
+// (which would leak via /proc/*/cmdline). Returns trimmed
+// combined output alongside any error, for caller-side message
+// formatting.
+func SudoRunStdin(stdin, name string, args ...string) (string, error) {
+	n, a := maybeSudo(name, args)
+	cmd := exec.Command(n, a...)
+	cmd.Stdin = strings.NewReader(stdin)
+	out, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(out)), err
 }
 
 // RunOutput executes a command and returns stdout as a string.
@@ -40,10 +68,11 @@ func RunOutput(name string, args ...string) (string, error) {
 	return strings.TrimSpace(string(output)), nil
 }
 
-// SudoRunOutput executes a command via sudo and returns stdout.
+// SudoRunOutput executes a command with root privilege and
+// returns stdout.
 func SudoRunOutput(name string, args ...string) (string, error) {
-	sudoArgs := append([]string{name}, args...)
-	return RunOutput("sudo", sudoArgs...)
+	n, a := maybeSudo(name, args)
+	return RunOutput(n, a...)
 }
 
 // RunContext executes a command with a timeout.
@@ -59,10 +88,11 @@ func RunContext(timeout time.Duration, name string, args ...string) (string, err
 	return strings.TrimSpace(string(output)), nil
 }
 
-// SudoRunContext executes a command via sudo with a timeout.
+// SudoRunContext executes a command with root privilege and a
+// timeout.
 func SudoRunContext(timeout time.Duration, name string, args ...string) (string, error) {
-	sudoArgs := append([]string{name}, args...)
-	return RunContext(timeout, "sudo", sudoArgs...)
+	n, a := maybeSudo(name, args)
+	return RunContext(timeout, n, a...)
 }
 
 // RunCombinedOutput executes a command and returns combined stdout+stderr.
@@ -76,10 +106,11 @@ func RunCombinedOutput(name string, args ...string) (string, error) {
 	return strings.TrimSpace(string(output)), nil
 }
 
-// SudoRunCombinedOutput executes a command via sudo and returns combined stdout+stderr.
+// SudoRunCombinedOutput executes a command with root privilege
+// and returns combined stdout+stderr.
 func SudoRunCombinedOutput(name string, args ...string) (string, error) {
-	sudoArgs := append([]string{name}, args...)
-	return RunCombinedOutput("sudo", sudoArgs...)
+	n, a := maybeSudo(name, args)
+	return RunCombinedOutput(n, a...)
 }
 
 // RunSilent executes a command and discards all output.
@@ -90,19 +121,21 @@ func RunSilent(name string, args ...string) error {
 	return cmd.Run()
 }
 
-// SudoRunSilent executes a command via sudo and discards all output.
+// SudoRunSilent executes a command with root privilege and
+// discards all output.
 func SudoRunSilent(name string, args ...string) error {
-	sudoArgs := append([]string{name}, args...)
-	return RunSilent("sudo", sudoArgs...)
+	n, a := maybeSudo(name, args)
+	return RunSilent(n, a...)
 }
 
-// SudoWriteFile atomically writes content to a root-owned path via sudo:
+// SudoWriteFile atomically writes content to a root-owned path
+// (directly as root, via sudo otherwise):
 // stages in a dest-dir temp (install -m), then rename(2) onto the path, so the
 // canonical path only ever holds the final mode and a crash never leaves it
 // partial or world-readable. os.CreateTemp's O_EXCL guards the staging file
 // against symlink attacks. Write failures are logged centrally for support.
 func SudoWriteFile(path string, content []byte, perm os.FileMode) error {
-	tmpFile, err := os.CreateTemp("", "rlvpn-write-")
+	tmpFile, err := os.CreateTemp("", "vpn-write-")
 	if err != nil {
 		return fmt.Errorf("create temp file: %w", err)
 	}
@@ -178,10 +211,16 @@ func torWrapper() string {
 	return ""
 }
 
-// SudoReadFile reads a file that requires root/sudo access.
-// Uses os.CreateTemp for secure temp file creation.
+// SudoReadFile reads a file that requires root access. As root
+// it reads directly (the error preserves os.IsNotExist for
+// callers that treat a missing file as empty); unprivileged it
+// stages a copy via sudo. Uses os.CreateTemp for secure temp
+// file creation.
 func SudoReadFile(path string) ([]byte, error) {
-	tmpFile, err := os.CreateTemp("", "rlvpn-read-")
+	if os.Geteuid() == 0 {
+		return os.ReadFile(path)
+	}
+	tmpFile, err := os.CreateTemp("", "vpn-read-")
 	if err != nil {
 		return nil, fmt.Errorf("create temp file: %w", err)
 	}

--- a/internal/welcome/cmds.go
+++ b/internal/welcome/cmds.go
@@ -36,11 +36,11 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/ripsline/virtual-private-node/internal/config"
-	"github.com/ripsline/virtual-private-node/internal/installer"
-	"github.com/ripsline/virtual-private-node/internal/lndrpc"
-	"github.com/ripsline/virtual-private-node/internal/logger"
-	"github.com/ripsline/virtual-private-node/internal/system"
+	"github.com/virtualprivatenode/vpn/internal/config"
+	"github.com/virtualprivatenode/vpn/internal/installer"
+	"github.com/virtualprivatenode/vpn/internal/lndrpc"
+	"github.com/virtualprivatenode/vpn/internal/logger"
+	"github.com/virtualprivatenode/vpn/internal/system"
 )
 
 // ── Polling & version ────────────────────────────────────
@@ -393,7 +393,7 @@ func showMacaroonCmd(cfg *config.AppConfig) tea.Cmd {
 	if mac == "" {
 		return nil
 	}
-	tmpFile, err := os.CreateTemp("", "rlvpn-macaroon-")
+	tmpFile, err := os.CreateTemp("", "vpn-macaroon-")
 	if err != nil {
 		return nil
 	}
@@ -419,7 +419,7 @@ func showInvoiceCmd(invoice string) tea.Cmd {
 	if invoice == "" {
 		return nil
 	}
-	tmpFile, err := os.CreateTemp("", "rlvpn-invoice-")
+	tmpFile, err := os.CreateTemp("", "vpn-invoice-")
 	if err != nil {
 		return nil
 	}
@@ -486,7 +486,7 @@ func showNodeURIsCmd(uris []string) tea.Cmd {
 		}
 		b.WriteString("\n")
 	}
-	tmpFile, err := os.CreateTemp("", "rlvpn-nodeuris-")
+	tmpFile, err := os.CreateTemp("", "vpn-nodeuris-")
 	if err != nil {
 		return nil
 	}

--- a/internal/welcome/helpbar.go
+++ b/internal/welcome/helpbar.go
@@ -6,7 +6,7 @@ import (
 	"charm.land/bubbles/v2/key"
 	"charm.land/lipgloss/v2"
 
-	"github.com/ripsline/virtual-private-node/internal/theme"
+	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
 func (m Model) renderHelpBar(maxW int) string {

--- a/internal/welcome/helpers.go
+++ b/internal/welcome/helpers.go
@@ -10,12 +10,12 @@ import (
 
 	"charm.land/bubbles/v2/viewport"
 	"charm.land/lipgloss/v2"
-	"github.com/ripsline/virtual-private-node/internal/config"
-	"github.com/ripsline/virtual-private-node/internal/lndrpc"
-	"github.com/ripsline/virtual-private-node/internal/logger"
-	"github.com/ripsline/virtual-private-node/internal/paths"
-	"github.com/ripsline/virtual-private-node/internal/system"
-	"github.com/ripsline/virtual-private-node/internal/theme"
+	"github.com/virtualprivatenode/vpn/internal/config"
+	"github.com/virtualprivatenode/vpn/internal/lndrpc"
+	"github.com/virtualprivatenode/vpn/internal/logger"
+	"github.com/virtualprivatenode/vpn/internal/paths"
+	"github.com/virtualprivatenode/vpn/internal/system"
+	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
 func readOnion(path string) string {

--- a/internal/welcome/model.go
+++ b/internal/welcome/model.go
@@ -5,10 +5,10 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/ripsline/virtual-private-node/internal/config"
-	"github.com/ripsline/virtual-private-node/internal/lndrpc"
-	"github.com/ripsline/virtual-private-node/internal/logger"
-	"github.com/ripsline/virtual-private-node/internal/theme"
+	"github.com/virtualprivatenode/vpn/internal/config"
+	"github.com/virtualprivatenode/vpn/internal/lndrpc"
+	"github.com/virtualprivatenode/vpn/internal/logger"
+	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
 type wSubview int

--- a/internal/welcome/nav.go
+++ b/internal/welcome/nav.go
@@ -5,7 +5,7 @@ import (
 
 	"charm.land/lipgloss/v2"
 
-	"github.com/ripsline/virtual-private-node/internal/theme"
+	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
 // Section IDs — 5 parents + theme toggle

--- a/internal/welcome/pane_builder.go
+++ b/internal/welcome/pane_builder.go
@@ -5,7 +5,7 @@ import (
 
 	"charm.land/lipgloss/v2"
 
-	"github.com/ripsline/virtual-private-node/internal/theme"
+	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
 // paneBuilder constructs consistently-formatted content

--- a/internal/welcome/screen.go
+++ b/internal/welcome/screen.go
@@ -4,8 +4,8 @@ import (
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/ripsline/virtual-private-node/internal/config"
-	"github.com/ripsline/virtual-private-node/internal/lndrpc"
+	"github.com/virtualprivatenode/vpn/internal/config"
+	"github.com/virtualprivatenode/vpn/internal/lndrpc"
 )
 
 // ── Screen interface ────────────────────────────────────

--- a/internal/welcome/screen_addon_syncthing.go
+++ b/internal/welcome/screen_addon_syncthing.go
@@ -7,7 +7,7 @@ import (
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/ripsline/virtual-private-node/internal/theme"
+	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
 // ── SyncthingDetailScreen ──────────────────────────────

--- a/internal/welcome/screen_addon_syncthing_device.go
+++ b/internal/welcome/screen_addon_syncthing_device.go
@@ -4,8 +4,8 @@ import (
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/ripsline/virtual-private-node/internal/config"
-	"github.com/ripsline/virtual-private-node/internal/theme"
+	"github.com/virtualprivatenode/vpn/internal/config"
+	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
 // ── SyncthingDeviceScreen ──────────────────────────────

--- a/internal/welcome/screen_addon_syncthing_install.go
+++ b/internal/welcome/screen_addon_syncthing_install.go
@@ -4,9 +4,9 @@ import (
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/ripsline/virtual-private-node/internal/config"
-	"github.com/ripsline/virtual-private-node/internal/installer"
-	"github.com/ripsline/virtual-private-node/internal/theme"
+	"github.com/virtualprivatenode/vpn/internal/config"
+	"github.com/virtualprivatenode/vpn/internal/installer"
+	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
 // ── SyncthingInstallScreen ─────────────────────────────

--- a/internal/welcome/screen_addon_syncthing_pair.go
+++ b/internal/welcome/screen_addon_syncthing_pair.go
@@ -7,8 +7,8 @@ import (
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/ripsline/virtual-private-node/internal/installer"
-	"github.com/ripsline/virtual-private-node/internal/theme"
+	"github.com/virtualprivatenode/vpn/internal/installer"
+	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
 // ── SyncthingPairScreen steps ──────────────────────────

--- a/internal/welcome/screen_addon_syncthing_webui.go
+++ b/internal/welcome/screen_addon_syncthing_webui.go
@@ -4,8 +4,8 @@ import (
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/ripsline/virtual-private-node/internal/paths"
-	"github.com/ripsline/virtual-private-node/internal/theme"
+	"github.com/virtualprivatenode/vpn/internal/paths"
+	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
 // ── SyncthingWebUIScreen ───────────────────────────────

--- a/internal/welcome/screen_addons_home.go
+++ b/internal/welcome/screen_addons_home.go
@@ -7,7 +7,7 @@ import (
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/ripsline/virtual-private-node/internal/theme"
+	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
 // ── AddonsHomeScreen ──────────────────────────────────

--- a/internal/welcome/screen_channels_close.go
+++ b/internal/welcome/screen_channels_close.go
@@ -6,7 +6,7 @@ import (
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/ripsline/virtual-private-node/internal/theme"
+	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
 // ── Close screen steps ──────────────────────────────────

--- a/internal/welcome/screen_channels_detail.go
+++ b/internal/welcome/screen_channels_detail.go
@@ -7,7 +7,7 @@ import (
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/ripsline/virtual-private-node/internal/theme"
+	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
 // ── ChannelDetailScreen ────────────────────────────────

--- a/internal/welcome/screen_channels_history.go
+++ b/internal/welcome/screen_channels_history.go
@@ -7,8 +7,8 @@ import (
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/ripsline/virtual-private-node/internal/lndrpc"
-	"github.com/ripsline/virtual-private-node/internal/theme"
+	"github.com/virtualprivatenode/vpn/internal/lndrpc"
+	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
 // ── ChannelHistoryScreen ───────────────────────────────

--- a/internal/welcome/screen_channels_home.go
+++ b/internal/welcome/screen_channels_home.go
@@ -9,7 +9,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
-	"github.com/ripsline/virtual-private-node/internal/theme"
+	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
 // ── ChannelsHomeScreen ─────────────────────────────────

--- a/internal/welcome/screen_channels_node_info.go
+++ b/internal/welcome/screen_channels_node_info.go
@@ -7,7 +7,7 @@ import (
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/ripsline/virtual-private-node/internal/theme"
+	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
 // ── NodeInfoScreen ──────────────────────────────────────

--- a/internal/welcome/screen_channels_open.go
+++ b/internal/welcome/screen_channels_open.go
@@ -8,8 +8,8 @@ import (
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/ripsline/virtual-private-node/internal/lndrpc"
-	"github.com/ripsline/virtual-private-node/internal/theme"
+	"github.com/virtualprivatenode/vpn/internal/lndrpc"
+	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
 // ── Channel open screen steps ──────────────────────────

--- a/internal/welcome/screen_channels_open_confirm.go
+++ b/internal/welcome/screen_channels_open_confirm.go
@@ -5,7 +5,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/ripsline/virtual-private-node/internal/theme"
+	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
 // ── Confirm step ───────────────────────────────────────

--- a/internal/welcome/screen_channels_open_custom.go
+++ b/internal/welcome/screen_channels_open_custom.go
@@ -6,7 +6,7 @@ import (
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/ripsline/virtual-private-node/internal/theme"
+	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
 // ── Custom peer step ───────────────────────────────────

--- a/internal/welcome/screen_channels_open_utxos.go
+++ b/internal/welcome/screen_channels_open_utxos.go
@@ -8,8 +8,8 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
-	"github.com/ripsline/virtual-private-node/internal/lndrpc"
-	"github.com/ripsline/virtual-private-node/internal/theme"
+	"github.com/virtualprivatenode/vpn/internal/lndrpc"
+	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
 // ── UTXO + transaction fetch for channel open ─────────

--- a/internal/welcome/screen_install_progress.go
+++ b/internal/welcome/screen_install_progress.go
@@ -6,9 +6,9 @@ import (
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/ripsline/virtual-private-node/internal/installer"
-	"github.com/ripsline/virtual-private-node/internal/logger"
-	"github.com/ripsline/virtual-private-node/internal/theme"
+	"github.com/virtualprivatenode/vpn/internal/installer"
+	"github.com/virtualprivatenode/vpn/internal/logger"
+	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
 // ── InstallProgressScreen ──────────────────────────────

--- a/internal/welcome/screen_offchain_home.go
+++ b/internal/welcome/screen_offchain_home.go
@@ -8,8 +8,8 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
-	"github.com/ripsline/virtual-private-node/internal/lndrpc"
-	"github.com/ripsline/virtual-private-node/internal/theme"
+	"github.com/virtualprivatenode/vpn/internal/lndrpc"
+	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
 // ── WalletHomeScreen ──────────────────────────────────

--- a/internal/welcome/screen_offchain_pairing.go
+++ b/internal/welcome/screen_offchain_pairing.go
@@ -6,8 +6,8 @@ import (
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/ripsline/virtual-private-node/internal/paths"
-	"github.com/ripsline/virtual-private-node/internal/theme"
+	"github.com/virtualprivatenode/vpn/internal/paths"
+	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
 // ── PairingScreen ──────────────────────────────────────

--- a/internal/welcome/screen_offchain_receive.go
+++ b/internal/welcome/screen_offchain_receive.go
@@ -8,7 +8,7 @@ import (
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/ripsline/virtual-private-node/internal/theme"
+	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
 // ── Receive screen steps ────────────────────────────────

--- a/internal/welcome/screen_offchain_send.go
+++ b/internal/welcome/screen_offchain_send.go
@@ -7,8 +7,8 @@ import (
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/ripsline/virtual-private-node/internal/lndrpc"
-	"github.com/ripsline/virtual-private-node/internal/theme"
+	"github.com/virtualprivatenode/vpn/internal/lndrpc"
+	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
 // ── Send screen steps ────────────────────────────────────

--- a/internal/welcome/screen_offchain_tx.go
+++ b/internal/welcome/screen_offchain_tx.go
@@ -4,8 +4,8 @@ import (
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/ripsline/virtual-private-node/internal/lndrpc"
-	"github.com/ripsline/virtual-private-node/internal/theme"
+	"github.com/virtualprivatenode/vpn/internal/lndrpc"
+	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
 // ── PaymentDetailScreen ────────────────────────────────

--- a/internal/welcome/screen_onchain_home.go
+++ b/internal/welcome/screen_onchain_home.go
@@ -9,8 +9,8 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
-	"github.com/ripsline/virtual-private-node/internal/lndrpc"
-	"github.com/ripsline/virtual-private-node/internal/theme"
+	"github.com/virtualprivatenode/vpn/internal/lndrpc"
+	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
 // ── OnChainHomeScreen ─────────────────────────────────

--- a/internal/welcome/screen_onchain_receive.go
+++ b/internal/welcome/screen_onchain_receive.go
@@ -4,7 +4,7 @@ import (
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/ripsline/virtual-private-node/internal/theme"
+	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
 // ── OCReceiveScreen ────────────────────────────────────

--- a/internal/welcome/screen_onchain_send.go
+++ b/internal/welcome/screen_onchain_send.go
@@ -11,8 +11,8 @@ import (
 	"charm.land/lipgloss/v2"
 	"charm.land/lipgloss/v2/tree"
 
-	"github.com/ripsline/virtual-private-node/internal/lndrpc"
-	"github.com/ripsline/virtual-private-node/internal/theme"
+	"github.com/virtualprivatenode/vpn/internal/lndrpc"
+	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
 // ── On-chain send screen steps ──────────────────────────

--- a/internal/welcome/screen_onchain_tx.go
+++ b/internal/welcome/screen_onchain_tx.go
@@ -6,8 +6,8 @@ import (
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/ripsline/virtual-private-node/internal/lndrpc"
-	"github.com/ripsline/virtual-private-node/internal/theme"
+	"github.com/virtualprivatenode/vpn/internal/lndrpc"
+	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
 // ── OnChainTxScreen ────────────────────────────────────

--- a/internal/welcome/screen_onchain_utxo.go
+++ b/internal/welcome/screen_onchain_utxo.go
@@ -6,8 +6,8 @@ import (
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/ripsline/virtual-private-node/internal/lndrpc"
-	"github.com/ripsline/virtual-private-node/internal/theme"
+	"github.com/virtualprivatenode/vpn/internal/lndrpc"
+	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
 // ── UtxoDetailScreen ───────────────────────────────────

--- a/internal/welcome/screen_system_auto_unlock.go
+++ b/internal/welcome/screen_system_auto_unlock.go
@@ -8,9 +8,9 @@ import (
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/ripsline/virtual-private-node/internal/config"
-	"github.com/ripsline/virtual-private-node/internal/installer"
-	"github.com/ripsline/virtual-private-node/internal/theme"
+	"github.com/virtualprivatenode/vpn/internal/config"
+	"github.com/virtualprivatenode/vpn/internal/installer"
+	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
 // ── AutoUnlockScreen ──────────────────────────────────

--- a/internal/welcome/screen_system_change_password.go
+++ b/internal/welcome/screen_system_change_password.go
@@ -46,9 +46,15 @@ func setUserPasswordCmd(
 	username string, newPassword installer.LoginPassword,
 ) tea.Cmd {
 	return func() tea.Msg {
-		return changePwDoneMsg{
-			err: installer.SetUserPassword(
-				username, newPassword)}
+		err := installer.SetUserPassword(
+			username, newPassword)
+		if err == nil {
+			// The operator now holds a password they chose, so
+			// any record of a never-displayed generated password
+			// is obsolete (see installer/passwordpending.go).
+			installer.ClearPasswordPendingMarker()
+		}
+		return changePwDoneMsg{err: err}
 	}
 }
 

--- a/internal/welcome/screen_system_change_password.go
+++ b/internal/welcome/screen_system_change_password.go
@@ -1,6 +1,7 @@
 package welcome
 
 import (
+	"fmt"
 	"os/user"
 	"strconv"
 	"strings"
@@ -9,8 +10,8 @@ import (
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/ripsline/virtual-private-node/internal/installer"
-	"github.com/ripsline/virtual-private-node/internal/theme"
+	"github.com/virtualprivatenode/vpn/internal/installer"
+	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
 // ── ChangePasswordScreen ───────────────────────────────
@@ -21,7 +22,7 @@ import (
 // Targets the current real user (os/user.Current()), not
 // a hardcoded username — this matches the "change MY
 // password" expectation and avoids assuming the codebase
-// always runs as ripsline. Refuses to operate if running
+// always runs as the admin user (vpn). Refuses to operate if running
 // as root (uid 0) so we never accidentally rewrite root's
 // password from a misconfigured launch.
 
@@ -393,8 +394,19 @@ func (s *ChangePasswordScreen) viewInput(w, h int) string {
 	confFocused := isFocused &&
 		s.focusZone == changePwZoneInputConfirm
 
+	// Live character count on both masked inputs (ruling xii:
+	// IA-3-U accepted — paste-overrun recovery outweighs the
+	// length leak; same treatment as auto_unlock's inputs).
 	p.input("New Password:", s.newInput.View(), newFocused)
+	if len(s.newInput.Value()) > 0 {
+		p.dim(fmt.Sprintf("(%d chars)",
+			len(s.newInput.Value())))
+	}
 	p.input("Confirm:     ", s.confInput.View(), confFocused)
+	if len(s.confInput.Value()) > 0 {
+		p.dim(fmt.Sprintf("(%d chars)",
+			len(s.confInput.Value())))
+	}
 
 	p.appendError(s.inputErr)
 

--- a/internal/welcome/screen_system_home.go
+++ b/internal/welcome/screen_system_home.go
@@ -9,9 +9,9 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
-	"github.com/ripsline/virtual-private-node/internal/bitcoin"
-	"github.com/ripsline/virtual-private-node/internal/installer"
-	"github.com/ripsline/virtual-private-node/internal/theme"
+	"github.com/virtualprivatenode/vpn/internal/bitcoin"
+	"github.com/virtualprivatenode/vpn/internal/installer"
+	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
 // ── SystemHomeScreen ──────────────────────────────────

--- a/internal/welcome/screen_system_p2p_upgrade.go
+++ b/internal/welcome/screen_system_p2p_upgrade.go
@@ -7,10 +7,10 @@ import (
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/ripsline/virtual-private-node/internal/config"
-	"github.com/ripsline/virtual-private-node/internal/installer"
-	"github.com/ripsline/virtual-private-node/internal/system"
-	"github.com/ripsline/virtual-private-node/internal/theme"
+	"github.com/virtualprivatenode/vpn/internal/config"
+	"github.com/virtualprivatenode/vpn/internal/installer"
+	"github.com/virtualprivatenode/vpn/internal/system"
+	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
 // ── P2PUpgradeScreen ──────────────────────────────────

--- a/internal/welcome/screen_system_self_update.go
+++ b/internal/welcome/screen_system_self_update.go
@@ -4,8 +4,8 @@ import (
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/ripsline/virtual-private-node/internal/installer"
-	"github.com/ripsline/virtual-private-node/internal/theme"
+	"github.com/virtualprivatenode/vpn/internal/installer"
+	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
 // ── SelfUpdateScreen ──────────────────────────────────

--- a/internal/welcome/screen_system_ssh_key_add.go
+++ b/internal/welcome/screen_system_ssh_key_add.go
@@ -7,8 +7,8 @@ import (
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/ripsline/virtual-private-node/internal/installer"
-	"github.com/ripsline/virtual-private-node/internal/theme"
+	"github.com/virtualprivatenode/vpn/internal/installer"
+	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
 // ── SSHKeyAddScreen ────────────────────────────────────
@@ -260,7 +260,7 @@ func (s *SSHKeyAddScreen) viewInput(w, h int) string {
 	p.blank()
 	p.dim("On your local machine, run in Terminal:")
 	p.blank()
-	p.mono("ssh-keygen -t ed25519 -f ~/.ssh/virtual-private-node-key -C rlvpn")
+	p.mono("ssh-keygen -t ed25519 -f ~/.ssh/virtual-private-node-key -C vpn")
 	p.blank()
 	p.dim("Generate a passphrase with a password")
 	p.dim("manager. You will enter it twice.")

--- a/internal/welcome/screen_system_ssh_key_detail.go
+++ b/internal/welcome/screen_system_ssh_key_detail.go
@@ -4,8 +4,8 @@ import (
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/ripsline/virtual-private-node/internal/installer"
-	"github.com/ripsline/virtual-private-node/internal/theme"
+	"github.com/virtualprivatenode/vpn/internal/installer"
+	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
 // ── SSHKeyDetailScreen ─────────────────────────────────

--- a/internal/welcome/screen_system_ssh_keys.go
+++ b/internal/welcome/screen_system_ssh_keys.go
@@ -7,8 +7,8 @@ import (
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/ripsline/virtual-private-node/internal/installer"
-	"github.com/ripsline/virtual-private-node/internal/theme"
+	"github.com/virtualprivatenode/vpn/internal/installer"
+	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
 // ── SSHKeysScreen ──────────────────────────────────────

--- a/internal/welcome/screen_system_ssh_password_auth.go
+++ b/internal/welcome/screen_system_ssh_password_auth.go
@@ -4,8 +4,8 @@ import (
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/ripsline/virtual-private-node/internal/installer"
-	"github.com/ripsline/virtual-private-node/internal/theme"
+	"github.com/virtualprivatenode/vpn/internal/installer"
+	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
 // ── SSHPasswordAuthScreen ──────────────────────────────

--- a/internal/welcome/screen_system_wallet_create.go
+++ b/internal/welcome/screen_system_wallet_create.go
@@ -7,8 +7,8 @@ import (
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/ripsline/virtual-private-node/internal/installer"
-	"github.com/ripsline/virtual-private-node/internal/theme"
+	"github.com/virtualprivatenode/vpn/internal/installer"
+	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
 // ── WalletCreateScreen ──────────────────────────────────

--- a/internal/welcome/status.go
+++ b/internal/welcome/status.go
@@ -4,11 +4,11 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/ripsline/virtual-private-node/internal/bitcoin"
-	"github.com/ripsline/virtual-private-node/internal/config"
-	"github.com/ripsline/virtual-private-node/internal/lndrpc"
-	"github.com/ripsline/virtual-private-node/internal/paths"
-	"github.com/ripsline/virtual-private-node/internal/system"
+	"github.com/virtualprivatenode/vpn/internal/bitcoin"
+	"github.com/virtualprivatenode/vpn/internal/config"
+	"github.com/virtualprivatenode/vpn/internal/lndrpc"
+	"github.com/virtualprivatenode/vpn/internal/paths"
+	"github.com/virtualprivatenode/vpn/internal/system"
 
 	tea "charm.land/bubbletea/v2"
 )

--- a/internal/welcome/update.go
+++ b/internal/welcome/update.go
@@ -5,9 +5,30 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/ripsline/virtual-private-node/internal/lndrpc"
-	"github.com/ripsline/virtual-private-node/internal/theme"
+	"github.com/virtualprivatenode/vpn/internal/installer"
+	"github.com/virtualprivatenode/vpn/internal/lndrpc"
+	"github.com/virtualprivatenode/vpn/internal/theme"
 )
+
+// ── First-run verification banner (ruling xvi) ───────────
+//
+// While cfg.KeyVerificationPending is set, the layout shows a
+// banner asking the operator to verify SSH access from a SECOND
+// terminal. It clears only on journal evidence of a real sshd
+// login for the admin user — the in-session handoff console is
+// deliberately not evidence. The check rides the status tick and
+// costs one privileged journal read per poll while pending.
+
+type adminLoginVerifiedMsg struct{}
+
+func checkAdminLoginCmd() tea.Cmd {
+	return func() tea.Msg {
+		if installer.AdminLoginObserved() {
+			return adminLoginVerifiedMsg{}
+		}
+		return nil
+	}
+}
 
 // ── Focus helpers ────────────────────────────────────────
 
@@ -490,14 +511,25 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Tab not found (shouldn't happen, but be
 		// defensive). Just refresh status.
 		return m, fetchStatus(m.cfg, m.lndClient)
+	case adminLoginVerifiedMsg:
+		if m.cfg.KeyVerificationPending {
+			m.cfg.KeyVerificationPending = false
+			m.saveCfg()
+		}
+		return m, nil
 	case tickMsg:
 		if m.fetchInFlight {
 			return m, tickEveryCmd(m.pollInterval())
 		}
 		m.fetchInFlight = true
-		return m, tea.Batch(
+		cmds := []tea.Cmd{
 			fetchStatus(m.cfg, m.lndClient),
-			tickEveryCmd(m.pollInterval()))
+			tickEveryCmd(m.pollInterval()),
+		}
+		if m.cfg.KeyVerificationPending {
+			cmds = append(cmds, checkAdminLoginCmd())
+		}
+		return m, tea.Batch(cmds...)
 	}
 	return m, nil
 }

--- a/internal/welcome/view_layout.go
+++ b/internal/welcome/view_layout.go
@@ -7,7 +7,9 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
-	"github.com/ripsline/virtual-private-node/internal/theme"
+	"github.com/virtualprivatenode/vpn/internal/paths"
+	"github.com/virtualprivatenode/vpn/internal/system"
+	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
 func (m Model) View() tea.View {
@@ -198,12 +200,32 @@ func (m Model) viewMain() string {
 	helpLine := centerInWidth(helpStr, totalW)
 
 	fullContent := frame + "\n" + helpLine
+	// First-run verification banner (ruling xvi): shown until
+	// the journal proves a real sshd login for the admin user.
+	if m.cfg.KeyVerificationPending {
+		fullContent = centerInWidth(
+			m.renderVerifyBanner(), totalW) +
+			"\n" + fullContent
+	}
 
 	return lipgloss.Place(
 		m.width, m.height,
 		lipgloss.Center, lipgloss.Center,
 		fullContent,
 	)
+}
+
+// renderVerifyBanner is the first-run access-verification
+// banner line. Copy is deliberately imperative and small: it
+// nags, it never blocks.
+func (m Model) renderVerifyBanner() string {
+	target := "ssh " + paths.AdminUser + "@<server-ip>"
+	if ip := system.PublicIPv4(); ip != "" {
+		target = "ssh " + paths.AdminUser + "@" + ip
+	}
+	return theme.Warning.Render("⚠ Key verification pending") +
+		theme.Dim.Render(
+			" — connect from a second terminal: "+target)
 }
 
 func (m Model) hasDetailTabs() bool {

--- a/internal/welcome/view_overlays.go
+++ b/internal/welcome/view_overlays.go
@@ -9,7 +9,7 @@ import (
 	"charm.land/lipgloss/v2"
 	qrterminal "github.com/mdp/qrterminal/v3"
 
-	"github.com/ripsline/virtual-private-node/internal/theme"
+	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
 // ── Fullscreen overlays ────────────────────────────────


### PR DESCRIPTION
What changed

The project has a new name. The binary is now vpn, the admin user is vpn, settings live in /etc/vpn, the log is /var/log/vpn.log, and the repository moved to github.com/virtualprivatenode/vpn. Installing is now a command of the signed binary itself: sudo vpn install. The bootstrap script is no longer part of the install path and will be removed in an upcoming release. MIGRATION.md in this repository walks existing nodes through the one time upgrade; wallets, channels, chain data and onion addresses are untouched by it.

The installer now asks before it acts. It shows every SSH key it finds on the machine, with fingerprints and comments, and copies only what you confirm; provider control lines are recognized and excluded rather than copied. It always asks for a login password of at least 16 characters as the console fallback, and it says plainly what that password is on your machine: a network login where password login is enabled, a console only recovery credential where it is not. It measures memory, disk and processor and recommends a database cache size for Bitcoin Core, which you confirm. An unattended flag runs the whole install without prompts for automated setups.

How it works

Running vpn with no arguments opens the node console; running sudo vpn install installs. Nothing is decided by probing machine state. The installer checks its environment first and refuses, with a full report, before changing anything. It also reads the running SSH daemon configuration before touching it: the firewall allows exactly the ports the daemon listens on, and the SSH hardening file it writes states the password login setting the machine already had, explicitly, so installing never silently changes how you log in. On migrated machines the stale hardening file from the old name is removed in a fixed order: read the current state, write the new file, remove the old one, validate the merged configuration, then restart the daemon. The firewall comes up immediately after the first package installation, before the long base upgrade, so the machine spends that window behind a default deny policy. When everything has finished, the installer opens the node console on the same terminal as the vpn user, and the console shows a reminder to verify SSH access from a second terminal; the reminder clears itself once a real login is observed.

Why it is safe

The install can be interrupted at any moment and rerun; it continues from the first incomplete step and verifies Tor routing again on every pass, and a failed or interrupted run is never recorded as complete. The Tor check watches progress rather than a clock: it keeps waiting while bootstrap is advancing and gives up only after ninety seconds without movement, or ten minutes in all. If an unattended install fails after applying its generated password but before showing it, the machine remembers that nobody has seen a working password yet, and the run that finishes the install applies and prints a fresh one; a rerun after a completed install never changes or reprints anything. On an existing node being migrated, the installer treats a carried over settings file as your previous answers and never overwrites them, and it removes nothing that belongs to the old installation except that one stale SSH hardening file, so the old login keeps working until you remove it yourself after verifying the new one. Every download is still verified against pinned signing keys before install, with any bad signature a hard stop. And if the node console cannot read its settings file, it now says so and stops, instead of silently substituting defaults that could mislabel the network and rewrite your answers on the next save.