### PR TITLE
feature: a root helper replaces passwordless sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ For the full setup guide, see
 
 ### Security
 
-- TUI runs as the unprivileged `vpn` admin user (passwordless sudo for system operations — scheduled for removal in favor of a root helper)
+- TUI runs as the unprivileged `vpn` admin user, which has **no sudo rights at all**. Privileged operations (service control, updates, config changes) go through a socket-activated root helper that serves a fixed menu of typed operations — no arbitrary commands, no arbitrary file reads — verifies the identity of every connecting process, and logs every operation to the system journal, which the admin user can read but not rewrite
 - All connections through Tor (SOCKS5 port 9050)
 - IPv6 disabled to prevent Tor bypass
 - Stream isolation (separate circuit per connection)
@@ -340,6 +340,7 @@ For manual binary verification before installation, see
 | /etc/lnd/lnd.conf | LND configuration |
 | /etc/syncthing/ | Syncthing configuration |
 | /etc/vpn/config.json | Install state and credentials |
+| /var/lib/vpn/state/ | Node facts staged for the console (onion addresses, staged credentials) |
 | /var/lib/bitcoin/ | Blockchain data |
 | /var/lib/lnd/ | LND data and wallet |
 | /var/lib/syncthing/lnd-backup/ | Auto-synced channel.backup |

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/virtualprivatenode/vpn/internal/config"
+	"github.com/virtualprivatenode/vpn/internal/helperd"
 	"github.com/virtualprivatenode/vpn/internal/installer"
 	"github.com/virtualprivatenode/vpn/internal/paths"
 	"github.com/virtualprivatenode/vpn/internal/welcome"
@@ -31,6 +32,15 @@ func main() {
 	case cmdInstall:
 		if err := installer.RunInstall(opts); err != nil {
 			fmt.Fprintf(os.Stderr, "\n  Failed: %v\n", err)
+			os.Exit(1)
+		}
+	case cmdHelperd:
+		// The root helper. Started by systemd when traffic
+		// arrives on its socket — never by hand; it verifies
+		// both conditions itself and explains if they don't
+		// hold.
+		if err := helperd.Serve(version); err != nil {
+			fmt.Fprintf(os.Stderr, "vpn helperd: %v\n", err)
 			os.Exit(1)
 		}
 	case cmdVersion:
@@ -83,6 +93,7 @@ type command int
 const (
 	cmdConsole command = iota
 	cmdInstall
+	cmdHelperd
 	cmdVersion
 	cmdHelp
 )
@@ -106,12 +117,20 @@ func parseArgs(
 				opts.Unattended = true
 			case "--until=bake":
 				opts.UntilBake = true
+			case "--allow-console-only":
+				opts.AllowConsoleOnly = true
 			default:
 				return 0, opts, fmt.Errorf(
 					"unknown install flag %q", a)
 			}
 		}
 		return cmdInstall, opts, nil
+	case "helperd":
+		if len(args) > 1 {
+			return 0, opts, fmt.Errorf(
+				"helperd takes no arguments")
+		}
+		return cmdHelperd, opts, nil
 	case "version", "--version", "-v":
 		return cmdVersion, opts, nil
 	case "help", "--help", "-h":
@@ -131,6 +150,12 @@ Usage:
       --testnet4     use testnet4 instead of mainnet
       --unattended   no prompts (keys auto-copied from the box,
                      login password generated and printed once)
+      --allow-console-only
+                     let an unattended install finish even when
+                     it would leave no SSH way in (no keys found
+                     and password login disabled)
+  vpn helperd        the node's root helper (started by systemd
+                     through its socket, not by hand)
   vpn version        print the version
 `
 }

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -42,4 +42,20 @@ func TestParseArgs(t *testing.T) {
 			t.Errorf("%s: got (%v,%v), want version", v, cmd, err)
 		}
 	}
+
+	cmd, opts, err = parseArgs([]string{
+		"install", "--unattended", "--allow-console-only"})
+	if err != nil || cmd != cmdInstall || !opts.AllowConsoleOnly {
+		t.Errorf("allow-console-only: got (%v,%+v,%v)",
+			cmd, opts, err)
+	}
+
+	cmd, _, err = parseArgs([]string{"helperd"})
+	if err != nil || cmd != cmdHelperd {
+		t.Errorf("helperd: got (%v,%v)", cmd, err)
+	}
+	if _, _, err := parseArgs(
+		[]string{"helperd", "--flag"}); err == nil {
+		t.Error("helperd with arguments accepted")
+	}
 }

--- a/internal/bitcoin/client.go
+++ b/internal/bitcoin/client.go
@@ -1,15 +1,32 @@
 // internal/bitcoin/client.go
 
+// Package bitcoin talks to the local bitcoind over its JSON-RPC
+// interface, authenticating with the node's own staged RPC
+// credential (see internal/installer/rpcauth.go). Plain HTTP to
+// 127.0.0.1 with basic auth — bitcoind's RPC is loopback-only
+// on this box — and no privileged operation anywhere: the
+// password is read from the staging board, which the admin
+// user can read by group.
 package bitcoin
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"strings"
 	"time"
 
+	"github.com/virtualprivatenode/vpn/internal/helper"
 	"github.com/virtualprivatenode/vpn/internal/paths"
-	"github.com/virtualprivatenode/vpn/internal/system"
 )
+
+// RPCUser must match the rpcauth line the installer writes
+// into bitcoin.conf (installer.BitcoindRPCUser; duplicated
+// here as a plain constant because a bitcoin→installer import
+// would be backwards). A unit test in the installer package
+// asserts the two constants agree.
+const RPCUser = "vpn"
 
 type BlockchainInfo struct {
 	Blocks     int
@@ -17,6 +34,10 @@ type BlockchainInfo struct {
 	Progress   float64
 	Synced     bool
 	Responding bool
+	// SizeOnDisk is bitcoind's own measure of its data
+	// footprint in bytes — which is why no privileged
+	// du of the data dir is needed for the status screen.
+	SizeOnDisk int64
 }
 
 type blockchainInfoResponse struct {
@@ -24,31 +45,141 @@ type blockchainInfoResponse struct {
 	Headers              int     `json:"headers"`
 	VerificationProgress float64 `json:"verificationprogress"`
 	InitialBlockDownload bool    `json:"initialblockdownload"`
+	SizeOnDisk           int64   `json:"size_on_disk"`
 }
 
-func GetBlockchainInfo() *BlockchainInfo {
-	output, err := system.SudoRunContext(10*time.Second,
-		"-u", "bitcoin", "bitcoin-cli",
-		"-datadir="+paths.BitcoinDataDir, "-conf="+paths.BitcoinConf,
-		"getblockchaininfo")
+// rpcCall performs one JSON-RPC call against loopback. The
+// credential never touches argv or the environment: it is read
+// from the board and sent as HTTP basic auth.
+func rpcCall(rpcPort int, method string,
+	params []any, result any) error {
+	pass, err := helper.ReadBoardString(paths.StateBitcoindRPCPass)
 	if err != nil {
-		return &BlockchainInfo{Responding: false}
+		return err
 	}
+	if params == nil {
+		params = []any{}
+	}
+	payload, err := json.Marshal(map[string]any{
+		"jsonrpc": "1.0",
+		"id":      "vpn",
+		"method":  method,
+		"params":  params,
+	})
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequest(http.MethodPost,
+		fmt.Sprintf("http://127.0.0.1:%d/", rpcPort),
+		bytes.NewReader(payload))
+	if err != nil {
+		return err
+	}
+	req.SetBasicAuth(RPCUser, pass)
+	req.Header.Set("Content-Type", "application/json")
 
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("bitcoind unreachable: %w", err)
+	}
+	defer resp.Body.Close()
+	switch resp.StatusCode {
+	case http.StatusUnauthorized:
+		// The staged password and the conf's rpcauth line are
+		// replaced together at install; disagreement means one
+		// of them was changed outside this app.
+		return fmt.Errorf(
+			"bitcoind rejected the staged RPC credential — " +
+				"bitcoin.conf and the staged password disagree")
+	case http.StatusForbidden:
+		return fmt.Errorf(
+			"bitcoind denied method %s for user %s", method, RPCUser)
+	}
+	var rpcResp struct {
+		Result json.RawMessage `json:"result"`
+		Error  *struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&rpcResp); err != nil {
+		return fmt.Errorf("decode %s response: %w", method, err)
+	}
+	if rpcResp.Error != nil {
+		return fmt.Errorf("%s: rpc error %d: %s",
+			method, rpcResp.Error.Code, rpcResp.Error.Message)
+	}
+	if result != nil {
+		if err := json.Unmarshal(rpcResp.Result, result); err != nil {
+			return fmt.Errorf("decode %s result: %w", method, err)
+		}
+	}
+	return nil
+}
+
+// GetBlockchainInfo probes chain status. Never errors — the
+// status screen renders Responding=false as "not responding",
+// which covers bitcoind being down, starting up, or the staged
+// credential being unavailable (each already logged closer to
+// its source).
+func GetBlockchainInfo(rpcPort int) *BlockchainInfo {
 	var resp blockchainInfoResponse
-	if err := json.Unmarshal([]byte(output), &resp); err != nil {
+	if err := rpcCall(rpcPort,
+		"getblockchaininfo", nil, &resp); err != nil {
 		return &BlockchainInfo{Responding: false}
 	}
-
 	return &BlockchainInfo{
 		Blocks:     resp.Blocks,
 		Headers:    resp.Headers,
 		Progress:   resp.VerificationProgress,
 		Synced:     !resp.InitialBlockDownload,
 		Responding: true,
+		SizeOnDisk: resp.SizeOnDisk,
 	}
+}
+
+// EstimateSmartFee returns the fee estimate for the target in
+// sat/vB (minimum 1), or an error when bitcoind has no
+// estimate yet.
+func EstimateSmartFee(rpcPort, target int) (float64, error) {
+	var resp struct {
+		FeeRate float64  `json:"feerate"`
+		Errors  []string `json:"errors"`
+	}
+	if err := rpcCall(rpcPort, "estimatesmartfee",
+		[]any{target}, &resp); err != nil {
+		return 0, err
+	}
+	if resp.FeeRate <= 0 || len(resp.Errors) > 0 {
+		return 0, fmt.Errorf("no estimate for target %d (%s)",
+			target, strings.Join(resp.Errors, "; "))
+	}
+	// bitcoind returns BTC/kvB; sat/vB = BTC/kvB × 1e8 / 1000.
+	satPerVB := resp.FeeRate * 100000
+	if satPerVB < 1 {
+		satPerVB = 1
+	}
+	return satPerVB, nil
 }
 
 func FormatProgress(progress float64) string {
 	return fmt.Sprintf("%.2f%%", progress*100)
+}
+
+// FormatSize renders a byte count the way the status screen
+// shows data-directory sizes ("12.3 GB").
+func FormatSize(bytes int64) string {
+	const gb = 1 << 30
+	const mb = 1 << 20
+	switch {
+	case bytes >= gb:
+		return fmt.Sprintf("%.1f GB", float64(bytes)/gb)
+	case bytes >= mb:
+		return fmt.Sprintf("%.0f MB", float64(bytes)/mb)
+	case bytes > 0:
+		return fmt.Sprintf("%d B", bytes)
+	default:
+		return "N/A"
+	}
 }

--- a/internal/helper/board.go
+++ b/internal/helper/board.go
@@ -1,0 +1,216 @@
+// internal/helper/board.go
+
+package helper
+
+import (
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/virtualprivatenode/vpn/internal/paths"
+)
+
+// ── The staging board ────────────────────────────────────
+//
+// /etc/vpn/state holds one file per privileged FACT the TUI
+// needs to display or use: onion hostnames, the staged bitcoind
+// RPC password, copies of LND's TLS certificate and admin
+// macaroon, Syncthing's API key and device ID, and the observed
+// SSH password-auth state. Root writes them; the admin user
+// (group vpn) reads them; nothing else can see them.
+//
+// The contract that keeps the board trustworthy:
+//
+//   - every file is (re)written by whatever operation changes
+//     the fact it carries — at install, and afterwards by the
+//     helper operation that performs the change. The full
+//     write-map lives in internal/helperd/matrix.go and is
+//     enforced by unit tests there.
+//   - readers NEVER guess. A missing or unreadable file means
+//     the feature renders as unavailable with a logged reason,
+//     not a stale or default value. Staleness must surface as
+//     visible breakage.
+//   - nothing wallet-critical lives here. The seed, wallet.db,
+//     and the auto-unlock password file are NOT board facts;
+//     the admin macaroon copy is a revocable credential the
+//     admin user needs to operate the node (it is the same
+//     authority every wallet screen already exercises).
+
+// ReadBoard reads one staging-board file. The error is written
+// for surfacing to the operator: it names the file and points
+// at the helper's journal, because a missing board file means a
+// staging step failed or was skipped — a real defect to report,
+// not a condition to paper over.
+func ReadBoard(path string) ([]byte, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"staged fact %s unavailable (%v) — a privileged "+
+				"operation should have staged it; check "+
+				"journalctl -u vpn-helperd and the install log",
+			filepath.Base(path), err)
+	}
+	return data, nil
+}
+
+// ReadBoardString reads a board file as a trimmed string
+// (hostname files and the API key are single lines).
+func ReadBoardString(path string) (string, error) {
+	data, err := ReadBoard(path)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
+// ── Root-side writer ─────────────────────────────────────
+
+// vpnGID resolves the admin group's numeric gid. The group may
+// legitimately not exist yet during the bake phase of an image
+// build (the admin user is created at first boot) — the caller
+// falls back to root-only modes and the first-boot staging step
+// re-applies ownership.
+func vpnGID() (int, bool) {
+	g, err := user.LookupGroup(paths.AdminUser)
+	if err != nil {
+		return 0, false
+	}
+	gid, err := strconv.Atoi(g.Gid)
+	if err != nil {
+		return 0, false
+	}
+	return gid, true
+}
+
+// EnsureBoardDir creates the board directory with root:vpn
+// 0750 (root:root 0700 before the admin group exists).
+// Idempotent — re-applies ownership and mode so a bake-phase
+// directory is corrected at first boot. As belt and braces on
+// top of the root-owned-ancestors guarantee, it refuses to
+// operate on anything that is not a real directory owned by
+// root.
+func EnsureBoardDir() error {
+	if err := os.MkdirAll(paths.VarLibVPN, 0o755); err != nil {
+		return fmt.Errorf("create %s: %w", paths.VarLibVPN, err)
+	}
+	if err := os.MkdirAll(paths.StateDir, 0o750); err != nil {
+		return fmt.Errorf("create %s: %w", paths.StateDir, err)
+	}
+	fi, err := os.Lstat(paths.StateDir)
+	if err != nil {
+		return fmt.Errorf("stat %s: %w", paths.StateDir, err)
+	}
+	if !fi.Mode().IsDir() {
+		return fmt.Errorf(
+			"%s is not a directory — refusing to stage",
+			paths.StateDir)
+	}
+	if st, ok := fi.Sys().(*syscall.Stat_t); ok && st.Uid != 0 {
+		return fmt.Errorf(
+			"%s is not owned by root — refusing to stage",
+			paths.StateDir)
+	}
+	gid, ok := vpnGID()
+	if !ok {
+		return os.Chmod(paths.StateDir, 0o700)
+	}
+	if err := os.Chown(paths.StateDir, 0, gid); err != nil {
+		return fmt.Errorf("chown %s: %w", paths.StateDir, err)
+	}
+	return os.Chmod(paths.StateDir, 0o750)
+}
+
+// WriteBoard writes one staging-board file atomically: same-dir
+// temp, explicit chmod (the open mode is filtered by umask),
+// chown root:vpn, then rename onto the final path — a reader
+// never sees a partial file or a loose mode. Runs as root only.
+func WriteBoard(path string, data []byte) error {
+	if err := EnsureBoardDir(); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(paths.StateDir,
+		"."+filepath.Base(path)+".tmp-")
+	if err != nil {
+		return fmt.Errorf("stage %s: %w", path, err)
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath) // no-op after successful rename
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return fmt.Errorf("stage %s: write: %w", path, err)
+	}
+	if err := tmp.Chmod(0o640); err != nil {
+		tmp.Close()
+		return fmt.Errorf("stage %s: chmod: %w", path, err)
+	}
+	if gid, ok := vpnGID(); ok {
+		if err := tmp.Chown(0, gid); err != nil {
+			tmp.Close()
+			return fmt.Errorf("stage %s: chown: %w", path, err)
+		}
+	} else if err := tmp.Chmod(0o600); err != nil {
+		// No admin group yet (bake phase): keep it root-only;
+		// the first-boot staging step re-owns every board file.
+		tmp.Close()
+		return fmt.Errorf("stage %s: chmod: %w", path, err)
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return fmt.Errorf("stage %s: sync: %w", path, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("stage %s: close: %w", path, err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("stage %s: rename: %w", path, err)
+	}
+	return nil
+}
+
+// RemoveBoard removes a board file (used when the fact it
+// carries ceases to exist, e.g. credentials for a component
+// that was removed). A missing file is success.
+func RemoveBoard(path string) error {
+	if err := os.Remove(path); err != nil &&
+		!os.IsNotExist(err) {
+		return fmt.Errorf("remove staged fact %s: %w", path, err)
+	}
+	return nil
+}
+
+// FixBoardOwnership re-applies root:vpn 0640 to every existing
+// board file and 0750 to the directory. The first-boot staging
+// step calls this so files written during an image bake (before
+// the admin group existed) become readable once the group does.
+func FixBoardOwnership() error {
+	if err := EnsureBoardDir(); err != nil {
+		return err
+	}
+	gid, ok := vpnGID()
+	if !ok {
+		return fmt.Errorf(
+			"admin group %q does not exist", paths.AdminUser)
+	}
+	entries, err := os.ReadDir(paths.StateDir)
+	if err != nil {
+		return fmt.Errorf("list %s: %w", paths.StateDir, err)
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		p := filepath.Join(paths.StateDir, e.Name())
+		if err := os.Chown(p, 0, gid); err != nil {
+			return fmt.Errorf("chown %s: %w", p, err)
+		}
+		if err := os.Chmod(p, 0o640); err != nil {
+			return fmt.Errorf("chmod %s: %w", p, err)
+		}
+	}
+	return nil
+}

--- a/internal/helper/board.go
+++ b/internal/helper/board.go
@@ -16,7 +16,7 @@ import (
 
 // ── The staging board ────────────────────────────────────
 //
-// /etc/vpn/state holds one file per privileged FACT the TUI
+// /var/lib/vpn/state holds one file per privileged FACT the TUI
 // needs to display or use: onion hostnames, the staged bitcoind
 // RPC password, copies of LND's TLS certificate and admin
 // macaroon, Syncthing's API key and device ID, and the observed

--- a/internal/helper/board_test.go
+++ b/internal/helper/board_test.go
@@ -1,0 +1,53 @@
+// internal/helper/board_test.go
+
+package helper
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A missing board file must produce an error that tells the
+// operator what to check — the fail-noisy contract: the reader
+// never guesses, and the noise carries the diagnosis pointer.
+func TestReadBoardMissingIsNoisy(t *testing.T) {
+	_, err := ReadBoard(filepath.Join(t.TempDir(), "no-such-fact"))
+	if err == nil {
+		t.Fatal("missing board file: expected error")
+	}
+	msg := err.Error()
+	for _, want := range []string{
+		"no-such-fact", "journalctl -u vpn-helperd",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error %q does not mention %q", msg, want)
+		}
+	}
+}
+
+func TestReadBoardString(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "fact")
+	if err := os.WriteFile(p,
+		[]byte("  value.onion\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ReadBoardString(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "value.onion" {
+		t.Errorf("got %q, want trimmed single value", got)
+	}
+}
+
+// RemoveBoard treats a missing file as success (the fact is
+// absent either way).
+func TestRemoveBoardMissingOK(t *testing.T) {
+	if err := RemoveBoard(
+		filepath.Join(t.TempDir(), "gone")); err != nil {
+		t.Errorf("remove of missing board file: %v", err)
+	}
+}

--- a/internal/helper/client.go
+++ b/internal/helper/client.go
@@ -1,0 +1,231 @@
+// internal/helper/client.go
+
+package helper
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/virtualprivatenode/vpn/internal/paths"
+)
+
+// ── Helper client ────────────────────────────────────────
+//
+// One privileged operation = one connection: dial the helper's
+// socket, write one request line, half-close, then read
+// progress events until the ok/error terminator. The socket's
+// ownership (root:vpn 0660) is what authorizes the connection;
+// there is no password and no token — being the admin user IS
+// the credential, and the helper re-checks the peer's uid on
+// every connection.
+//
+// The helper serializes execution: while it runs one operation,
+// a second connection waits its turn in the kernel's queue.
+// Deadlines are enforced on the root side per operation; the
+// client just reads until the connection ends.
+
+const dialTimeout = 5 * time.Second
+
+// maxEventBytes bounds one response line. Events are small; the
+// bound exists so a defect can't balloon client memory.
+const maxEventBytes = 1 << 20
+
+// helperDown wraps a transport-level failure in operator-facing
+// language: what to check, in order.
+func helperDown(op string, err error) error {
+	return fmt.Errorf(
+		"%s: cannot reach the node's helper service (%v) — "+
+			"check: systemctl status vpn-helperd.socket, then "+
+			"journalctl -u vpn-helperd", op, err)
+}
+
+// Session is one in-flight helper request. Callers either
+// drain it with Wait (simple verbs) or step through it with
+// WaitStep + Wait (streaming verbs feeding a step renderer).
+type Session struct {
+	conn    *net.UnixConn
+	scanner *bufio.Scanner
+	verb    string
+
+	end    *Event // terminator, once seen
+	nextIx int    // next step index expected by WaitStep
+	stepOK map[int]bool
+	err    error // sticky transport/protocol error
+}
+
+// Start dials the helper and sends the request. It returns
+// immediately after the request is written; the operation runs
+// (and possibly queues) on the root side.
+func Start(verb string, params any) (*Session, error) {
+	d := net.Dialer{Timeout: dialTimeout}
+	c, err := d.Dial("unix", paths.HelperSocket)
+	if err != nil {
+		return nil, helperDown(verb, err)
+	}
+	conn, ok := c.(*net.UnixConn)
+	if !ok { // cannot happen for a unix dial; belt and braces
+		c.Close()
+		return nil, helperDown(verb,
+			errors.New("not a unix socket connection"))
+	}
+
+	req := Request{Verb: verb}
+	if params != nil {
+		raw, err := json.Marshal(params)
+		if err != nil {
+			conn.Close()
+			return nil, fmt.Errorf("%s: encode params: %w", verb, err)
+		}
+		req.Params = raw
+	}
+	line, err := json.Marshal(req)
+	if err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("%s: encode request: %w", verb, err)
+	}
+	if err := conn.SetWriteDeadline(
+		time.Now().Add(dialTimeout)); err == nil {
+		defer conn.SetWriteDeadline(time.Time{})
+	}
+	if _, err := conn.Write(append(line, '\n')); err != nil {
+		conn.Close()
+		return nil, helperDown(verb, err)
+	}
+	// Half-close our sending side: the helper reads a clean EOF
+	// after the request line even if a future client forgets
+	// the trailing newline.
+	if err := conn.CloseWrite(); err != nil {
+		conn.Close()
+		return nil, helperDown(verb, err)
+	}
+
+	sc := bufio.NewScanner(conn)
+	sc.Buffer(make([]byte, 0, 64*1024), maxEventBytes)
+	return &Session{
+		conn:    conn,
+		scanner: sc,
+		verb:    verb,
+		stepOK:  map[int]bool{},
+	}, nil
+}
+
+// readEvent reads the next response line. Returns nil at
+// end-of-stream (which is only legitimate after a terminator).
+func (s *Session) readEvent() (*Event, error) {
+	if !s.scanner.Scan() {
+		if err := s.scanner.Err(); err != nil {
+			return nil, helperDown(s.verb, err)
+		}
+		return nil, nil // EOF
+	}
+	var ev Event
+	if err := json.Unmarshal(s.scanner.Bytes(), &ev); err != nil {
+		return nil, fmt.Errorf(
+			"%s: malformed helper response: %w", s.verb, err)
+	}
+	return &ev, nil
+}
+
+// advance consumes events until the wanted step index has
+// completed or the stream terminates.
+func (s *Session) advance(untilStep int) error {
+	if s.err != nil {
+		return s.err
+	}
+	for {
+		if untilStep >= 0 && s.stepOK[untilStep] {
+			return nil
+		}
+		if s.end != nil {
+			return s.endErr(untilStep)
+		}
+		ev, err := s.readEvent()
+		if err != nil {
+			s.err = err
+			return err
+		}
+		if ev == nil {
+			// Stream ended without a terminator: the helper died
+			// mid-operation or its deadline expired.
+			s.err = helperDown(s.verb, errors.New(
+				"connection closed before the operation finished"))
+			return s.err
+		}
+		switch ev.Event {
+		case "step":
+			if ev.Err != "" {
+				s.err = fmt.Errorf("%s", ev.Err)
+				return s.err
+			}
+			s.stepOK[ev.Index] = true
+		case "end":
+			s.end = ev
+			if untilStep < 0 {
+				return s.endErr(untilStep)
+			}
+		default:
+			// Unknown event kinds are ignored: additive protocol
+			// growth must not break older clients.
+		}
+	}
+}
+
+// endErr folds the terminator into an error (or nil).
+func (s *Session) endErr(untilStep int) error {
+	if s.end.OK {
+		if untilStep >= 0 && !s.stepOK[untilStep] {
+			// Terminated OK without reporting the step the caller
+			// is waiting on — a protocol drift bug.
+			s.err = fmt.Errorf(
+				"%s: helper finished without reporting step %d",
+				s.verb, untilStep+1)
+			return s.err
+		}
+		return nil
+	}
+	s.err = errors.New(s.end.Error)
+	return s.err
+}
+
+// WaitStep blocks until step i (0-based) completes on the root
+// side, a step fails, or the stream ends in an error.
+func (s *Session) WaitStep(i int) error {
+	return s.advance(i)
+}
+
+// Wait blocks until the terminator, decoding its result payload
+// into result (which may be nil), and closes the connection.
+func (s *Session) Wait(result any) error {
+	defer s.conn.Close()
+	if err := s.advance(-1); err != nil {
+		return err
+	}
+	if result != nil && len(s.end.Result) > 0 {
+		if err := json.Unmarshal(s.end.Result, result); err != nil {
+			return fmt.Errorf(
+				"%s: decode helper result: %w", s.verb, err)
+		}
+	}
+	return nil
+}
+
+// Close abandons the session. The root side finishes the
+// operation it started regardless — abandoning a mutation
+// halfway is exactly the inconsistent state the helper exists
+// to prevent — but this client stops listening.
+func (s *Session) Close() { s.conn.Close() }
+
+// Call performs a whole verb in one blocking call: start, drain
+// any progress events, decode the terminator. For streaming
+// verbs it simply ignores per-step progress.
+func Call(verb string, params, result any) error {
+	s, err := Start(verb, params)
+	if err != nil {
+		return err
+	}
+	return s.Wait(result)
+}

--- a/internal/helper/wire.go
+++ b/internal/helper/wire.go
@@ -1,0 +1,249 @@
+// internal/helper/wire.go
+
+// Package helper is the unprivileged side of the node's
+// privilege boundary. It holds three things:
+//
+//   - the wire protocol shared by the root helper (vpn helperd)
+//     and its clients: one JSON request line per connection,
+//     answered by zero or more progress events and exactly one
+//     ok/error terminator (wire.go);
+//   - the client the TUI uses to request privileged operations
+//     over the helper's unix socket (client.go);
+//   - the staging-board reader and writer: the root-written
+//     files under /etc/vpn/state that carry privileged facts
+//     (onion hostnames, staged credentials) to the admin user
+//     without any privileged code running on the read path
+//     (board.go).
+//
+// The package deliberately does NOT import the installer: the
+// installer imports this package to write board files, and the
+// helper daemon (internal/helperd) imports both.
+package helper
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Verb names. The helper serves this fixed menu and nothing
+// else — there is no verb that runs a caller-supplied command,
+// and no verb that returns a caller-chosen file. Every verb
+// validates its parameters against a closed set of accepted
+// values before touching the system.
+const (
+	// Simple verbs: one request, one terminator.
+	VerbServiceAction        = "service-action"
+	VerbReboot               = "reboot"
+	VerbDirSize              = "dir-size"
+	VerbSetUserPassword      = "set-user-password"
+	VerbStageWalletPassword  = "stage-wallet-password"
+	VerbRemoveWalletPassword = "remove-wallet-password"
+	VerbStageLNDCredentials  = "stage-lnd-credentials"
+	VerbRebuildSSHConfig     = "rebuild-ssh-config"
+	VerbRebuildTorConfig     = "rebuild-tor-config"
+
+	// Streaming verbs: step progress events precede the
+	// terminator, and feed the TUI's step renderer.
+	VerbPackageUpdate    = "package-update"
+	VerbSelfUpdate       = "self-update"
+	VerbSetP2PMode       = "set-p2p-mode"
+	VerbSyncthingInstall = "syncthing-install"
+)
+
+// Request is the single line a client writes after connecting.
+type Request struct {
+	Verb   string          `json:"verb"`
+	Params json.RawMessage `json:"params,omitempty"`
+}
+
+// Event is one response line from the helper. Two kinds:
+//
+//   - "step": progress from a streaming verb. Index is the
+//     0-based position in the verb's fixed step list; Err is
+//     non-empty if that step failed (a failed step is always
+//     followed by an error terminator).
+//   - "end": the terminator. Exactly one per connection. OK
+//     with an optional Result payload, or an Error message.
+type Event struct {
+	Event string `json:"event"` // "step" or "end"
+
+	// step fields
+	Index int    `json:"index,omitempty"`
+	Err   string `json:"err,omitempty"`
+
+	// end fields
+	OK     bool            `json:"ok,omitempty"`
+	Error  string          `json:"error,omitempty"`
+	Result json.RawMessage `json:"result,omitempty"`
+}
+
+// ── Typed parameters ─────────────────────────────────────
+//
+// Every value that crosses the privilege boundary is a field in
+// one of these structs, and the helper validates each against a
+// closed set (see internal/helperd). The structs live here so
+// client and server marshal/unmarshal the same shape.
+
+// ServiceActionParams: systemctl <action> <unit>. Both fields
+// are validated against closed sets on the root side.
+type ServiceActionParams struct {
+	Unit   string `json:"unit"`
+	Action string `json:"action"`
+}
+
+// DirSizeParams: which data directory to measure. "lnd" is the
+// only accepted value — the bitcoin data dir's size comes from
+// bitcoind's own getblockchaininfo (size_on_disk) over RPC,
+// with no privileged operation at all.
+type DirSizeParams struct {
+	Which string `json:"which"`
+}
+
+// DirSizeResult carries the measured size back, already
+// human-formatted ("12G").
+type DirSizeResult struct {
+	Size string `json:"size"`
+}
+
+// SetUserPasswordParams: change a login password. User must be
+// the admin user — no other account's password is manageable
+// through the helper. The password is re-validated root-side
+// against the same 16-character rule the client enforces.
+type SetUserPasswordParams struct {
+	User     string `json:"user"`
+	Password string `json:"password"`
+}
+
+// StageWalletPasswordParams: enable LND auto-unlock. The
+// password the operator typed is written root-side to LND's
+// wallet_password file (which stays owned by the service user,
+// never readable by the admin user) and the LND service is
+// rewritten to use it.
+type StageWalletPasswordParams struct {
+	Password string `json:"password"`
+}
+
+// RebuildSSHConfigParams: rewrite the SSH hardening drop-in.
+// The template lives on the root side; the only caller-chosen
+// value is the password-auth flag.
+type RebuildSSHConfigParams struct {
+	PasswordAuthDisabled bool `json:"password_auth_disabled"`
+}
+
+// RebuildTorConfigParams: rewrite torrc from the root-side
+// template and restart Tor. The flags select which of the
+// template's fixed hidden-service blocks are present — no
+// caller-supplied torrc content, ever.
+type RebuildTorConfigParams struct {
+	LND       bool `json:"lnd"`
+	Syncthing bool `json:"syncthing"`
+}
+
+// SetP2PModeParams: switch LND between tor-only and hybrid
+// P2P. For "hybrid" the helper derives the box's public IPv4
+// itself (kernel routing table) — the client cannot supply an
+// address.
+type SetP2PModeParams struct {
+	Mode string `json:"mode"` // "tor" or "hybrid"
+}
+
+// SelfUpdateParams: update the vpn binary to a release version.
+// Validated root-side: strict version shape, and same-major
+// only (a cross-major release requires reading its release
+// notes; the helper refuses it no matter what a client asks).
+type SelfUpdateParams struct {
+	Version string `json:"version"`
+}
+
+// SyncthingInstallResult returns the generated web-UI password
+// for the operator's config.
+type SyncthingInstallResult struct {
+	Password string `json:"password"`
+}
+
+// ── Version gate (shared by both sides) ──────────────────
+
+// releaseVersion is the accepted shape for a release version.
+// Anchored and strict: this is the single choke point between
+// "string from the network" and "string in a release URL".
+var releaseVersion = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+$`)
+
+// SameMajor reports whether two release versions share a major
+// version. It errors when either does not parse — callers
+// refuse rather than guess. Both the TUI (which renders a
+// cross-major release as "see the release notes", with no
+// update action) and the helper (which refuses to install one)
+// use this same function, so the two halves of the gate cannot
+// drift.
+func SameMajor(current, target string) (bool, error) {
+	if !releaseVersion.MatchString(current) {
+		return false, fmt.Errorf(
+			"running version %q is not a release build — "+
+				"self-update requires one", current)
+	}
+	if !releaseVersion.MatchString(target) {
+		return false, fmt.Errorf(
+			"%q is not a valid release version", target)
+	}
+	return strings.SplitN(current, ".", 2)[0] ==
+		strings.SplitN(target, ".", 2)[0], nil
+}
+
+// ── Streaming step lists ─────────────────────────────────
+//
+// A streaming verb's step names are fixed per verb and known to
+// both sides: the client renders the full list up front, the
+// server reports completion by index. A unit test in the helper
+// daemon asserts each server-side step list matches these — the
+// two can never silently drift past a test run.
+
+// SelfUpdateStepNames mirrors the server's self-update steps.
+func SelfUpdateStepNames(version string) []string {
+	return []string{
+		"Downloading v" + version,
+		"Verifying signature",
+		"Verifying checksum",
+		"Installing new binary",
+	}
+}
+
+// PackageUpdateStepNames mirrors the server's package-update
+// steps.
+func PackageUpdateStepNames() []string {
+	return []string{
+		"Refreshing package lists",
+		"Upgrading packages",
+	}
+}
+
+// SetP2PModeStepNames mirrors the server's P2P-mode steps.
+func SetP2PModeStepNames() []string {
+	return []string{
+		"Updating LND config",
+		"Updating firewall",
+		"Restarting LND",
+		"Restaging LND credentials",
+	}
+}
+
+// SyncthingInstallStepNames mirrors the server's Syncthing
+// install steps.
+func SyncthingInstallStepNames(version string) []string {
+	return []string{
+		"Downloading Syncthing " + version,
+		"Verifying Syncthing",
+		"Installing Syncthing",
+		"Creating Syncthing directories",
+		"Creating Syncthing service",
+		"Configuring Syncthing authentication",
+		"Configuring firewall",
+		"Rebuilding Tor config",
+		"Restarting Tor",
+		"Starting Syncthing",
+		"Registering backup folder",
+		"Setting up channel backup watcher",
+		"Staging Syncthing facts",
+	}
+}

--- a/internal/helper/wire.go
+++ b/internal/helper/wire.go
@@ -10,10 +10,10 @@
 //   - the client the TUI uses to request privileged operations
 //     over the helper's unix socket (client.go);
 //   - the staging-board reader and writer: the root-written
-//     files under /etc/vpn/state that carry privileged facts
-//     (onion hostnames, staged credentials) to the admin user
-//     without any privileged code running on the read path
-//     (board.go).
+//     files under /var/lib/vpn/state that carry privileged
+//     facts (onion hostnames, staged credentials) to the
+//     admin user without any privileged code running on the
+//     read path (board.go).
 //
 // The package deliberately does NOT import the installer: the
 // installer imports this package to write board files, and the
@@ -61,9 +61,13 @@ type Request struct {
 // Event is one response line from the helper. Two kinds:
 //
 //   - "step": progress from a streaming verb. Index is the
-//     0-based position in the verb's fixed step list; Err is
-//     non-empty if that step failed (a failed step is always
-//     followed by an error terminator).
+//     0-based position in the verb's fixed step list. The
+//     helper emits a step event on COMPLETION only — a step
+//     that fails produces no step event; the failure arrives
+//     as the error terminator. Err is reserved wire surface
+//     for a per-step error report: the helper never sets it
+//     today, and clients treat a non-empty Err as fatal if
+//     one ever appears.
 //   - "end": the terminator. Exactly one per connection. OK
 //     with an optional Result payload, or an Error message.
 type Event struct {

--- a/internal/helper/wire_test.go
+++ b/internal/helper/wire_test.go
@@ -1,0 +1,70 @@
+// internal/helper/wire_test.go
+
+package helper
+
+import "testing"
+
+// The same-major gate is shared by the TUI's rendering and the
+// helper's refusal — one function, both sides. These tables pin
+// its behavior, including the refuse-don't-guess direction on
+// anything that is not a plain release version.
+func TestSameMajor(t *testing.T) {
+	cases := []struct {
+		current, target string
+		same            bool
+		wantErr         bool
+	}{
+		{"0.7.0", "0.7.1", true, false},
+		{"0.7.0", "0.9.9", true, false},
+		{"0.7.0", "1.0.0", false, false},
+		{"1.2.3", "2.0.0", false, false},
+		{"10.0.0", "1.0.0", false, false}, // "10" != "1"
+		{"dev", "0.7.1", false, true},
+		{"0.7.0", "dev", false, true},
+		{"0.7.0", "", false, true},
+		{"0.7.0", "v0.7.1", false, true},
+		{"0.7.0", "0.7.1-rc1", false, true},
+		{"0.7.0", "0.7", false, true},
+		{"0.7.0", "0.7.1.2", false, true},
+		{"0.7.0", "0.7.1;rm -rf /", false, true},
+	}
+	for _, c := range cases {
+		same, err := SameMajor(c.current, c.target)
+		if c.wantErr {
+			if err == nil {
+				t.Errorf("SameMajor(%q,%q): expected error",
+					c.current, c.target)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("SameMajor(%q,%q): %v", c.current, c.target, err)
+			continue
+		}
+		if same != c.same {
+			t.Errorf("SameMajor(%q,%q) = %v, want %v",
+				c.current, c.target, same, c.same)
+		}
+	}
+}
+
+// Streaming step lists must never be empty — the client adapter
+// keys its whole lifecycle on step indices existing.
+func TestStepListsNonEmpty(t *testing.T) {
+	lists := map[string][]string{
+		"self-update":       SelfUpdateStepNames("0.7.1"),
+		"package-update":    PackageUpdateStepNames(),
+		"set-p2p-mode":      SetP2PModeStepNames(),
+		"syncthing-install": SyncthingInstallStepNames("2.1.1"),
+	}
+	for name, l := range lists {
+		if len(l) == 0 {
+			t.Errorf("%s: empty step list", name)
+		}
+		for i, n := range l {
+			if n == "" {
+				t.Errorf("%s: step %d has no name", name, i)
+			}
+		}
+	}
+}

--- a/internal/helperd/helperd.go
+++ b/internal/helperd/helperd.go
@@ -1,0 +1,371 @@
+// internal/helperd/helperd.go
+
+// Package helperd is the root side of the node's privilege
+// boundary: `vpn helperd`, a socket-activated service that
+// executes a fixed menu of privileged operations ("verbs") for
+// the unprivileged admin user.
+//
+// The trust model, in one breath: systemd owns the unix socket
+// at /run/vpn-helperd.sock and creates its node root:vpn 0660
+// before this process ever runs, so only root and the admin
+// user can connect — the socket's permissions are the
+// authentication. On top of that, every accepted connection is
+// re-identified with SO_PEERCRED (a kernel statement about the
+// connecting process, not a client claim) and refused unless
+// the peer uid is the admin user or root. What a connection can
+// then do is bounded by the verb menu: there is no verb that
+// runs a caller-supplied command line and no verb that returns
+// a caller-chosen file.
+//
+// Lifecycle: systemd starts this process when a connection
+// arrives and passes it the listening socket. Connections are
+// served ONE AT A TIME — privileged mutations are serialized by
+// construction, and a second client simply waits in the
+// kernel's queue. After 120 seconds with no connection the
+// process exits; the socket stays, and the next connection
+// starts a fresh helper. The timer only ever runs between
+// connections, so no in-flight operation can be cut short by
+// it. 120 seconds is an engineering constant, not a security
+// control: it sits far above systemd's default start-rate
+// limit (5 starts per 10 seconds) so that normal use can never
+// trip rate limiting — at worst the helper is started once per
+// idle period — while a quiet box still runs no resident root
+// process. See the unit files the installer writes for the
+// systemd half of this arrangement.
+//
+// Every verb call and outcome is logged to stdout, which
+// journald captures under the vpn-helperd unit. The admin user
+// can read that record (systemd-journal group) but cannot
+// rewrite it — the audit trail of privileged operations
+// survives a compromise of the admin account. Parameters are
+// never logged: some carry secrets.
+package helperd
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"os/user"
+	"strconv"
+	"syscall"
+	"time"
+
+	"github.com/virtualprivatenode/vpn/internal/helper"
+	"github.com/virtualprivatenode/vpn/internal/paths"
+)
+
+const (
+	// idleExit is how long the helper waits for a connection
+	// before exiting. Chosen against systemd's start-rate
+	// limit (see the package comment); not a security dial.
+	idleExit = 120 * time.Second
+
+	// headerTimeout bounds reading the request line, so a
+	// client that connects and stalls cannot wedge the
+	// serialized helper.
+	headerTimeout = 5 * time.Second
+
+	// maxRequestBytes bounds the request line.
+	maxRequestBytes = 1 << 20
+
+	// listenFdsStart is where systemd-passed file descriptors
+	// begin (the sd_listen_fds(3) protocol).
+	listenFdsStart = 3
+)
+
+// Serve is the `vpn helperd` entry point. version is the
+// running binary's version (the self-update verb's same-major
+// gate compares against it).
+func Serve(version string) error {
+	if os.Geteuid() != 0 {
+		return errors.New(
+			"vpn helperd runs as root via its systemd unit — " +
+				"it is not meant to be started by hand")
+	}
+	// Non-interactive package operations for apt-running verbs
+	// (same environment the installer uses).
+	os.Setenv("DEBIAN_FRONTEND", "noninteractive")
+	os.Setenv("NEEDRESTART_MODE", "a")
+
+	ln, err := activationListener()
+	if err != nil {
+		return err
+	}
+	defer ln.Close()
+
+	allowed, err := resolveAllowedUIDs()
+	if err != nil {
+		// Fail-noisy: a missing admin account means the install
+		// is broken, not that everyone is welcome.
+		return err
+	}
+
+	audit("start", `{"event":"start","version":%q}`, version)
+	srv := &server{version: version, allowed: allowed}
+	for {
+		if err := ln.SetDeadline(time.Now().Add(idleExit)); err != nil {
+			return fmt.Errorf("arm idle timer: %w", err)
+		}
+		conn, err := ln.Accept()
+		if err != nil {
+			if errors.Is(err, os.ErrDeadlineExceeded) {
+				audit("idle", `{"event":"idle-exit"}`)
+				return nil
+			}
+			return fmt.Errorf("accept: %w", err)
+		}
+		uc, ok := conn.(*net.UnixConn)
+		if !ok { // cannot happen on a unix listener
+			conn.Close()
+			continue
+		}
+		exit := srv.handleConn(uc)
+		if exit {
+			// A verb (self-update) asked the process to exit so
+			// the next activation runs the new binary. Clients
+			// lose nothing: connections queue on systemd's
+			// socket while no helper runs.
+			audit("exit", `{"event":"exit-for-update"}`)
+			return nil
+		}
+	}
+}
+
+// activationListener returns the single listening unix socket
+// passed by systemd socket activation. This is the only place
+// the LISTEN_* protocol is read.
+func activationListener() (*net.UnixListener, error) {
+	// Unset-env hygiene regardless of outcome: children this
+	// process execs (systemctl, apt-get, chpasswd) must never
+	// see LISTEN_* or a child Go binary could mis-detect
+	// activation.
+	defer func() {
+		os.Unsetenv("LISTEN_PID")
+		os.Unsetenv("LISTEN_FDS")
+		os.Unsetenv("LISTEN_FDNAMES")
+	}()
+
+	pidStr := os.Getenv("LISTEN_PID")
+	if pidStr == "" {
+		return nil, errors.New(
+			"not socket-activated (LISTEN_PID unset) — start " +
+				"vpn-helperd.socket and connect to it instead of " +
+				"running helperd directly")
+	}
+	pid, err := strconv.Atoi(pidStr)
+	if err != nil {
+		return nil, fmt.Errorf("bad LISTEN_PID %q: %v", pidStr, err)
+	}
+	if pid != os.Getpid() {
+		// Environment addressed to another process; the fds are
+		// not ours to consume.
+		return nil, fmt.Errorf(
+			"LISTEN_PID %d is not this process (%d)",
+			pid, os.Getpid())
+	}
+	nfds, err := strconv.Atoi(os.Getenv("LISTEN_FDS"))
+	if err != nil {
+		return nil, fmt.Errorf("bad LISTEN_FDS: %v", err)
+	}
+	if nfds != 1 {
+		return nil, fmt.Errorf(
+			"want exactly 1 activated socket, got %d", nfds)
+	}
+
+	// systemd passes fds WITHOUT close-on-exec; set it before
+	// anything can fork+exec, or a child could hold the
+	// listener open past this helper's exit.
+	syscall.CloseOnExec(listenFdsStart)
+
+	f := os.NewFile(uintptr(listenFdsStart), "vpn-helperd.socket")
+	if f == nil {
+		return nil, errors.New("activated fd 3 is not valid")
+	}
+	// net.FileListener duplicates the fd; close our original
+	// after the wrap.
+	defer f.Close()
+
+	ln, err := net.FileListener(f)
+	if err != nil {
+		return nil, fmt.Errorf("wrap activated socket: %w", err)
+	}
+	ul, ok := ln.(*net.UnixListener)
+	if !ok {
+		ln.Close()
+		return nil, fmt.Errorf(
+			"activated socket is %T, want unix", ln)
+	}
+	return ul, nil
+}
+
+// resolveAllowedUIDs resolves the peer uids allowed to issue
+// verbs: root and the admin user. Resolved once at startup —
+// resolving per connection would turn a passwd corruption into
+// a fail-open ambiguity; once turns it into a loud start error.
+func resolveAllowedUIDs() (map[uint32]bool, error) {
+	u, err := user.Lookup(paths.AdminUser)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"resolve admin user %q: %w", paths.AdminUser, err)
+	}
+	uid, err := strconv.ParseUint(u.Uid, 10, 32)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"admin uid %q not numeric: %v", u.Uid, err)
+	}
+	return map[uint32]bool{0: true, uint32(uid): true}, nil
+}
+
+// server carries per-process state into connection handling.
+type server struct {
+	version string
+	allowed map[uint32]bool
+}
+
+// handleConn serves exactly one request on one connection.
+// Returns true if the process should exit after this
+// connection (self-update).
+func (s *server) handleConn(c *net.UnixConn) (exitAfter bool) {
+	defer c.Close()
+
+	cred, err := peerCred(c)
+	if err != nil {
+		auditErr("peercred", `{"event":"reject","reason":"peercred failed: %v"}`, err)
+		return false
+	}
+	if !s.allowed[cred.Uid] {
+		// Unauthorized peers get silence, not a protocol
+		// conversation.
+		auditErr("reject", `{"event":"reject","uid":%d,"gid":%d,"pid":%d}`,
+			cred.Uid, cred.Gid, cred.Pid)
+		return false
+	}
+
+	if err := c.SetReadDeadline(
+		time.Now().Add(headerTimeout)); err != nil {
+		auditErr("deadline", `{"event":"error","detail":"arm header deadline: %v"}`, err)
+		return false
+	}
+	sc := bufio.NewScanner(c)
+	sc.Buffer(make([]byte, 0, 64*1024), maxRequestBytes)
+	if !sc.Scan() {
+		auditErr("request", `{"event":"error","uid":%d,"detail":"request read: %v"}`,
+			cred.Uid, sc.Err())
+		return false
+	}
+	var req helper.Request
+	if err := json.Unmarshal(sc.Bytes(), &req); err != nil {
+		writeEnd(c, &helper.Event{Event: "end",
+			Error: "malformed request: " + err.Error()})
+		auditErr("request", `{"event":"error","uid":%d,"detail":"malformed request"}`,
+			cred.Uid)
+		return false
+	}
+
+	def, ok := verbs[req.Verb]
+	if !ok {
+		writeEnd(c, &helper.Event{Event: "end",
+			Error: fmt.Sprintf("unknown verb %q", req.Verb)})
+		auditErr(req.Verb, `{"event":"error","uid":%d,"verb":%q,"detail":"unknown verb"}`,
+			cred.Uid, req.Verb)
+		return false
+	}
+
+	// One absolute deadline bounds the verb's execution and
+	// every response write: a wedged operation cannot hold the
+	// serialized queue past its budget. Deadlines are per verb
+	// (a package upgrade legitimately needs half an hour; a
+	// password change does not).
+	if err := c.SetDeadline(time.Now().Add(def.deadline)); err != nil {
+		auditErr(req.Verb, `{"event":"error","detail":"arm verb deadline: %v"}`, err)
+		return false
+	}
+
+	audit(req.Verb, `{"event":"verb","verb":%q,"uid":%d,"pid":%d}`,
+		req.Verb, cred.Uid, cred.Pid)
+	start := time.Now()
+
+	ctx := &verbCtx{conn: c, version: s.version}
+	result, err := def.handler(ctx, req.Params)
+	ms := time.Since(start).Milliseconds()
+	if err != nil {
+		writeEnd(c, &helper.Event{Event: "end", Error: err.Error()})
+		auditErr(req.Verb, `{"event":"outcome","verb":%q,"uid":%d,"outcome":"error","ms":%d,"detail":%q}`,
+			req.Verb, cred.Uid, ms, err.Error())
+		return false
+	}
+	end := &helper.Event{Event: "end", OK: true}
+	if result != nil {
+		if raw, mErr := json.Marshal(result); mErr == nil {
+			end.Result = raw
+		}
+	}
+	writeEnd(c, end)
+	audit(req.Verb, `{"event":"outcome","verb":%q,"uid":%d,"outcome":"ok","ms":%d}`,
+		req.Verb, cred.Uid, ms)
+
+	if ctx.afterEnd != nil {
+		// Post-terminator action (reboot; self-update's exit).
+		// The client already has its answer.
+		c.Close()
+		ctx.afterEnd()
+	}
+	return ctx.exitAfterEnd
+}
+
+// verbCtx is what a verb handler gets to work with.
+type verbCtx struct {
+	conn    *net.UnixConn
+	version string
+
+	// afterEnd runs after the ok terminator is written and the
+	// connection is closed (reboot, self-update exit).
+	afterEnd func()
+	// exitAfterEnd makes the process exit after this
+	// connection — the self-update contract: the next
+	// activation runs the freshly installed binary.
+	exitAfterEnd bool
+}
+
+// emitStep reports step i of a streaming verb as complete.
+// Write failures are deliberately not fatal to the OPERATION:
+// a client that vanished mid-stream does not get to abort a
+// privileged mutation halfway — the operation finishes and the
+// journal keeps the record; only the progress reporting is
+// lost.
+func (ctx *verbCtx) emitStep(i int) {
+	writeEvent(ctx.conn, &helper.Event{Event: "step", Index: i})
+}
+
+func writeEvent(c *net.UnixConn, ev *helper.Event) {
+	raw, err := json.Marshal(ev)
+	if err != nil {
+		return
+	}
+	if _, err := c.Write(append(raw, '\n')); err != nil {
+		auditErr("write", `{"event":"error","detail":"client write failed (operation continues): %v"}`, err)
+	}
+}
+
+func writeEnd(c *net.UnixConn, ev *helper.Event) {
+	writeEvent(c, ev)
+}
+
+// ── Audit output ─────────────────────────────────────────
+//
+// One line per record to stdout; journald stamps each with
+// trusted metadata (_UID=0, _SYSTEMD_UNIT=vpn-helperd.service)
+// that no client-side writer can forge. The "<3>" prefix marks
+// error-priority records (journald parses and strips it).
+// The tag argument exists only to keep call sites readable.
+
+func audit(_ string, format string, args ...any) {
+	fmt.Fprintf(os.Stdout, format+"\n", args...)
+}
+
+func auditErr(_ string, format string, args ...any) {
+	fmt.Fprintf(os.Stdout, "<3>"+format+"\n", args...)
+}

--- a/internal/helperd/helperd.go
+++ b/internal/helperd/helperd.go
@@ -274,11 +274,16 @@ func (s *server) handleConn(c *net.UnixConn) (exitAfter bool) {
 		return false
 	}
 
-	// One absolute deadline bounds the verb's execution and
-	// every response write: a wedged operation cannot hold the
-	// serialized queue past its budget. Deadlines are per verb
-	// (a package upgrade legitimately needs half an hour; a
-	// password change does not).
+	// One absolute deadline bounds this connection's SOCKET
+	// I/O — every remaining read and every response write. It
+	// does NOT reach into the verb's subprocesses: nothing is
+	// waiting on the socket while a privileged command runs, so
+	// a wedged subprocess is bounded by its own limits — the
+	// download timeouts and retry caps in system.doDownload,
+	// apt's Acquire timeout configuration, systemd's per-unit
+	// stop timeouts — not by this deadline. Deadlines are per
+	// verb (a package upgrade legitimately needs half an hour;
+	// a password change does not).
 	if err := c.SetDeadline(time.Now().Add(def.deadline)); err != nil {
 		auditErr(req.Verb, `{"event":"error","detail":"arm verb deadline: %v"}`, err)
 		return false

--- a/internal/helperd/helperd_test.go
+++ b/internal/helperd/helperd_test.go
@@ -1,0 +1,61 @@
+// internal/helperd/helperd_test.go
+
+package helperd
+
+import (
+	"os"
+	"strconv"
+	"testing"
+)
+
+// activationListener must refuse to run outside socket
+// activation, and must refuse environment addressed to a
+// different process — consuming another process's fds would be
+// wrong in both directions.
+func TestActivationListenerRefusals(t *testing.T) {
+	unset := func() {
+		os.Unsetenv("LISTEN_PID")
+		os.Unsetenv("LISTEN_FDS")
+		os.Unsetenv("LISTEN_FDNAMES")
+	}
+	unset()
+	t.Cleanup(unset)
+
+	if _, err := activationListener(); err == nil {
+		t.Error("no LISTEN_PID: expected error")
+	}
+
+	os.Setenv("LISTEN_PID", "1") // not us
+	os.Setenv("LISTEN_FDS", "1")
+	if _, err := activationListener(); err == nil {
+		t.Error("foreign LISTEN_PID: expected error")
+	}
+	// The refusal path must still have scrubbed the env so no
+	// child of ours can mis-detect activation.
+	if os.Getenv("LISTEN_PID") != "" {
+		t.Error("LISTEN_PID not scrubbed")
+	}
+
+	os.Setenv("LISTEN_PID", strconv.Itoa(os.Getpid()))
+	os.Setenv("LISTEN_FDS", "2") // wrong count
+	if _, err := activationListener(); err == nil {
+		t.Error("two fds: expected error")
+	}
+
+	os.Setenv("LISTEN_PID", strconv.Itoa(os.Getpid()))
+	os.Setenv("LISTEN_FDS", "junk")
+	if _, err := activationListener(); err == nil {
+		t.Error("junk LISTEN_FDS: expected error")
+	}
+}
+
+// Serve refuses to run unprivileged with a message that names
+// the intended path (started by systemd), not a bare failure.
+func TestServeRefusesUnprivileged(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root")
+	}
+	if err := Serve("0.7.0"); err == nil {
+		t.Error("unprivileged Serve: expected error")
+	}
+}

--- a/internal/helperd/matrix.go
+++ b/internal/helperd/matrix.go
@@ -1,0 +1,121 @@
+// internal/helperd/matrix.go
+
+package helperd
+
+import (
+	"fmt"
+
+	"github.com/virtualprivatenode/vpn/internal/helper"
+	"github.com/virtualprivatenode/vpn/internal/installer"
+	"github.com/virtualprivatenode/vpn/internal/paths"
+)
+
+// ── The freshness matrix ─────────────────────────────────
+//
+// The staging board's one failure mode is staleness: an
+// operation changes reality and the board file carrying the old
+// fact survives. The defense is this table. It maps each verb
+// to the board facts that verb invalidates, and restage(verb)
+// — called by every handler as part of its postcondition — is
+// driven BY the table, so the mapping is the mechanism, not
+// documentation that can drift from it.
+//
+// Reading the matrix: a verb not listed here invalidates no
+// staged fact (a service restart changes no credential; a
+// package upgrade changes no onion address). The unit tests in
+// matrix_test.go walk every cell: every listed fact has a
+// stager, every stager is reachable from a verb or the
+// installer's staging step, and the sets match this table
+// exactly.
+
+// stagers maps each board file to the function that refreshes
+// it from current reality. All run as root.
+var stagers = map[string]func() error{
+	paths.StateOnionBitcoinP2P: func() error {
+		return installer.StageOnionHostname(
+			paths.TorBitcoinP2P+"/hostname",
+			paths.StateOnionBitcoinP2P)
+	},
+	paths.StateOnionLNDGRPC: func() error {
+		return installer.StageOnionHostname(
+			paths.TorLNDGRPC+"/hostname",
+			paths.StateOnionLNDGRPC)
+	},
+	paths.StateOnionLNDREST: func() error {
+		return installer.StageOnionHostname(
+			paths.TorLNDRESTHostname,
+			paths.StateOnionLNDREST)
+	},
+	paths.StateOnionSyncthing: func() error {
+		return installer.StageOnionHostname(
+			paths.TorSyncthingHostname,
+			paths.StateOnionSyncthing)
+	},
+	paths.StateLNDTLSCert:      installer.StageLNDTLSCert,
+	paths.StateLNDMacaroon:     installer.StageLNDMacaroon,
+	paths.StateSyncthingAPIKey: installer.StageSyncthingAPIKey,
+	paths.StateSyncthingDevID:  installer.StageSyncthingDeviceID,
+	paths.StateSSHPasswordAuth: installer.StageSSHAuthFact,
+}
+
+// freshnessMatrix: verb → board facts the verb invalidates and
+// therefore re-stages on success.
+var freshnessMatrix = map[string][]string{
+	// Rebuilding torrc restarts Tor; hidden-service dirs are
+	// (re)created and hostnames may newly exist. Onion KEYS
+	// persist, so existing addresses do not change — but a
+	// toggled-on service's hostname appears here for the first
+	// time, and re-staging the unchanged ones is free.
+	helper.VerbRebuildTorConfig: {
+		paths.StateOnionBitcoinP2P,
+		paths.StateOnionLNDGRPC,
+		paths.StateOnionLNDREST,
+		paths.StateOnionSyncthing,
+	},
+	// Wallet creation mints fresh macaroons; the staging verb
+	// exists exactly for that moment (and re-copies the cert,
+	// which is free).
+	helper.VerbStageLNDCredentials: {
+		paths.StateLNDTLSCert,
+		paths.StateLNDMacaroon,
+	},
+	// A P2P mode change alters the cert's contents (LND
+	// regenerates it via tlsautorefresh), so the staged copy
+	// is stale the moment LND restarts.
+	helper.VerbSetP2PMode: {
+		paths.StateLNDTLSCert,
+		paths.StateLNDMacaroon,
+	},
+	// A fresh Syncthing install generates a new identity and
+	// API key, and its Tor rebuild creates the web-UI onion.
+	helper.VerbSyncthingInstall: {
+		paths.StateSyncthingAPIKey,
+		paths.StateSyncthingDevID,
+		paths.StateOnionSyncthing,
+	},
+	// The SSH drop-in write changes effective password-auth
+	// state; the staged observation must follow it.
+	helper.VerbRebuildSSHConfig: {
+		paths.StateSSHPasswordAuth,
+	},
+}
+
+// restage refreshes every fact the given verb invalidates.
+// Failures here fail the VERB: an operation that succeeded but
+// left a stale board would be exactly the silent divergence the
+// board's contract forbids — better to surface it now, with the
+// journal naming the file.
+func restage(verb string) error {
+	for _, file := range freshnessMatrix[verb] {
+		st, ok := stagers[file]
+		if !ok {
+			return fmt.Errorf(
+				"no stager for %s (defect: matrix and stagers "+
+					"disagree)", file)
+		}
+		if err := st(); err != nil {
+			return fmt.Errorf("restage %s: %w", file, err)
+		}
+	}
+	return nil
+}

--- a/internal/helperd/matrix.go
+++ b/internal/helperd/matrix.go
@@ -21,9 +21,12 @@ import (
 // documentation that can drift from it.
 //
 // Reading the matrix: a verb not listed here invalidates no
-// staged fact (a service restart changes no credential; a
-// package upgrade changes no onion address). The unit tests in
-// matrix_test.go walk every cell: every listed fact has a
+// staged fact (a package upgrade changes no onion address). One
+// entry is conditional: service-action invalidates the staged
+// LND TLS certificate only when the unit acted on is lnd — the
+// handler applies the entry under that condition, because the
+// verb-keyed table cannot see verb parameters. The unit tests
+// in matrix_test.go walk every cell: every listed fact has a
 // stager, every stager is reachable from a verb or the
 // installer's staging step, and the sets match this table
 // exactly.
@@ -97,6 +100,15 @@ var freshnessMatrix = map[string][]string{
 	// state; the staged observation must follow it.
 	helper.VerbRebuildSSHConfig: {
 		paths.StateSSHPasswordAuth,
+	},
+	// An lnd start or restart can regenerate the TLS
+	// certificate (tlsautorefresh detects parameter changes and
+	// approaching expiry at startup), so the staged copy must
+	// follow. CONDITIONAL: the handler applies this entry only
+	// when the unit acted on is lnd and the action is not stop
+	// — no other unit changes a staged fact.
+	helper.VerbServiceAction: {
+		paths.StateLNDTLSCert,
 	},
 }
 

--- a/internal/helperd/matrix_test.go
+++ b/internal/helperd/matrix_test.go
@@ -1,0 +1,184 @@
+// internal/helperd/matrix_test.go
+
+package helperd
+
+import (
+	"testing"
+
+	"github.com/virtualprivatenode/vpn/internal/config"
+	"github.com/virtualprivatenode/vpn/internal/helper"
+	"github.com/virtualprivatenode/vpn/internal/installer"
+	"github.com/virtualprivatenode/vpn/internal/paths"
+)
+
+// ── Freshness-matrix tests ───────────────────────────────
+//
+// The staging board's failure mode is staleness, and the
+// freshness matrix is the defense — so the matrix itself is
+// pinned by tests. expectedMatrix below restates the ruled
+// verb × fact table INDEPENDENTLY of matrix.go; if either side
+// is edited alone, these tests fail and force the two back
+// into agreement.
+
+var expectedMatrix = map[string][]string{
+	helper.VerbRebuildTorConfig: {
+		paths.StateOnionBitcoinP2P,
+		paths.StateOnionLNDGRPC,
+		paths.StateOnionLNDREST,
+		paths.StateOnionSyncthing,
+	},
+	helper.VerbStageLNDCredentials: {
+		paths.StateLNDTLSCert,
+		paths.StateLNDMacaroon,
+	},
+	helper.VerbSetP2PMode: {
+		paths.StateLNDTLSCert,
+		paths.StateLNDMacaroon,
+	},
+	helper.VerbSyncthingInstall: {
+		paths.StateSyncthingAPIKey,
+		paths.StateSyncthingDevID,
+		paths.StateOnionSyncthing,
+	},
+	helper.VerbRebuildSSHConfig: {
+		paths.StateSSHPasswordAuth,
+	},
+}
+
+func TestFreshnessMatrixMatchesRuledTable(t *testing.T) {
+	for verb, wantFiles := range expectedMatrix {
+		got := freshnessMatrix[verb]
+		if len(got) != len(wantFiles) {
+			t.Errorf("%s: %d facts, want %d",
+				verb, len(got), len(wantFiles))
+			continue
+		}
+		for i, f := range wantFiles {
+			if got[i] != f {
+				t.Errorf("%s[%d] = %s, want %s",
+					verb, i, got[i], f)
+			}
+		}
+	}
+	for verb := range freshnessMatrix {
+		if _, ok := expectedMatrix[verb]; !ok {
+			t.Errorf(
+				"matrix has verb %s the expected table lacks — "+
+					"update BOTH deliberately", verb)
+		}
+	}
+}
+
+// Every fact in the matrix must have a stager, every verb in
+// the matrix must exist on the verb menu, and every stager key
+// must be a real board path.
+func TestFreshnessMatrixIsClosed(t *testing.T) {
+	boardFiles := map[string]bool{
+		paths.StateBitcoindRPCPass: true,
+		paths.StateLNDTLSCert:      true,
+		paths.StateLNDMacaroon:     true,
+		paths.StateOnionBitcoinP2P: true,
+		paths.StateOnionLNDGRPC:    true,
+		paths.StateOnionLNDREST:    true,
+		paths.StateOnionSyncthing:  true,
+		paths.StateSyncthingAPIKey: true,
+		paths.StateSyncthingDevID:  true,
+		paths.StateSSHPasswordAuth: true,
+	}
+	for verb, files := range freshnessMatrix {
+		if _, ok := verbs[verb]; !ok {
+			t.Errorf("matrix verb %s is not on the verb menu", verb)
+		}
+		for _, f := range files {
+			if !boardFiles[f] {
+				t.Errorf("%s re-stages unknown file %s", verb, f)
+			}
+			if _, ok := stagers[f]; !ok {
+				t.Errorf("%s: no stager registered for %s", verb, f)
+			}
+		}
+	}
+	for f := range stagers {
+		if !boardFiles[f] {
+			t.Errorf("stager registered for unknown file %s", f)
+		}
+	}
+}
+
+// restage must fail loudly on a matrix/stager mismatch instead
+// of silently skipping a fact.
+func TestRestageUnknownVerbIsNoop(t *testing.T) {
+	if err := restage("no-such-verb"); err != nil {
+		t.Errorf("unknown verb should re-stage nothing: %v", err)
+	}
+}
+
+// ── Step-name alignment ──────────────────────────────────
+//
+// Streaming verbs report progress by INDEX; the client renders
+// NAMES from the shared lists in the helper package. These
+// tests are what make drift between the two impossible to ship.
+
+func stepNames(steps []installer.InstallStep) []string {
+	out := make([]string, len(steps))
+	for i, s := range steps {
+		out[i] = s.Name
+	}
+	return out
+}
+
+func assertNamesEqual(t *testing.T, verb string,
+	server, shared []string) {
+	t.Helper()
+	if len(server) != len(shared) {
+		t.Fatalf("%s: server has %d steps, shared list %d",
+			verb, len(server), len(shared))
+	}
+	for i := range server {
+		if server[i] != shared[i] {
+			t.Errorf("%s step %d: server %q, shared %q",
+				verb, i, server[i], shared[i])
+		}
+	}
+}
+
+func TestSelfUpdateStepNamesAligned(t *testing.T) {
+	v := "0.7.1"
+	assertNamesEqual(t, helper.VerbSelfUpdate,
+		stepNames(installer.SelfUpdateSteps(v)),
+		helper.SelfUpdateStepNames(v))
+}
+
+func TestPackageUpdateStepNamesAligned(t *testing.T) {
+	assertNamesEqual(t, helper.VerbPackageUpdate,
+		stepNames(installer.PackageUpdateSteps()),
+		helper.PackageUpdateStepNames())
+}
+
+func TestSetP2PModeStepNamesAligned(t *testing.T) {
+	cfg := config.Default()
+	cfg.P2PMode = "hybrid"
+	cfg.LNDInstalled = true
+	server := stepNames(installer.P2PUpgradeSteps(cfg, "203.0.113.7"))
+	// The verb reports one extra step after the installer's
+	// three: re-staging the regenerated credentials.
+	server = append(server, "Restaging LND credentials")
+	assertNamesEqual(t, helper.VerbSetP2PMode,
+		server, helper.SetP2PModeStepNames())
+}
+
+func TestSyncthingInstallStepNamesAligned(t *testing.T) {
+	cfg := config.Default()
+	cfg.SyncthingInstalled = true
+	steps, _, err := installer.SyncthingInstallSteps(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := stepNames(steps)
+	// The verb reports one extra step: staging the new
+	// component's facts.
+	server = append(server, "Staging Syncthing facts")
+	assertNamesEqual(t, helper.VerbSyncthingInstall,
+		server, helper.SyncthingInstallStepNames(
+			installer.SyncthingVersionStr()))
+}

--- a/internal/helperd/matrix_test.go
+++ b/internal/helperd/matrix_test.go
@@ -43,6 +43,12 @@ var expectedMatrix = map[string][]string{
 	helper.VerbRebuildSSHConfig: {
 		paths.StateSSHPasswordAuth,
 	},
+	// Applied by the handler only for the lnd unit (start or
+	// restart): LND can regenerate its TLS certificate during
+	// startup, so the staged copy must follow.
+	helper.VerbServiceAction: {
+		paths.StateLNDTLSCert,
+	},
 }
 
 func TestFreshnessMatrixMatchesRuledTable(t *testing.T) {

--- a/internal/helperd/peercred_linux.go
+++ b/internal/helperd/peercred_linux.go
@@ -1,0 +1,44 @@
+// internal/helperd/peercred_linux.go
+
+//go:build linux
+
+package helperd
+
+import (
+	"net"
+	"syscall"
+)
+
+// peerCredentials carries the kernel's statement about the
+// process on the other end of a unix socket connection.
+type peerCredentials struct {
+	Uid uint32
+	Gid uint32
+	Pid int32
+}
+
+// peerCred reads SO_PEERCRED from a live connection without
+// stealing its fd. The uid/gid are kernel-recorded facts about
+// the connecting process at connect time; the pid is a
+// snapshot that may be reused, so it is logged as context but
+// never used for decisions.
+func peerCred(c *net.UnixConn) (*peerCredentials, error) {
+	raw, err := c.SyscallConn()
+	if err != nil {
+		return nil, err
+	}
+	var cred *syscall.Ucred
+	var credErr error
+	if err := raw.Control(func(fd uintptr) {
+		cred, credErr = syscall.GetsockoptUcred(int(fd),
+			syscall.SOL_SOCKET, syscall.SO_PEERCRED)
+	}); err != nil {
+		return nil, err
+	}
+	if credErr != nil {
+		return nil, credErr
+	}
+	return &peerCredentials{
+		Uid: cred.Uid, Gid: cred.Gid, Pid: cred.Pid,
+	}, nil
+}

--- a/internal/helperd/peercred_other.go
+++ b/internal/helperd/peercred_other.go
@@ -1,0 +1,27 @@
+// internal/helperd/peercred_other.go
+
+//go:build !linux
+
+package helperd
+
+import (
+	"errors"
+	"net"
+)
+
+// peerCredentials carries the kernel's statement about the
+// process on the other end of a unix socket connection.
+type peerCredentials struct {
+	Uid uint32
+	Gid uint32
+	Pid int32
+}
+
+// peerCred exists on non-Linux only so the tree compiles for
+// development. The helper runs exclusively on the node's
+// Debian target, where the Linux implementation applies; here
+// it refuses every connection.
+func peerCred(c *net.UnixConn) (*peerCredentials, error) {
+	return nil, errors.New(
+		"peer credentials are only supported on Linux")
+}

--- a/internal/helperd/verbs.go
+++ b/internal/helperd/verbs.go
@@ -1,0 +1,389 @@
+// internal/helperd/verbs.go
+
+package helperd
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/virtualprivatenode/vpn/internal/config"
+	"github.com/virtualprivatenode/vpn/internal/helper"
+	"github.com/virtualprivatenode/vpn/internal/installer"
+	"github.com/virtualprivatenode/vpn/internal/paths"
+	"github.com/virtualprivatenode/vpn/internal/system"
+)
+
+// ── The verb menu ────────────────────────────────────────
+//
+// Each verb: a typed parameter struct (decoded strictly),
+// validation against closed sets, the operation itself, a
+// postcondition where the outcome is checkable, and re-staging
+// of every board fact the operation invalidated (the freshness
+// matrix in matrix.go drives that last part — handlers call
+// restage(verb) rather than remembering individual files).
+//
+// Deadlines bound how long one verb may hold the serialized
+// queue. They are sized to the operation's legitimate worst
+// case — bitcoind alone is allowed 10 minutes to stop, a
+// package upgrade can take most of half an hour over Tor — so
+// a wedged operation fails loudly instead of blocking an
+// urgent service restart forever.
+
+type verbDef struct {
+	deadline time.Duration
+	handler  func(ctx *verbCtx, params json.RawMessage) (any, error)
+}
+
+var verbs = map[string]verbDef{
+	helper.VerbServiceAction:        {14 * time.Minute, verbServiceAction},
+	helper.VerbReboot:               {1 * time.Minute, verbReboot},
+	helper.VerbDirSize:              {2 * time.Minute, verbDirSize},
+	helper.VerbSetUserPassword:      {1 * time.Minute, verbSetUserPassword},
+	helper.VerbStageWalletPassword:  {6 * time.Minute, verbStageWalletPassword},
+	helper.VerbRemoveWalletPassword: {6 * time.Minute, verbRemoveWalletPassword},
+	helper.VerbStageLNDCredentials:  {3 * time.Minute, verbStageLNDCredentials},
+	helper.VerbRebuildSSHConfig:     {3 * time.Minute, verbRebuildSSHConfig},
+	helper.VerbRebuildTorConfig:     {4 * time.Minute, verbRebuildTorConfig},
+	helper.VerbPackageUpdate:        {30 * time.Minute, verbPackageUpdate},
+	helper.VerbSelfUpdate:           {15 * time.Minute, verbSelfUpdate},
+	helper.VerbSetP2PMode:           {8 * time.Minute, verbSetP2PMode},
+	helper.VerbSyncthingInstall:     {30 * time.Minute, verbSyncthingInstall},
+}
+
+// decode unmarshals params strictly: unknown fields are an
+// error, so a client/server drift surfaces as a loud refusal
+// instead of a silently ignored option.
+func decode(params json.RawMessage, into any) error {
+	dec := json.NewDecoder(strings.NewReader(string(params)))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(into); err != nil {
+		return fmt.Errorf("invalid parameters: %v", err)
+	}
+	return nil
+}
+
+// loadConfig reads the node's config root-side. Verbs use it
+// for facts the client must not be able to misstate (network,
+// installed components); the client remains the owner of
+// PERSISTING config changes after a verb succeeds.
+func loadConfig() (*config.AppConfig, error) {
+	cfg, err := config.Load()
+	if err != nil {
+		return nil, fmt.Errorf(
+			"read node config: %v — the node may not be "+
+				"installed", err)
+	}
+	return cfg, nil
+}
+
+// ── Service control ──────────────────────────────────────
+
+var allowedUnits = map[string]bool{
+	"tor": true, "bitcoind": true, "lnd": true, "syncthing": true,
+}
+var allowedActions = map[string]bool{
+	"start": true, "stop": true, "restart": true,
+}
+
+func verbServiceAction(_ *verbCtx, params json.RawMessage) (any, error) {
+	var p helper.ServiceActionParams
+	if err := decode(params, &p); err != nil {
+		return nil, err
+	}
+	if !allowedUnits[p.Unit] {
+		return nil, fmt.Errorf("unit %q is not managed here", p.Unit)
+	}
+	if !allowedActions[p.Action] {
+		return nil, fmt.Errorf("action %q is not supported", p.Action)
+	}
+	if err := system.SudoRun("systemctl", p.Action, p.Unit); err != nil {
+		return nil, err
+	}
+	// Postcondition: rc=0 means systemctl ran, not that the
+	// world changed. Ask systemd what state the unit is
+	// actually in now.
+	active := system.IsServiceActive(p.Unit)
+	switch p.Action {
+	case "stop":
+		if active {
+			return nil, fmt.Errorf(
+				"%s is still active after stop", p.Unit)
+		}
+	default:
+		if !active {
+			return nil, fmt.Errorf(
+				"%s is not active after %s — check: journalctl "+
+					"-u %s", p.Unit, p.Action, p.Unit)
+		}
+	}
+	return nil, nil
+}
+
+func verbReboot(ctx *verbCtx, _ json.RawMessage) (any, error) {
+	// Answer first, reboot after: the client gets its
+	// terminator before the box goes down.
+	ctx.afterEnd = func() {
+		if err := system.SudoRun("systemctl", "reboot"); err != nil {
+			auditErr("reboot",
+				`{"event":"error","detail":"reboot failed: %v"}`, err)
+		}
+	}
+	return nil, nil
+}
+
+// ── Sizes ────────────────────────────────────────────────
+
+func verbDirSize(_ *verbCtx, params json.RawMessage) (any, error) {
+	var p helper.DirSizeParams
+	if err := decode(params, &p); err != nil {
+		return nil, err
+	}
+	// Closed enum, not a path. "lnd" is the only entry: the
+	// bitcoin data dir's size comes from bitcoind's own RPC
+	// (size_on_disk) with no privileged call at all.
+	if p.Which != "lnd" {
+		return nil, fmt.Errorf("unknown directory %q", p.Which)
+	}
+	size := system.DirSize(paths.LNDDataDir)
+	if size == "N/A" {
+		return nil, errors.New("could not measure the LND data dir")
+	}
+	return helper.DirSizeResult{Size: size}, nil
+}
+
+// ── Passwords ────────────────────────────────────────────
+
+func verbSetUserPassword(_ *verbCtx, params json.RawMessage) (any, error) {
+	var p helper.SetUserPasswordParams
+	if err := decode(params, &p); err != nil {
+		return nil, err
+	}
+	if p.User != paths.AdminUser {
+		return nil, fmt.Errorf(
+			"only the %q user's password is managed here",
+			paths.AdminUser)
+	}
+	// Same rule as the client's input screen, enforced again
+	// at the boundary — the two share one constructor, so they
+	// cannot disagree.
+	pw, err := installer.NewLoginPassword(p.Password)
+	if err != nil {
+		return nil, err
+	}
+	if err := installer.SetUserPassword(p.User, pw); err != nil {
+		return nil, err
+	}
+	// An operator-chosen password supersedes any generated one
+	// that was never displayed (the unattended-install marker).
+	installer.ClearPasswordPendingMarker()
+	return nil, nil
+}
+
+// validateWalletPassword bounds the auto-unlock payload. LND
+// enforces its own minimum at wallet creation; here we only
+// refuse shapes that would corrupt the password file protocol.
+func validateWalletPassword(pw string) error {
+	if pw == "" {
+		return errors.New("wallet password is empty")
+	}
+	if len(pw) > 512 {
+		return errors.New("wallet password is implausibly long")
+	}
+	if strings.ContainsAny(pw, "\n\r") {
+		return errors.New("wallet password has a line break")
+	}
+	return nil
+}
+
+func verbStageWalletPassword(_ *verbCtx, params json.RawMessage) (any, error) {
+	var p helper.StageWalletPasswordParams
+	if err := decode(params, &p); err != nil {
+		return nil, err
+	}
+	if err := validateWalletPassword(p.Password); err != nil {
+		return nil, err
+	}
+	return nil, installer.SetupAutoUnlock(p.Password)
+}
+
+func verbRemoveWalletPassword(_ *verbCtx, _ json.RawMessage) (any, error) {
+	return nil, installer.DisableAutoUnlock()
+}
+
+// ── Credential staging ───────────────────────────────────
+
+func verbStageLNDCredentials(_ *verbCtx, _ json.RawMessage) (any, error) {
+	return nil, restage(helper.VerbStageLNDCredentials)
+}
+
+// ── Config writers (templates live on this side) ─────────
+
+func verbRebuildSSHConfig(_ *verbCtx, params json.RawMessage) (any, error) {
+	var p helper.RebuildSSHConfigParams
+	if err := decode(params, &p); err != nil {
+		return nil, err
+	}
+	// The zero-auth lockout guard and the validate-and-restore
+	// sequence live inside RebuildSSHHardeningConfig — at the
+	// write boundary, so every caller inherits them.
+	view := &config.AppConfig{
+		SSHPasswordAuthDisabled: p.PasswordAuthDisabled,
+	}
+	if err := installer.RebuildSSHHardeningConfig(view); err != nil {
+		return nil, err
+	}
+	return nil, restage(helper.VerbRebuildSSHConfig)
+}
+
+func verbRebuildTorConfig(_ *verbCtx, params json.RawMessage) (any, error) {
+	var p helper.RebuildTorConfigParams
+	if err := decode(params, &p); err != nil {
+		return nil, err
+	}
+	cfg, err := loadConfig()
+	if err != nil {
+		return nil, err
+	}
+	// The toggles select which fixed template blocks are
+	// present; everything else about the torrc comes from the
+	// root-side template and the node's own config.
+	cfg.LNDInstalled = p.LND
+	cfg.SyncthingInstalled = p.Syncthing
+	if err := installer.RebuildTorConfig(cfg); err != nil {
+		return nil, err
+	}
+	if err := installer.RestartTor(); err != nil {
+		return nil, err
+	}
+	return nil, restage(helper.VerbRebuildTorConfig)
+}
+
+// ── Streaming verbs ──────────────────────────────────────
+
+// runSteps executes installer steps sequentially, emitting one
+// progress event per completed step. The client renders these
+// in the same step widget the installer uses.
+func runSteps(ctx *verbCtx, steps []installer.InstallStep) error {
+	for i := range steps {
+		if err := steps[i].Fn(); err != nil {
+			return fmt.Errorf("%s: %v", steps[i].Name, err)
+		}
+		ctx.emitStep(i)
+	}
+	return nil
+}
+
+func verbPackageUpdate(ctx *verbCtx, _ json.RawMessage) (any, error) {
+	steps := installer.PackageUpdateSteps()
+	if err := runSteps(ctx, steps); err != nil {
+		return nil, err
+	}
+	// Postcondition: no packages left half-configured.
+	if out, err := system.RunOutput("dpkg", "--audit"); err != nil ||
+		strings.TrimSpace(out) != "" {
+		return nil, fmt.Errorf(
+			"packages left in an inconsistent state after "+
+				"upgrade (dpkg --audit: %v %s)", err,
+			strings.TrimSpace(out))
+	}
+	return nil, nil
+}
+
+func verbSelfUpdate(ctx *verbCtx, params json.RawMessage) (any, error) {
+	var p helper.SelfUpdateParams
+	if err := decode(params, &p); err != nil {
+		return nil, err
+	}
+	// Same-major gate, enforced HERE and not only in the
+	// client's rendering: a gate that lives only in UI copy is
+	// copy. A major release carries changes that need the
+	// operator to read its release notes first. (The strict
+	// version-shape validation lives inside SameMajor — the
+	// one choke point before the version reaches a URL.)
+	same, err := helper.SameMajor(ctx.version, p.Version)
+	if err != nil {
+		return nil, err
+	}
+	if !same {
+		return nil, fmt.Errorf(
+			"v%s is a major release — it is not installed "+
+				"through self-update; see its release notes",
+			p.Version)
+	}
+	// Download, GPG-verify, checksum-verify, and install — all
+	// on this side of the boundary. Nothing the unprivileged
+	// user staged is trusted anywhere in this path.
+	if err := runSteps(ctx,
+		installer.SelfUpdateSteps(p.Version)); err != nil {
+		return nil, err
+	}
+	// Exit after answering: the next activation of the helper
+	// runs the NEW binary, so helper and TUI can never disagree
+	// about versions for longer than one connection.
+	ctx.exitAfterEnd = true
+	return nil, nil
+}
+
+func verbSetP2PMode(ctx *verbCtx, params json.RawMessage) (any, error) {
+	var p helper.SetP2PModeParams
+	if err := decode(params, &p); err != nil {
+		return nil, err
+	}
+	if p.Mode != "tor" && p.Mode != "hybrid" {
+		return nil, fmt.Errorf("unknown P2P mode %q", p.Mode)
+	}
+	cfg, err := loadConfig()
+	if err != nil {
+		return nil, err
+	}
+	publicIP := ""
+	if p.Mode == "hybrid" {
+		// Derived here, from the kernel routing table — the
+		// client cannot supply an address for LND to advertise.
+		publicIP = system.PublicIPv4()
+		if publicIP == "" {
+			return nil, errors.New(
+				"could not determine this box's public IPv4 " +
+					"address — hybrid mode needs one")
+		}
+	}
+	cfg.P2PMode = p.Mode
+	steps := installer.P2PUpgradeSteps(cfg, publicIP)
+	if err := runSteps(ctx, steps); err != nil {
+		return nil, err
+	}
+	// The mode switch makes LND regenerate its TLS certificate
+	// (the cert's contents change), so the staged copy is now
+	// stale — re-stage it, reported as one more step.
+	if err := restage(helper.VerbSetP2PMode); err != nil {
+		return nil, err
+	}
+	ctx.emitStep(len(steps))
+	return nil, nil
+}
+
+func verbSyncthingInstall(ctx *verbCtx, _ json.RawMessage) (any, error) {
+	cfg, err := loadConfig()
+	if err != nil {
+		return nil, err
+	}
+	cfg.SyncthingInstalled = true
+	steps, password, err := installer.SyncthingInstallSteps(cfg)
+	if err != nil {
+		return nil, err
+	}
+	if err := runSteps(ctx, steps); err != nil {
+		return nil, err
+	}
+	// Stage the facts the admin user needs from the new
+	// component: API key, device ID, and the new onion
+	// hostname — reported as one more step.
+	if err := restage(helper.VerbSyncthingInstall); err != nil {
+		return nil, err
+	}
+	ctx.emitStep(len(steps))
+	return helper.SyncthingInstallResult{Password: password}, nil
+}

--- a/internal/helperd/verbs.go
+++ b/internal/helperd/verbs.go
@@ -25,12 +25,15 @@ import (
 // matrix in matrix.go drives that last part — handlers call
 // restage(verb) rather than remembering individual files).
 //
-// Deadlines bound how long one verb may hold the serialized
-// queue. They are sized to the operation's legitimate worst
-// case — bitcoind alone is allowed 10 minutes to stop, a
-// package upgrade can take most of half an hour over Tor — so
-// a wedged operation fails loudly instead of blocking an
-// urgent service restart forever.
+// Deadlines bound the connection's socket I/O for one verb.
+// They are sized to the operation's legitimate worst case —
+// bitcoind alone is allowed 10 minutes to stop, a package
+// upgrade can take most of half an hour over Tor. A deadline
+// alone cannot cut short a wedged SUBPROCESS (nothing does
+// socket I/O while one runs); the bounds there live with the
+// subprocesses themselves — download timeouts and retry caps
+// (system.doDownload), apt's Acquire timeout configuration,
+// and systemd's per-unit stop timeouts.
 
 type verbDef struct {
 	deadline time.Duration

--- a/internal/helperd/verbs.go
+++ b/internal/helperd/verbs.go
@@ -119,6 +119,21 @@ func verbServiceAction(_ *verbCtx, params json.RawMessage) (any, error) {
 					"-u %s", p.Unit, p.Action, p.Unit)
 		}
 	}
+	// LND rewrites its TLS certificate during startup when its
+	// parameters changed or the certificate nears expiry
+	// (tlsautorefresh in lnd.conf), so a start or restart of
+	// the lnd unit can invalidate the staged certificate copy
+	// the console reads. Re-stage it so the board keeps
+	// matching the certificate LND actually serves. The
+	// freshness matrix carries this as service-action's entry;
+	// the unit condition lives here because whether the
+	// invalidation happened depends on a verb parameter, which
+	// the verb-keyed table cannot express alone.
+	if p.Unit == "lnd" && p.Action != "stop" {
+		if err := restage(helper.VerbServiceAction); err != nil {
+			return nil, err
+		}
+	}
 	return nil, nil
 }
 

--- a/internal/helperd/verbs_test.go
+++ b/internal/helperd/verbs_test.go
@@ -1,0 +1,191 @@
+// internal/helperd/verbs_test.go
+
+package helperd
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/virtualprivatenode/vpn/internal/helper"
+)
+
+// Every verb on the menu carries a deadline: an operation with
+// no ceiling could hold the serialized queue forever.
+func TestEveryVerbHasDeadline(t *testing.T) {
+	if len(verbs) == 0 {
+		t.Fatal("empty verb menu")
+	}
+	for name, def := range verbs {
+		if def.deadline <= 0 {
+			t.Errorf("%s: no deadline", name)
+		}
+		if def.handler == nil {
+			t.Errorf("%s: no handler", name)
+		}
+		if def.deadline > time.Hour {
+			t.Errorf("%s: deadline %v is implausibly long",
+				name, def.deadline)
+		}
+	}
+}
+
+// The menu is closed: exactly the ruled verbs, nothing else.
+// Adding a verb must be a deliberate act that updates this
+// list too.
+func TestVerbMenuIsExactlyTheRuledSet(t *testing.T) {
+	want := []string{
+		helper.VerbServiceAction,
+		helper.VerbReboot,
+		helper.VerbDirSize,
+		helper.VerbSetUserPassword,
+		helper.VerbStageWalletPassword,
+		helper.VerbRemoveWalletPassword,
+		helper.VerbStageLNDCredentials,
+		helper.VerbRebuildSSHConfig,
+		helper.VerbRebuildTorConfig,
+		helper.VerbPackageUpdate,
+		helper.VerbSelfUpdate,
+		helper.VerbSetP2PMode,
+		helper.VerbSyncthingInstall,
+	}
+	if len(verbs) != len(want) {
+		t.Errorf("verb menu has %d entries, want %d",
+			len(verbs), len(want))
+	}
+	for _, v := range want {
+		if _, ok := verbs[v]; !ok {
+			t.Errorf("menu is missing %s", v)
+		}
+	}
+}
+
+func raw(t *testing.T, v any) json.RawMessage {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+// Parameter validation refuses everything outside the closed
+// sets, before any side effect. (Only refusal paths run here —
+// success paths mutate a system and belong to the live run.)
+func TestServiceActionValidation(t *testing.T) {
+	ctx := &verbCtx{}
+	cases := []helper.ServiceActionParams{
+		{Unit: "sshd", Action: "restart"},     // not a managed unit
+		{Unit: "bitcoind", Action: "disable"}, // not an allowed action
+		{Unit: "", Action: ""},
+		{Unit: "bitcoind; rm -rf /", Action: "start"},
+	}
+	for _, c := range cases {
+		if _, err := verbServiceAction(ctx, raw(t, c)); err == nil {
+			t.Errorf("accepted %+v", c)
+		}
+	}
+	// Unknown fields refuse too (strict decoding).
+	if _, err := verbServiceAction(ctx, json.RawMessage(
+		`{"unit":"tor","action":"restart","extra":1}`)); err == nil {
+		t.Error("accepted unknown params field")
+	}
+}
+
+func TestDirSizeValidation(t *testing.T) {
+	ctx := &verbCtx{}
+	for _, which := range []string{
+		"bitcoin", "", "/etc", "../lnd", "lnd/..",
+	} {
+		if _, err := verbDirSize(ctx, raw(t,
+			helper.DirSizeParams{Which: which})); err == nil {
+			t.Errorf("accepted which=%q", which)
+		}
+	}
+}
+
+func TestSetUserPasswordValidation(t *testing.T) {
+	ctx := &verbCtx{}
+	long := strings.Repeat("a", 20)
+	cases := []helper.SetUserPasswordParams{
+		{User: "root", Password: long},
+		{User: "bitcoin", Password: long},
+		{User: "", Password: long},
+		{User: "vpn", Password: "short"}, // under the minimum
+		{User: "vpn", Password: "with\nnl" + long},
+		{User: "vpn", Password: ""},
+	}
+	for _, c := range cases {
+		if _, err := verbSetUserPassword(ctx, raw(t, c)); err == nil {
+			t.Errorf("accepted user=%q pwlen=%d",
+				c.User, len(c.Password))
+		}
+	}
+}
+
+func TestWalletPasswordValidation(t *testing.T) {
+	if err := validateWalletPassword(""); err == nil {
+		t.Error("accepted empty wallet password")
+	}
+	if err := validateWalletPassword(
+		strings.Repeat("x", 513)); err == nil {
+		t.Error("accepted oversized wallet password")
+	}
+	if err := validateWalletPassword("a\nb"); err == nil {
+		t.Error("accepted wallet password with newline")
+	}
+	if err := validateWalletPassword("correct horse"); err != nil {
+		t.Errorf("rejected a normal wallet password: %v", err)
+	}
+}
+
+func TestSetP2PModeValidation(t *testing.T) {
+	ctx := &verbCtx{}
+	for _, mode := range []string{"", "clearnet", "Hybrid", "both"} {
+		if _, err := verbSetP2PMode(ctx, raw(t,
+			helper.SetP2PModeParams{Mode: mode})); err == nil {
+			t.Errorf("accepted mode=%q", mode)
+		}
+	}
+}
+
+// The self-update gate refuses before any network or disk
+// activity: bad target shapes, cross-major targets, and a
+// non-release running version all stop at the boundary.
+func TestSelfUpdateGate(t *testing.T) {
+	ctx := &verbCtx{version: "0.7.0"}
+	for _, target := range []string{
+		"", "dev", "v0.7.1", "0.7", "1.0.0", "2.3.4",
+		"0.7.1-rc1", "0.7.1;curl evil",
+	} {
+		if _, err := verbSelfUpdate(ctx, raw(t,
+			helper.SelfUpdateParams{
+				Version: target,
+			})); err == nil {
+			t.Errorf("gate passed target %q", target)
+		}
+	}
+	// A dev build refuses everything (cannot prove same-major).
+	dev := &verbCtx{version: "dev"}
+	if _, err := verbSelfUpdate(dev, raw(t,
+		helper.SelfUpdateParams{Version: "0.7.1"})); err == nil {
+		t.Error("dev build accepted a self-update")
+	}
+}
+
+// decode is strict: unknown fields and malformed JSON refuse.
+func TestDecodeStrict(t *testing.T) {
+	var p helper.RebuildSSHConfigParams
+	if err := decode(json.RawMessage(
+		`{"password_auth_disabled":true,"bonus":1}`), &p); err == nil {
+		t.Error("accepted unknown field")
+	}
+	if err := decode(json.RawMessage(`{`), &p); err == nil {
+		t.Error("accepted malformed JSON")
+	}
+	if err := decode(json.RawMessage(
+		`{"password_auth_disabled":true}`), &p); err != nil {
+		t.Errorf("rejected valid params: %v", err)
+	}
+}

--- a/internal/installer/bitcoin.go
+++ b/internal/installer/bitcoin.go
@@ -54,11 +54,21 @@ func extractAndInstallBitcoin(version, workDir string) error {
 	return nil
 }
 
-// BuildBitcoinConfig generates bitcoin.conf content from config state.
-// Pure logic — no side effects.
-func BuildBitcoinConfig(cfg *config.AppConfig) string {
+// BuildBitcoinConfig generates bitcoin.conf content from config
+// state. Pure logic — no side effects. rpcauthLine, when
+// non-empty, is the salted-hash credential line for this node's
+// own tooling (see rpcauth.go); it is placed in the GLOBAL
+// section deliberately — auth options are not network-scoped,
+// and on testnet4 an appended line would land inside the
+// [testnet4] section.
+func BuildBitcoinConfig(cfg *config.AppConfig, rpcauthLine string) string {
 	net := cfg.NetworkConfig()
 	pruneMB := cfg.PruneSize * 1000
+
+	auth := ""
+	if rpcauthLine != "" {
+		auth = rpcauthLine + "\n"
+	}
 
 	if net.Name == "testnet4" {
 		return fmt.Sprintf(`# Virtual Private Node — Bitcoin Core
@@ -71,7 +81,7 @@ maxmempool=300
 proxy=127.0.0.1:9050
 listen=1
 listenonion=1
-
+%s
 [testnet4]
 bind=127.0.0.1
 rpcbind=127.0.0.1
@@ -79,7 +89,7 @@ rpcport=%d
 rpcallowip=127.0.0.1
 zmqpubrawblock=tcp://127.0.0.1:%d
 zmqpubrawtx=tcp://127.0.0.1:%d
-`, net.BitcoinFlag, pruneMB, cfg.DbCacheMB(),
+`, net.BitcoinFlag, pruneMB, cfg.DbCacheMB(), auth,
 			net.RPCPort, net.ZMQBlockPort, net.ZMQTxPort)
 	}
 
@@ -92,19 +102,27 @@ maxmempool=300
 proxy=127.0.0.1:9050
 listen=1
 listenonion=1
-
+%s
 bind=127.0.0.1
 rpcbind=127.0.0.1
 rpcport=%d
 rpcallowip=127.0.0.1
 zmqpubrawblock=tcp://127.0.0.1:%d
 zmqpubrawtx=tcp://127.0.0.1:%d
-`, pruneMB, cfg.DbCacheMB(),
+`, pruneMB, cfg.DbCacheMB(), auth,
 		net.RPCPort, net.ZMQBlockPort, net.ZMQTxPort)
 }
 
+// writeBitcoinConfig writes bitcoin.conf with a FRESH rpcauth
+// credential, staging the matching password on the board in
+// the same operation — the hashed line and the cleartext are
+// only ever replaced together, so they cannot drift apart.
 func writeBitcoinConfig(cfg *config.AppConfig) error {
-	content := BuildBitcoinConfig(cfg)
+	rpcauthLine, err := writeRPCAuthCredential()
+	if err != nil {
+		return err
+	}
+	content := BuildBitcoinConfig(cfg, rpcauthLine)
 	if err := system.SudoWriteFile(paths.BitcoinConf, []byte(content), 0640); err != nil {
 		return err
 	}

--- a/internal/installer/bitcoin.go
+++ b/internal/installer/bitcoin.go
@@ -153,6 +153,13 @@ WantedBy=multi-user.target
 	return system.SudoWriteFile(paths.BitcoindService, []byte(content), 0644)
 }
 
+// startBitcoind enables and starts Bitcoin Core. `systemctl
+// restart` rather than `start`, deliberately: start is a no-op
+// on a service that is already running, and an install pass can
+// run on a box where bitcoind already runs under a PREVIOUS
+// unit and config (reinstall, migration). Restart makes the
+// unit and config this run just wrote the ones actually in
+// effect; on a fresh box the two commands are equivalent.
 func startBitcoind() error {
 	if err := system.SudoRun("systemctl", "daemon-reload"); err != nil {
 		return err
@@ -160,5 +167,5 @@ func startBitcoind() error {
 	if err := system.SudoRun("systemctl", "enable", "bitcoind"); err != nil {
 		return err
 	}
-	return system.SudoRun("systemctl", "start", "bitcoind")
+	return system.SudoRun("systemctl", "restart", "bitcoind")
 }

--- a/internal/installer/bitcoin_test.go
+++ b/internal/installer/bitcoin_test.go
@@ -6,12 +6,13 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/virtualprivatenode/vpn/internal/bitcoin"
 	"github.com/virtualprivatenode/vpn/internal/config"
 )
 
 func TestBitcoinConfigMainnet(t *testing.T) {
 	cfg := config.Default()
-	content := BuildBitcoinConfig(cfg)
+	content := BuildBitcoinConfig(cfg, "")
 
 	required := []string{
 		"server=1",
@@ -46,7 +47,7 @@ func TestBitcoinConfigTestnet4(t *testing.T) {
 		PruneSize: 25,
 		P2PMode:   "tor",
 	}
-	content := BuildBitcoinConfig(cfg)
+	content := BuildBitcoinConfig(cfg, "")
 
 	required := []string{
 		"testnet4=1",
@@ -65,7 +66,7 @@ func TestBitcoinConfigTestnet4(t *testing.T) {
 
 func TestBitcoinConfigAlwaysHasProxy(t *testing.T) {
 	cfg := config.Default()
-	content := BuildBitcoinConfig(cfg)
+	content := BuildBitcoinConfig(cfg, "")
 	if !strings.Contains(content, "proxy=127.0.0.1:9050") {
 		t.Error("bitcoin config must always have Tor proxy")
 	}
@@ -73,7 +74,7 @@ func TestBitcoinConfigAlwaysHasProxy(t *testing.T) {
 
 func TestBitcoinConfigAlwaysHasServer(t *testing.T) {
 	cfg := config.Default()
-	content := BuildBitcoinConfig(cfg)
+	content := BuildBitcoinConfig(cfg, "")
 	if !strings.Contains(content, "server=1") {
 		t.Error("bitcoin config must always have server=1")
 	}
@@ -81,7 +82,7 @@ func TestBitcoinConfigAlwaysHasServer(t *testing.T) {
 
 func TestBitcoinConfigHeader(t *testing.T) {
 	cfg := config.Default()
-	content := BuildBitcoinConfig(cfg)
+	content := BuildBitcoinConfig(cfg, "")
 	if !strings.Contains(content, "Virtual Private Node") {
 		t.Error("bitcoin config should have VPN header comment")
 	}
@@ -89,8 +90,46 @@ func TestBitcoinConfigHeader(t *testing.T) {
 
 func TestBitcoinConfigWalletDisabled(t *testing.T) {
 	cfg := config.Default()
-	content := BuildBitcoinConfig(cfg)
+	content := BuildBitcoinConfig(cfg, "")
 	if !strings.Contains(content, "disablewallet=1") {
 		t.Error("bitcoin config must have disablewallet=1")
+	}
+}
+
+// The rpcauth credential line must land in the GLOBAL section:
+// auth options are not network-scoped, and on testnet4 a line
+// appended at the end would fall inside [testnet4].
+func TestBitcoinConfigRPCAuthPlacement(t *testing.T) {
+	line := "rpcauth=vpn:aabb$ccdd"
+
+	cfg := config.Default()
+	if got := BuildBitcoinConfig(cfg, line); !strings.Contains(
+		got, line+"\n") {
+		t.Error("mainnet config missing rpcauth line")
+	}
+
+	tn := &config.AppConfig{
+		Network: "testnet4", PruneSize: 25, P2PMode: "tor",
+	}
+	got := BuildBitcoinConfig(tn, line)
+	authIdx := strings.Index(got, line)
+	sectIdx := strings.Index(got, "[testnet4]")
+	if authIdx == -1 || sectIdx == -1 {
+		t.Fatalf("missing rpcauth (%d) or section (%d)",
+			authIdx, sectIdx)
+	}
+	if authIdx > sectIdx {
+		t.Error("rpcauth line landed inside the [testnet4] " +
+			"section — it must be global")
+	}
+}
+
+// The RPC identity the conf grants and the identity the client
+// authenticates as are declared in two packages (import
+// direction); this pins them together.
+func TestBitcoindRPCUserAgreesWithClient(t *testing.T) {
+	if BitcoindRPCUser != bitcoin.RPCUser {
+		t.Errorf("installer says RPC user %q, client says %q",
+			BitcoindRPCUser, bitcoin.RPCUser)
 	}
 }

--- a/internal/installer/handoff.go
+++ b/internal/installer/handoff.go
@@ -128,7 +128,10 @@ func printConnectInstructions() {
 // unreadable, -g unsupported) report false: the banner stays,
 // which only nags, never locks out.
 func AdminLoginObserved() bool {
-	out, err := system.SudoRunOutput("journalctl",
+	// No privilege on either calling side: root reads the
+	// journal freely, and the admin user reads it through
+	// systemd-journal group membership (granted at install).
+	out, err := system.RunOutput("journalctl",
 		"-u", "ssh", "--no-pager", "-o", "cat",
 		"-g", "Accepted")
 	if err != nil {

--- a/internal/installer/handoff.go
+++ b/internal/installer/handoff.go
@@ -120,6 +120,24 @@ func printConnectInstructions() {
 		"\n\n  Connect to your node:\n\n    ssh %s\n\n", target)
 }
 
+// printConsoleOnlyInstructions replaces the ssh hint when the
+// completed install left no SSH way in — no keys copied and
+// password login over SSH observed off, the end state consented
+// to by name with --allow-console-only. An ssh line here would
+// be affirmatively misleading: it cannot work until the
+// operator adds a key or enables password login. This is a
+// statement of the reached end state, not a warning — the
+// consent already happened, on the command line.
+func printConsoleOnlyInstructions() {
+	fmt.Printf("\n  Install complete."+
+		"\n\n  This box has no SSH way in: no SSH keys were"+
+		"\n  installed and password login over SSH is disabled."+
+		"\n  Log in as %q at your provider console with the"+
+		"\n  login password, then add an SSH key or enable"+
+		"\n  password login from the node console (System)."+
+		"\n\n", paths.AdminUser)
+}
+
 // AdminLoginObserved reports whether sshd's journal shows an
 // accepted login for the admin user. Evidence for clearing the
 // first-run verification banner: the admin user exists only

--- a/internal/installer/helperstep.go
+++ b/internal/installer/helperstep.go
@@ -1,0 +1,169 @@
+// internal/installer/helperstep.go
+
+package installer
+
+// The install steps that stand up the runtime privilege
+// boundary: the root helper's socket-activated units, the admin
+// user's journal-read access, and the staging board. Together
+// with identity.access having stopped granting sudo, these are
+// what make the end state true: the admin user holds no root
+// privilege of any kind — it can request the helper's fixed
+// operations over the socket, read the journal, and read the
+// staged facts, and that is all.
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/virtualprivatenode/vpn/internal/logger"
+	"github.com/virtualprivatenode/vpn/internal/paths"
+	"github.com/virtualprivatenode/vpn/internal/system"
+)
+
+// helperSocketUnit is the .socket unit. The socket node's
+// ownership and mode are the authentication for the privilege
+// boundary: systemd creates the node root:vpn 0660 BEFORE any
+// helper process exists, so there is no bind-then-chmod window
+// where it is world-connectable.
+const helperSocketUnit = `[Unit]
+Description=vpn root helper control socket
+
+[Socket]
+ListenStream=` + paths.HelperSocket + `
+# root:vpn 0660 — the mode is applied when systemd creates the
+# node, so the socket is never briefly world-connectable. These
+# permissions ARE the authentication; the helper additionally
+# verifies each connecting process's uid (SO_PEERCRED).
+SocketUser=root
+SocketGroup=` + paths.AdminUser + `
+SocketMode=0660
+# Default, stated for the record: one helper process receives
+# the listening socket and serves connections one at a time.
+Accept=no
+# Remove the node on a deliberate stop of this socket unit.
+# The helper's own idle exit does not stop the socket unit and
+# keeps the node in place.
+RemoveOnStop=yes
+
+[Install]
+WantedBy=sockets.target
+`
+
+// helperServiceUnit is the .service unit. It has no [Install]
+// section on purpose: the service is only ever started by
+// socket traffic, never enabled directly.
+const helperServiceUnit = `[Unit]
+Description=vpn root helper (socket-activated)
+# systemd's defaults, restated so they are visible: at most 5
+# starts per 10 seconds, after which activation is refused and
+# the SOCKET unit enters a failed state until
+# ` + "`systemctl reset-failed vpn-helperd.socket`" + `. The helper's
+# 120-second idle exit keeps normal use far below this budget
+# (steady state is at most one start per idle period).
+StartLimitIntervalSec=10s
+StartLimitBurst=5
+
+[Service]
+# exec, not simple: the start job fails if the binary is
+# missing or broken (matters right after a self-update), and
+# that failure is visible in systemctl status immediately.
+Type=exec
+ExecStart=` + paths.BinaryPath + ` helperd
+# No supervisor restarts: socket activation IS the restart
+# path. Restart=always would loop on every clean idle exit and
+# drive the start-rate limit into refusing real work.
+Restart=no
+# Audit trail: stdout/stderr go to the journal under this
+# identifier. The admin user can read it (systemd-journal
+# group) but cannot alter it.
+SyslogIdentifier=vpn-helperd
+# Confinement that composes with a root helper that must write
+# /etc and /var and run apt: private /tmp and no access into
+# home directories. Broader sandboxing (ProtectSystem=) would
+# break the helper's actual job.
+PrivateTmp=yes
+ProtectHome=yes
+`
+
+// installHelperUnits is the helper.enable step: write both
+// units, reload systemd, enable and start the socket, and
+// verify the socket unit is actually listening.
+func installHelperUnits() error {
+	if err := system.SudoWriteFile(paths.HelperSocketUnit,
+		[]byte(helperSocketUnit), 0644); err != nil {
+		return err
+	}
+	if err := system.SudoWriteFile(paths.HelperServiceUnit,
+		[]byte(helperServiceUnit), 0644); err != nil {
+		return err
+	}
+	if err := system.SudoRun("systemctl", "daemon-reload"); err != nil {
+		return err
+	}
+	if err := system.SudoRun("systemctl", "enable", "--now",
+		paths.HelperSocketUnitName); err != nil {
+		return err
+	}
+	// Postcondition: the socket unit reports active AND the
+	// node exists with the expected ownership story (root-owned
+	// file node; systemd applied SocketMode at creation).
+	if !system.IsServiceActive(paths.HelperSocketUnitName) {
+		return fmt.Errorf("%s is not active after enable",
+			paths.HelperSocketUnitName)
+	}
+	if _, err := os.Stat(paths.HelperSocket); err != nil {
+		return fmt.Errorf(
+			"helper socket node missing after enable: %w", err)
+	}
+	logger.Install("helper socket enabled at %s (root:%s 0660)",
+		paths.HelperSocket, paths.AdminUser)
+	return nil
+}
+
+// setupJournalAccess is the journal.access step: make journal
+// storage persistent (an audit trail that vanishes at reboot
+// is not much of a record) and let the admin user read it.
+func setupJournalAccess() error {
+	// Persistent journald storage hinges on /var/log/journal
+	// existing (Storage=auto). Assert it on the actual box
+	// rather than trusting packaging defaults; the tmpfiles
+	// pass applies the packaged ownership/ACLs that make the
+	// systemd-journal group model work.
+	if _, err := os.Stat("/var/log/journal"); os.IsNotExist(err) {
+		if err := os.MkdirAll("/var/log/journal", 0o755); err != nil {
+			return fmt.Errorf("create /var/log/journal: %w", err)
+		}
+		if err := system.SudoRun("systemd-tmpfiles", "--create",
+			"--prefix", "/var/log/journal"); err != nil {
+			return err
+		}
+		if err := system.SudoRun("journalctl", "--flush"); err != nil {
+			return err
+		}
+		logger.Install("journald storage switched to persistent")
+	}
+
+	// systemd-journal membership grants read on ALL system
+	// journals — sshd auth lines included, which the first-run
+	// banner needs. Read-only: members cannot write or rewrite
+	// journal files. -aG, never -G: a bare -G REPLACES the
+	// supplementary group set.
+	if err := system.SudoRun("usermod", "-aG",
+		"systemd-journal", paths.AdminUser); err != nil {
+		return err
+	}
+	// Postcondition: the membership is really there.
+	out, err := system.RunOutput("id", "-nG", paths.AdminUser)
+	if err != nil {
+		return fmt.Errorf("verify group membership: %w", err)
+	}
+	for _, g := range strings.Fields(out) {
+		if g == "systemd-journal" {
+			return nil
+		}
+	}
+	return fmt.Errorf(
+		"%s is not in systemd-journal after usermod (groups: %s)",
+		paths.AdminUser, out)
+}

--- a/internal/installer/helperstep.go
+++ b/internal/installer/helperstep.go
@@ -78,12 +78,18 @@ Restart=no
 # identifier. The admin user can read it (systemd-journal
 # group) but cannot alter it.
 SyslogIdentifier=vpn-helperd
-# Confinement that composes with a root helper that must write
-# /etc and /var and run apt: private /tmp and no access into
-# home directories. Broader sandboxing (ProtectSystem=) would
+# Confinement for a root helper that must write /etc and /var
+# and run apt: private /tmp, and home mounted read-only. Note:
+# ProtectHome=read-only, NOT =yes, is load-bearing. The
+# password-auth lockout guard (the rebuild-ssh-config verb)
+# reads the admin user's authorized_keys under /home to refuse
+# stranding the box; hiding home (=yes) makes it read an empty
+# /home and wrongly refuse every disable. Read-only still stops
+# the helper from writing home, and the node's secrets live in
+# /var/lib, not home. Broader sandboxing (ProtectSystem=) would
 # break the helper's actual job.
 PrivateTmp=yes
-ProtectHome=yes
+ProtectHome=read-only
 `
 
 // installHelperUnits is the helper.enable step: write both

--- a/internal/installer/identity.go
+++ b/internal/installer/identity.go
@@ -188,12 +188,18 @@ type InstallDecisions struct {
 }
 
 // applyIdentityAccess is the identity.access step: create the
-// admin user, grant NOPASSWD sudo (commit 7 deletes this — the
-// TUI still runs on sudo until the root helper lands), write the
-// confirmed keys, set the login password, and configure the
-// SSH-login auto-launch. Idempotent — safe to re-run after an
-// interrupt (adduser is guarded, writes overwrite, chpasswd
-// resets to the same password).
+// admin user, write the confirmed keys, set the login
+// password, and configure the SSH-login auto-launch.
+// Idempotent — safe to re-run after an interrupt (adduser is
+// guarded, writes overwrite, chpasswd resets to the same
+// password).
+//
+// What this step deliberately does NOT do: grant sudo. The
+// admin user has no sudo rights at all — privileged operations
+// go through the root helper's socket, and any sudoers rule
+// from an earlier build of this software is REMOVED here.
+// The journal-read group and the helper's units are set up by
+// their own steps (helper.enable, journal.access).
 func applyIdentityAccess(dec *InstallDecisions) error {
 	if _, err := user.Lookup(paths.AdminUser); err != nil {
 		if err := system.SudoRun("adduser",
@@ -204,10 +210,15 @@ func applyIdentityAccess(dec *InstallDecisions) error {
 		}
 	}
 
-	sudoers := paths.AdminUser + " ALL=(ALL) NOPASSWD:ALL\n"
-	if err := system.SudoWriteFile(
-		paths.AdminSudoers, []byte(sudoers), 0440); err != nil {
-		return fmt.Errorf("write sudoers rule: %w", err)
+	// Remove any NOPASSWD grant an earlier build wrote. (No
+	// released binary shipped one under this user's name, but
+	// the removal is one idempotent call and makes the zero-
+	// sudo end state unconditional.)
+	if err := os.Remove(paths.AdminSudoers); err != nil &&
+		!os.IsNotExist(err) {
+		return fmt.Errorf(
+			"remove old sudoers rule %s: %w",
+			paths.AdminSudoers, err)
 	}
 
 	if len(dec.Keys) > 0 {

--- a/internal/installer/lnd.go
+++ b/internal/installer/lnd.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/virtualprivatenode/vpn/internal/config"
+	"github.com/virtualprivatenode/vpn/internal/helper"
 	"github.com/virtualprivatenode/vpn/internal/logger"
 	"github.com/virtualprivatenode/vpn/internal/paths"
 	"github.com/virtualprivatenode/vpn/internal/system"
@@ -225,8 +226,10 @@ func startLND() error {
 }
 
 func setupAutoUnlock(password string) error {
-	// Write password to a secure temp file, then sudo move it.
-	// os.CreateTemp uses O_EXCL to prevent symlink attacks.
+	// Write the password to a secure temp file, then move it
+	// into place with the service user's ownership (this runs
+	// as root). os.CreateTemp uses O_EXCL to prevent symlink
+	// attacks.
 	tmpFile, err := os.CreateTemp("", "vpn-wallet-pw-")
 	if err != nil {
 		return fmt.Errorf("create temp: %w", err)
@@ -284,18 +287,20 @@ WantedBy=multi-user.target
 	return system.SudoRun("systemctl", "restart", "lnd")
 }
 
-// disableAutoUnlock removes the wallet password file
-// and rewrites the LND systemd service back to its
-// initial (no auto-unlock) form, then restarts LND.
-// After this returns successfully, LND will require
-// manual unlock (e.g. `lncli unlock`) on next startup.
+// disableAutoUnlock rewrites the LND systemd service back to
+// its initial (no auto-unlock) form, restarts LND, and only
+// THEN removes the wallet password file. After this returns
+// successfully, LND requires manual unlock (e.g. `lncli
+// unlock`) on next startup.
+//
+// The password file is removed LAST, deliberately. The old
+// order (remove first) meant a failure partway left the
+// security-relevant half already done while the operation
+// reported failure and the app still believed auto-unlock was
+// enabled — the state on disk, the service, and the config all
+// disagreed. With removal last, any failure leaves the file in
+// place and the operation honestly failed; a retry converges.
 func disableAutoUnlock() error {
-	// SudoRunSilent because the file may not exist if
-	// called from an inconsistent state — that's fine,
-	// we just want it gone.
-	system.SudoRunSilent(
-		"rm", "-f", paths.LNDWalletPassword)
-
 	if err := writeLNDServiceInitial(systemUser); err != nil {
 		return fmt.Errorf("rewrite service: %w", err)
 	}
@@ -303,8 +308,16 @@ func disableAutoUnlock() error {
 		"systemctl", "daemon-reload"); err != nil {
 		return fmt.Errorf("daemon-reload: %w", err)
 	}
-	return system.SudoRun(
-		"systemctl", "restart", "lnd")
+	if err := system.SudoRun(
+		"systemctl", "restart", "lnd"); err != nil {
+		return fmt.Errorf("restart lnd: %w", err)
+	}
+	// SudoRunSilent because the file may not exist if called
+	// from an inconsistent state — that's fine, we just want
+	// it gone.
+	system.SudoRunSilent(
+		"rm", "-f", paths.LNDWalletPassword)
+	return nil
 }
 
 func waitForLND() error {
@@ -332,35 +345,47 @@ func WaitForLND() error {
 	return waitForLND()
 }
 
-// SetupAutoUnlock writes the wallet password to a
-// permission-locked file and rewrites the LND systemd
-// service to start LND with --wallet-unlock-password-file.
-// LND is restarted as the final step.
+// SetupAutoUnlock enables wallet auto-unlock. As root
+// (installer, helper) it performs the operation directly; from
+// the unprivileged TUI it requests the helper's typed
+// stage-wallet-password operation — the password travels over
+// the local root-owned socket and is written root-side to a
+// file the admin user can never read.
 func SetupAutoUnlock(password string) error {
-	return setupAutoUnlock(password)
+	if os.Geteuid() == 0 {
+		return setupAutoUnlock(password)
+	}
+	return helper.Call(helper.VerbStageWalletPassword,
+		helper.StageWalletPasswordParams{Password: password}, nil)
 }
 
-// DisableAutoUnlock removes the wallet password file and
-// rewrites the LND systemd service back to its initial
-// (no-auto-unlock) form. LND is restarted as the final
-// step. After this call, LND will require manual unlock
-// (e.g. `lncli unlock`) on next startup.
+// DisableAutoUnlock disables wallet auto-unlock (service
+// rewritten and restarted first; password file removed last —
+// see disableAutoUnlock). Root performs it directly; the TUI
+// requests the helper's typed operation.
 func DisableAutoUnlock() error {
-	return disableAutoUnlock()
+	if os.Geteuid() == 0 {
+		return disableAutoUnlock()
+	}
+	return helper.Call(helper.VerbRemoveWalletPassword, nil, nil)
+}
+
+// lndTLSCertBytes returns LND's TLS certificate for client
+// use: read directly where permitted (root; some setups leave
+// it world-readable), else from the staging board copy.
+func lndTLSCertBytes() ([]byte, error) {
+	if data, err := os.ReadFile(paths.LNDTLSCert); err == nil {
+		return data, nil
+	}
+	return helper.ReadBoard(paths.StateLNDTLSCert)
 }
 
 func buildLNDClient() *http.Client {
 	tlsConfig := &tls.Config{}
-	// Try direct read first, fall back to sudo
-	certData, err := os.ReadFile(paths.LNDTLSCert)
+	certData, err := lndTLSCertBytes()
 	if err != nil {
-		output, sudoErr := system.SudoRunOutput("cat", paths.LNDTLSCert)
-		if sudoErr == nil {
-			certData = []byte(output)
-			err = nil
-		}
-	}
-	if err == nil {
+		logger.System("LND REST client: %v", err)
+	} else {
 		pool := x509.NewCertPool()
 		if pool.AppendCertsFromPEM(certData) {
 			tlsConfig.RootCAs = pool

--- a/internal/installer/lnd.go
+++ b/internal/installer/lnd.go
@@ -191,8 +191,19 @@ healthcheck.diskspace.interval=12h
 	return system.SudoRun("chown", "root:"+systemUser, paths.LNDConf)
 }
 
-func writeLNDServiceInitial(username string) error {
-	content := fmt.Sprintf(`[Unit]
+// lndServiceUnit renders the LND systemd unit. withUnlock adds
+// LND's --wallet-unlock-password-file flag, pointing at the
+// root-staged password file, so the wallet unlocks without an
+// operator on every service start. Everything else about the
+// two variants is identical by construction — they come from
+// this one template. Pure — unit-tested.
+func lndServiceUnit(username string, withUnlock bool) string {
+	unlockFlag := ""
+	if withUnlock {
+		unlockFlag = " --wallet-unlock-password-file=" +
+			paths.LNDWalletPassword
+	}
+	return fmt.Sprintf(`[Unit]
 Description=LND Lightning Network Daemon
 After=bitcoind.service tor.service
 Wants=bitcoind.service
@@ -201,7 +212,7 @@ Wants=bitcoind.service
 Type=simple
 User=%s
 Group=%s
-ExecStart=/usr/local/bin/lnd --configfile=/etc/lnd/lnd.conf
+ExecStart=/usr/local/bin/lnd --configfile=/etc/lnd/lnd.conf%s
 Restart=on-failure
 RestartSec=30
 TimeoutStopSec=300
@@ -211,10 +222,50 @@ NoNewPrivileges=true
 
 [Install]
 WantedBy=multi-user.target
-`, username, username)
-	return system.SudoWriteFile(paths.LNDService, []byte(content), 0644)
+`, username, username, unlockFlag)
 }
 
+// writeLNDService writes the LND unit in the requested variant.
+func writeLNDService(username string, withUnlock bool) error {
+	return system.SudoWriteFile(paths.LNDService,
+		[]byte(lndServiceUnit(username, withUnlock)), 0644)
+}
+
+// writeLNDServiceFromConfig writes the LND unit that matches the
+// node's RECORDED state: the unlock variant when the config says
+// auto-unlock is enabled AND the wallet password file is actually
+// present, the plain variant otherwise. An install pass does not
+// only run on fresh boxes — on a reinstall or a migration the
+// auto_unlock answer and the password file both carry over, and
+// unconditionally writing the plain unit there disarmed
+// auto-unlock at the next service restart while the config still
+// claimed it enabled. Requiring the file too is deliberate: a
+// unit pointing at a missing password file would keep LND from
+// starting at all.
+func writeLNDServiceFromConfig(cfg *config.AppConfig, username string) error {
+	withUnlock := cfg.AutoUnlock && walletPasswordFileExists()
+	if cfg.AutoUnlock && !withUnlock {
+		logger.Install(
+			"auto_unlock is enabled in the config but %s is "+
+				"missing — writing the LND unit without the unlock "+
+				"flag; re-enable auto-unlock from the node console",
+			paths.LNDWalletPassword)
+	}
+	return writeLNDService(username, withUnlock)
+}
+
+func walletPasswordFileExists() bool {
+	_, err := os.Stat(paths.LNDWalletPassword)
+	return err == nil
+}
+
+// startLND enables and starts LND. `systemctl restart` rather
+// than `start`, deliberately: start is a no-op on a service that
+// is already running, and an install pass can run on a box where
+// LND already runs under a PREVIOUS unit and config (reinstall,
+// migration). Restart makes the unit and config this run just
+// wrote the ones actually in effect; on a fresh box the two
+// commands are equivalent.
 func startLND() error {
 	if err := system.SudoRun("systemctl", "daemon-reload"); err != nil {
 		return err
@@ -222,7 +273,7 @@ func startLND() error {
 	if err := system.SudoRun("systemctl", "enable", "lnd"); err != nil {
 		return err
 	}
-	return system.SudoRun("systemctl", "start", "lnd")
+	return system.SudoRun("systemctl", "restart", "lnd")
 }
 
 func setupAutoUnlock(password string) error {
@@ -257,28 +308,7 @@ func setupAutoUnlock(password string) error {
 		return fmt.Errorf("move wallet password: %w", err)
 	}
 
-	content := fmt.Sprintf(`[Unit]
-Description=LND Lightning Network Daemon
-After=bitcoind.service tor.service
-Wants=bitcoind.service
-
-[Service]
-Type=simple
-User=%s
-Group=%s
-ExecStart=/usr/local/bin/lnd --configfile=/etc/lnd/lnd.conf --wallet-unlock-password-file=/var/lib/lnd/wallet_password
-Restart=on-failure
-RestartSec=30
-TimeoutStopSec=300
-PrivateTmp=true
-ProtectSystem=full
-NoNewPrivileges=true
-
-[Install]
-WantedBy=multi-user.target
-`, systemUser, systemUser)
-
-	if err := system.SudoWriteFile(paths.LNDService, []byte(content), 0644); err != nil {
+	if err := writeLNDService(systemUser, true); err != nil {
 		return err
 	}
 	if err := system.SudoRun("systemctl", "daemon-reload"); err != nil {
@@ -301,7 +331,7 @@ WantedBy=multi-user.target
 // disagreed. With removal last, any failure leaves the file in
 // place and the operation honestly failed; a retry converges.
 func disableAutoUnlock() error {
-	if err := writeLNDServiceInitial(systemUser); err != nil {
+	if err := writeLNDService(systemUser, false); err != nil {
 		return fmt.Errorf("rewrite service: %w", err)
 	}
 	if err := system.SudoRun(

--- a/internal/installer/lnd_test.go
+++ b/internal/installer/lnd_test.go
@@ -1,0 +1,56 @@
+// internal/installer/lnd_test.go
+
+package installer
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/virtualprivatenode/vpn/internal/paths"
+)
+
+// The LND unit template: one source for both variants, so they
+// can never drift apart in anything but the unlock flag.
+func TestLNDServiceUnit(t *testing.T) {
+	plain := lndServiceUnit("bitcoin", false)
+	unlock := lndServiceUnit("bitcoin", true)
+
+	unlockFlag := "--wallet-unlock-password-file=" +
+		paths.LNDWalletPassword
+	if strings.Contains(plain, unlockFlag) {
+		t.Error("plain unit carries the unlock flag")
+	}
+	if got := strings.Count(unlock, unlockFlag); got != 1 {
+		t.Errorf("unlock unit has %d unlock flags, want 1", got)
+	}
+
+	// The only difference between the variants is the flag.
+	if strings.Replace(unlock, " "+unlockFlag, "", 1) != plain {
+		t.Error("variants differ beyond the unlock flag")
+	}
+
+	for _, unit := range []string{plain, unlock} {
+		for _, want := range []string{
+			"User=bitcoin",
+			"Group=bitcoin",
+			"ExecStart=/usr/local/bin/lnd " +
+				"--configfile=/etc/lnd/lnd.conf",
+			"Restart=on-failure",
+			"TimeoutStopSec=300",
+			"WantedBy=multi-user.target",
+		} {
+			if !strings.Contains(unit, want) {
+				t.Errorf("unit lacks %q", want)
+			}
+		}
+	}
+
+	// The unlock flag rides the ExecStart line, not a line of
+	// its own — systemd would ignore a bare flag line.
+	for _, line := range strings.Split(unlock, "\n") {
+		if strings.Contains(line, unlockFlag) &&
+			!strings.HasPrefix(line, "ExecStart=") {
+			t.Errorf("unlock flag off the ExecStart line: %q", line)
+		}
+	}
+}

--- a/internal/installer/preflight.go
+++ b/internal/installer/preflight.go
@@ -75,6 +75,13 @@ func RunPreflight() (SSHObservation, error) {
 			failed++
 		}
 	}
+	// Warnings never refuse; they are printed and logged so the
+	// operator can judge them.
+	for _, w := range preflightWarnings() {
+		fmt.Fprintf(os.Stderr, "\n  WARNING: %s\n", w)
+		logger.Install("Preflight WARNING: %s", w)
+	}
+
 	if failed == 0 {
 		logger.Install("Preflight passed (%d/%d checks)",
 			len(results), len(results))
@@ -106,6 +113,24 @@ func runPreflightChecks() ([]PreflightResult, SSHObservation) {
 	results = append(results,
 		PreflightResult{checkNameSSHState, obsErr})
 	return results, obs
+}
+
+// preflightWarnings collects conditions worth telling the
+// operator about that are not grounds for refusal.
+func preflightWarnings() []string {
+	var ws []string
+	// A world-readable /etc/sudoers.d discloses the box's sudo
+	// POLICY to any local user (Debian 13 ships it 750). It
+	// holds no credentials, and this node grants no sudo rules
+	// anyway — a disclosure note, never a refusal.
+	if fi, err := os.Stat(paths.SudoersDir); err == nil &&
+		fi.Mode().Perm()&0o004 != 0 {
+		ws = append(ws, fmt.Sprintf(
+			"%s is world-readable (%o) — local users can read "+
+				"sudo policy; Debian ships it 0750",
+			paths.SudoersDir, fi.Mode().Perm()))
+	}
+	return ws
 }
 
 // ── Check 1: OS ──────────────────────────────────────────
@@ -157,17 +182,18 @@ func checkOSRelease(content string) error {
 // ── Check 2: sudo I/O logging (IA-3-H) ───────────────────
 
 // checkSudoersIOLogging asserts no sudoers file enables sudo's
-// input/output recording. With log_input set, the moment the TUI
-// pipes the admin password to `sudo chpasswd`, sudo would tee the
-// plaintext to /var/log/sudo-io — a passive credential sink. Scope:
-// /etc/sudoers plus every file sudo's @includedir would parse in
-// /etc/sudoers.d. Residual (documented, accepted): a nonstandard
-// @includedir pointing elsewhere is not followed.
+// input/output recording. Scope: /etc/sudoers plus every file
+// sudo's @includedir would parse in /etc/sudoers.d. Residual
+// (documented, accepted): a nonstandard @includedir pointing
+// elsewhere is not followed.
 //
-// The install itself runs as root and never trips this — the check
-// protects the ADMIN-USER era that starts at handoff (and it dies
-// with the TUI's sudo use at commit 7, when the root helper takes
-// over).
+// This app itself no longer runs anything through sudo (the
+// admin user has no sudo rights; privileged operations go
+// through the root helper), so nothing of OURS can be captured
+// by sudo I/O recording anymore. The check stays because a box
+// where someone silently records terminal input is a box this
+// installer should not set a node up on — the assertion is
+// about the environment's hygiene, cheap to keep.
 func checkSudoersIOLogging() error {
 	files := []string{paths.SudoersFile}
 	dropIns, err := listSudoersDropIns()

--- a/internal/installer/rpcauth.go
+++ b/internal/installer/rpcauth.go
@@ -1,0 +1,80 @@
+// internal/installer/rpcauth.go
+
+package installer
+
+// bitcoind RPC credentials for this node's own tooling (the
+// TUI's chain status probe and the bitcoin-cli shell wrapper).
+//
+// The mechanism is bitcoind's rpcauth option: bitcoin.conf
+// carries only a salted HMAC of the password — an attacker who
+// reads the conf learns nothing usable — while the cleartext
+// password is staged once on the board (root:vpn 0640) for the
+// admin user's clients. Compared to bitcoind's cookie file,
+// the static credential survives bitcoind restarts without
+// re-reading anything, and gives this node's tooling its own
+// RPC identity (which is what would make per-user method
+// whitelisting possible later). LND is unaffected: it keeps
+// its cookie-file configuration, which bitcoind still writes.
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/virtualprivatenode/vpn/internal/helper"
+	"github.com/virtualprivatenode/vpn/internal/paths"
+)
+
+// BitcoindRPCUser is the RPC identity the node's own tooling
+// authenticates as.
+const BitcoindRPCUser = "vpn"
+
+// generateRPCAuth produces an rpcauth= line and the matching
+// cleartext password. It reproduces Bitcoin Core's reference
+// generator (share/rpcauth/rpcauth.py) exactly:
+//
+//   - password: 32 random bytes, unpadded URL-safe base64;
+//   - salt: 16 random bytes as 32 lowercase hex chars;
+//   - HMAC-SHA256 keyed by the hex salt STRING (not the raw
+//     bytes — reversing this yields a line that never
+//     authenticates), message = the password bytes.
+func generateRPCAuth(user string) (line, password string, err error) {
+	var pw [32]byte
+	if _, err := rand.Read(pw[:]); err != nil {
+		return "", "", fmt.Errorf("generate RPC password: %w", err)
+	}
+	password = base64.RawURLEncoding.EncodeToString(pw[:])
+
+	var salt [16]byte
+	if _, err := rand.Read(salt[:]); err != nil {
+		return "", "", fmt.Errorf("generate RPC salt: %w", err)
+	}
+	saltHex := hex.EncodeToString(salt[:])
+
+	mac := hmac.New(sha256.New, []byte(saltHex))
+	mac.Write([]byte(password))
+	line = fmt.Sprintf("rpcauth=%s:%s$%s",
+		user, saltHex, hex.EncodeToString(mac.Sum(nil)))
+	return line, password, nil
+}
+
+// writeRPCAuthCredential regenerates the credential pair and
+// installs BOTH halves: the hashed line is returned for the
+// bitcoin.conf write, the cleartext is staged on the board.
+// The two are only ever replaced together — a conf line
+// without its staged password (or vice versa) would strand
+// every client on an auth error.
+func writeRPCAuthCredential() (rpcauthLine string, err error) {
+	line, password, err := generateRPCAuth(BitcoindRPCUser)
+	if err != nil {
+		return "", err
+	}
+	if err := helper.WriteBoard(paths.StateBitcoindRPCPass,
+		[]byte(password+"\n")); err != nil {
+		return "", err
+	}
+	return line, nil
+}

--- a/internal/installer/rpcauth_test.go
+++ b/internal/installer/rpcauth_test.go
@@ -1,0 +1,59 @@
+// internal/installer/rpcauth_test.go
+
+package installer
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// The rpcauth line must be exactly what bitcoind's reference
+// generator produces: user:salt$hmac, 32-hex-char salt, 64-hex
+// HMAC keyed by the hex salt STRING over the password bytes.
+// The recomputation here is the cross-check — a keying mistake
+// (raw salt bytes, or salt/password swapped) yields a
+// well-formed line that never authenticates, which no format
+// check alone would catch.
+func TestGenerateRPCAuth(t *testing.T) {
+	line, password, err := generateRPCAuth("vpn")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	shape := regexp.MustCompile(
+		`^rpcauth=vpn:([0-9a-f]{32})\$([0-9a-f]{64})$`)
+	m := shape.FindStringSubmatch(line)
+	if m == nil {
+		t.Fatalf("line %q does not match the rpcauth shape", line)
+	}
+	saltHex, hmacHex := m[1], m[2]
+
+	mac := hmac.New(sha256.New, []byte(saltHex))
+	mac.Write([]byte(password))
+	if want := hex.EncodeToString(mac.Sum(nil)); want != hmacHex {
+		t.Errorf("HMAC mismatch: line %s, recomputed %s",
+			hmacHex, want)
+	}
+
+	// token_urlsafe(32): 43 chars, URL-safe alphabet, no
+	// padding.
+	if len(password) != 43 {
+		t.Errorf("password length %d, want 43", len(password))
+	}
+	if strings.ContainsAny(password, "+/=\n") {
+		t.Errorf("password %q not URL-safe/unpadded", password)
+	}
+
+	// Two generations must not repeat.
+	line2, password2, err := generateRPCAuth("vpn")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if line == line2 || password == password2 {
+		t.Error("two generations produced identical output")
+	}
+}

--- a/internal/installer/runlock.go
+++ b/internal/installer/runlock.go
@@ -1,0 +1,43 @@
+// internal/installer/runlock.go
+
+package installer
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// acquireRunLock takes an exclusive advisory lock on the
+// install ledger, so two concurrent `sudo vpn install` runs
+// cannot interleave step execution and ledger writes. The
+// second run refuses immediately with a clear message.
+//
+// flock, not a pid file, deliberately: the lock belongs to the
+// open file description, so it evaporates the instant the
+// process dies — by any death, including SIGKILL — and there is
+// no stale-lock state to clean up. The caller must keep the
+// returned *os.File referenced until the install returns
+// (dropping it lets the runtime close the file and release the
+// lock mid-install), and must NOT delete the file on release —
+// unlinking a lock file creates the classic two-holders race.
+// The ledger is a persistent file anyway.
+func acquireRunLock(path string) (*os.File, error) {
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open install lock %s: %w", path, err)
+	}
+	if err := syscall.Flock(int(f.Fd()),
+		syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		f.Close()
+		if errors.Is(err, syscall.EWOULDBLOCK) {
+			return nil, fmt.Errorf(
+				"another `vpn install` is already running " +
+					"(the install ledger is locked) — wait for it " +
+					"to finish")
+		}
+		return nil, fmt.Errorf("lock %s: %w", path, err)
+	}
+	return f, nil
+}

--- a/internal/installer/runlock_test.go
+++ b/internal/installer/runlock_test.go
@@ -1,0 +1,38 @@
+// internal/installer/runlock_test.go
+
+package installer
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Two acquisitions of the same lock path must conflict — flock
+// is per open file description, so a second open in the same
+// process contends exactly like a second process would — and
+// the refusal message must say what is happening in operator
+// language.
+func TestRunLockExcludesSecondAcquire(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "install-state.json")
+
+	first, err := acquireRunLock(path)
+	if err != nil {
+		t.Fatalf("first acquire: %v", err)
+	}
+	defer first.Close()
+
+	if _, err := acquireRunLock(path); err == nil {
+		t.Fatal("second acquire succeeded while first is held")
+	} else if !strings.Contains(err.Error(), "already running") {
+		t.Errorf("refusal message %q lacks the diagnosis", err)
+	}
+
+	// Releasing the first makes the lock available again.
+	first.Close()
+	third, err := acquireRunLock(path)
+	if err != nil {
+		t.Fatalf("acquire after release: %v", err)
+	}
+	third.Close()
+}

--- a/internal/installer/setup.go
+++ b/internal/installer/setup.go
@@ -25,8 +25,9 @@ const (
 
 var appVersion = "dev"
 
-func SetVersion(v string)   { appVersion = v }
-func LndVersionStr() string { return lndVersion }
+func SetVersion(v string)         { appVersion = v }
+func LndVersionStr() string       { return lndVersion }
+func SyncthingVersionStr() string { return syncthingVersion }
 
 // ── Main install flow ────────────────────────────────────
 //
@@ -57,6 +58,15 @@ type InstallOptions struct {
 	// WITHOUT InstallComplete, without handoff, without the
 	// verification banner — first-boot steps are still owed.
 	UntilBake bool
+	// AllowConsoleOnly permits an unattended install to
+	// complete with NO SSH way in: no enumerable keys AND
+	// password auth observed off means the printed password
+	// works only at the provider console. Without this flag
+	// such a run REFUSES — completing it would strand the box
+	// by automation. The flag names the consequence so the
+	// consent is auditable wherever the command line is
+	// recorded.
+	AllowConsoleOnly bool
 }
 
 // RunInstall is the `sudo vpn install` entry point.
@@ -76,6 +86,18 @@ func RunInstall(opts InstallOptions) error {
 	// showing its dialog mid-upgrade.
 	os.Setenv("DEBIAN_FRONTEND", "noninteractive")
 	os.Setenv("NEEDRESTART_MODE", "a")
+
+	// One install at a time: an exclusive lock on the ledger,
+	// held for the whole run (released by process exit on any
+	// death). A second concurrent run refuses immediately.
+	if err := os.MkdirAll(paths.ConfigDir, 0750); err != nil {
+		return fmt.Errorf("create %s: %w", paths.ConfigDir, err)
+	}
+	runLock, err := acquireRunLock(paths.InstallStateFile)
+	if err != nil {
+		return err
+	}
+	defer runLock.Close()
 
 	// Preflight (principle 3): assert the environment before the
 	// first mutation; refuses with a full report on any failure.
@@ -137,13 +159,10 @@ func RunInstall(opts InstallOptions) error {
 	cfg.LNDInstalled = true
 	cfg.Components = "bitcoin+lnd"
 
-	// The ledger lives in the config dir; the dir must exist
-	// before the first step completes. Root-owned during the
-	// install; ownership of the dir and config.json passes to
-	// the admin user at completion (migration requirement 2).
-	if err := os.MkdirAll(paths.ConfigDir, 0750); err != nil {
-		return fmt.Errorf("create %s: %w", paths.ConfigDir, err)
-	}
+	// (The config dir was created above, before the run lock —
+	// the ledger lives in it. Root-owned during the install;
+	// ownership of the dir and config.json passes to the admin
+	// user at completion, migration requirement 2.)
 
 	dec := &InstallDecisions{Obs: obs}
 	steps := buildInstallSteps(cfg, dec)
@@ -193,7 +212,8 @@ func RunInstall(opts InstallOptions) error {
 	var res RunResult
 	openConsole := false
 	if opts.Unattended {
-		if err := fillUnattendedDecisions(dec); err != nil {
+		if err := fillUnattendedDecisions(
+			dec, opts.AllowConsoleOnly); err != nil {
 			return err
 		}
 		fmt.Printf("\n  Virtual Private Node — unattended install\n\n")
@@ -331,8 +351,30 @@ func finalizeOwnership() {
 // instead of guessing — and the password is randomly generated
 // (ruling vii: random survives ONLY here) and printed at the
 // end. dbcache takes the hardware recommendation.
-func fillUnattendedDecisions(dec *InstallDecisions) error {
+//
+// Zero-key strand guard: the interactive wizard refuses zero
+// selected keys when observed password auth is off; this is the
+// unattended equivalent. A box with no enumerable keys AND
+// password auth off would finish with no SSH way in at all —
+// the printed password works only at the provider console. That
+// outcome must be asked for by name (--allow-console-only),
+// never reached by default: a warning scrolling past in an
+// unattended run is not consent.
+func fillUnattendedDecisions(
+	dec *InstallDecisions, allowConsoleOnly bool,
+) error {
 	dec.Keys = DedupeKeys(EnumerateKeySources())
+	if strandsBox(len(dec.Keys), dec.Obs.PasswordAuth,
+		allowConsoleOnly) {
+		return errors.New(
+			"refusing: no SSH keys found anywhere on this box " +
+				"and password login is disabled in sshd — " +
+				"completing would leave no SSH way in (the " +
+				"generated password works only at a console). " +
+				"Add a key, enable password auth, or re-run " +
+				"with --allow-console-only if console-only " +
+				"access is really what you want")
+	}
 	gen, err := generateAdminPassword()
 	if err != nil {
 		return err
@@ -345,6 +387,15 @@ func fillUnattendedDecisions(dec *InstallDecisions) error {
 	dec.GeneratedPassword = gen
 	dec.DbCacheMB = RecommendDbCache(DetectHardware().RAMMB)
 	return nil
+}
+
+// strandsBox is the zero-key strand condition: no keys to
+// write, password auth off, and no explicit console-only
+// consent. Pure — unit-tested.
+func strandsBox(
+	keyCount int, passwordAuth, allowConsoleOnly bool,
+) bool {
+	return keyCount == 0 && !passwordAuth && !allowConsoleOnly
 }
 
 // ── Absorbed bootstrap steps (script Phase 1) ────────────
@@ -597,6 +648,24 @@ func buildInstallSteps(
 			Fn: func() error {
 				return installSSHHardening(cfg)
 			}},
+		// The runtime privilege boundary. Three steps, all
+		// first-boot (they need the admin user and group to
+		// exist): journal read access for the admin user, the
+		// root helper's socket-activated units, and the staging
+		// board snapshot. After these — and with
+		// identity.access granting no sudo — the end state
+		// holds: the admin user has no root privilege at all,
+		// and every privileged operation it can request is one
+		// of the helper's fixed, typed, journal-audited verbs.
+		{Key: "journal.access", Phase: PhaseFirstBoot,
+			Name: "Granting journal read access",
+			Fn:   setupJournalAccess},
+		{Key: "helper.enable", Phase: PhaseFirstBoot,
+			Name: "Enabling the root helper socket",
+			Fn:   installHelperUnits},
+		{Key: "state.stage", Phase: PhaseFirstBoot,
+			Name: "Staging node facts for the console",
+			Fn:   StageBoardAll},
 		// Formerly a post-TUI special case that warned but
 		// completed anyway (IA-1-16). As a real step it
 		// inherits the ledger, the completion gate, failure
@@ -868,6 +937,21 @@ func readFileOrDefault(path, def string) string {
 	return string(data)
 }
 
+// setupShellEnvironment writes the admin user's cli wrappers.
+// Both run with NO privilege: they are the recovery path a
+// zero-sudo box leans on when the console itself misbehaves,
+// so they must work exactly as the admin user.
+//
+//   - bitcoin-cli authenticates with the node's own RPC
+//     credential: the staged password is fed on stdin
+//     (-stdinrpcpass), never on the command line, where it
+//     would be visible in /proc/*/cmdline. The wrapper cannot
+//     read bitcoin.conf (root-owned) and does not need to —
+//     connection details are passed explicitly.
+//   - lncli reads the staged certificate and macaroon copies.
+//     The wallet-create ceremony passes its own flags
+//     (cert-only — no macaroon exists yet); this wrapper is
+//     for the day-to-day case.
 func setupShellEnvironment(cfg *config.AppConfig) error {
 	bashrc := paths.AdminBashrc
 	data, _ := os.ReadFile(bashrc)
@@ -884,14 +968,20 @@ func setupShellEnvironment(cfg *config.AppConfig) error {
 		}
 		content += fmt.Sprintf(`
 # -- Virtual Private Node --
+# RPC password comes from the staged credential file on stdin;
+# commands that themselves read stdin should be run with
+# explicit flags instead of this wrapper.
 bitcoin-cli() {
-    sudo -u bitcoin /usr/local/bin/bitcoin-cli \
-        -datadir=/var/lib/bitcoin \
-        -conf=/etc/bitcoin/bitcoin.conf \%s
-        "$@"
+    /usr/local/bin/bitcoin-cli \
+        -rpcconnect=127.0.0.1 \
+        -rpcport=%d \
+        -rpcuser=%s \
+        -stdinrpcpass \%s
+        "$@" < %s
 }
 export -f bitcoin-cli
-`, btcNetFlag)
+`, net.RPCPort, BitcoindRPCUser, btcNetFlag,
+			paths.StateBitcoindRPCPass)
 	}
 
 	// lncli wrapper — always set up now that LND is part of
@@ -906,14 +996,14 @@ export -f bitcoin-cli
 		}
 		content += fmt.Sprintf(`
 lncli() {
-    sudo -u bitcoin /usr/local/bin/lncli \
-        --lnddir=/var/lib/lnd \%s
-        --macaroonpath=/var/lib/lnd/data/chain/bitcoin/%s/admin.macaroon \
-        --tlscertpath=/var/lib/lnd/tls.cert \
+    /usr/local/bin/lncli \
+        --rpcserver=localhost:10009 \%s
+        --macaroonpath=%s \
+        --tlscertpath=%s \
         "$@"
 }
 export -f lncli
-`, lndNetFlag, net.LNCLINetwork)
+`, lndNetFlag, paths.StateLNDMacaroon, paths.StateLNDTLSCert)
 	}
 
 	if content == "" {

--- a/internal/installer/setup.go
+++ b/internal/installer/setup.go
@@ -307,7 +307,15 @@ func RunInstall(opts InstallOptions) error {
 	}
 
 	if opts.Unattended {
-		printConnectInstructions()
+		// The console-only end state (reachable only with
+		// --allow-console-only) has no working ssh line to
+		// print — say what IS true instead. Same condition the
+		// strand guard evaluated, minus the consent flag.
+		if strandsBox(len(dec.Keys), dec.Obs.PasswordAuth, false) {
+			printConsoleOnlyInstructions()
+		} else {
+			printConnectInstructions()
+		}
 		return nil
 	}
 	// The done screen offered a real choice (live-run fix):

--- a/internal/installer/setup.go
+++ b/internal/installer/setup.go
@@ -628,7 +628,7 @@ func buildInstallSteps(
 				if err := writeLNDConfig(cfg, ""); err != nil {
 					return err
 				}
-				return writeLNDServiceInitial(systemUser)
+				return writeLNDServiceFromConfig(cfg, systemUser)
 			}},
 		{Key: "tor.lnd", Name: "Configuring Tor for LND",
 			Fn: func() error {

--- a/internal/installer/sshd.go
+++ b/internal/installer/sshd.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/virtualprivatenode/vpn/internal/config"
+	"github.com/virtualprivatenode/vpn/internal/helper"
 	"github.com/virtualprivatenode/vpn/internal/paths"
 	"github.com/virtualprivatenode/vpn/internal/system"
 )
@@ -133,7 +134,17 @@ func RebuildSSHHardeningConfig(cfg *config.AppConfig) error {
 			detail)
 	}
 
-	return restartSSHD()
+	if err := restartSSHD(); err != nil {
+		return err
+	}
+
+	// Postcondition: record the now-effective password-auth
+	// answer on the staging board, where unprivileged readers
+	// (the key-removal guard, screen copy) consult it. A
+	// staging failure fails the whole operation — succeeding
+	// while leaving a stale staged answer would be the silent
+	// divergence the board's contract forbids.
+	return StageSSHAuthFact()
 }
 
 // restorePreviousDropIn puts the drop-in back to its
@@ -148,26 +159,76 @@ func restorePreviousDropIn(prev []byte, existed bool) error {
 }
 
 // SetSSHPasswordAuth flips the password-auth flag in cfg and
-// rebuilds the drop-in. The zero-auth lockout guard lives in
-// RebuildSSHHardeningConfig (the write boundary), so every
-// caller passes through it. On ANY failure the in-memory
-// flag is restored, keeping cfg, disk, and sshd in
-// agreement.
+// rebuilds the drop-in. On ANY failure the in-memory flag is
+// restored, keeping cfg, disk, and sshd in agreement.
+//
+// As root the rebuild runs directly; from the unprivileged TUI
+// it is requested from the helper as the typed
+// rebuild-ssh-config operation — the drop-in template, the
+// zero-auth lockout guard, and the validate-and-restore
+// sequence all live on the root side either way (the write
+// boundary), so every caller passes through them.
 func SetSSHPasswordAuth(
 	cfg *config.AppConfig, disabled bool,
 ) error {
 	prev := cfg.SSHPasswordAuthDisabled
 	cfg.SSHPasswordAuthDisabled = disabled
-	if err := RebuildSSHHardeningConfig(cfg); err != nil {
+	var err error
+	if os.Geteuid() == 0 {
+		err = RebuildSSHHardeningConfig(cfg)
+	} else {
+		err = helper.Call(helper.VerbRebuildSSHConfig,
+			helper.RebuildSSHConfigParams{
+				PasswordAuthDisabled: disabled,
+			}, nil)
+	}
+	if err != nil {
 		cfg.SSHPasswordAuthDisabled = prev
 		return err
 	}
 	return nil
 }
 
-// EffectiveSSHPasswordAuth reports whether sshd's EFFECTIVE
-// configuration permits password authentication for the
-// admin user, by asking sshd itself:
+// EffectiveSSHPasswordAuth reports whether sshd's effective
+// configuration permits password authentication for the admin
+// user.
+//
+// Two sources, by privilege:
+//
+//   - As root (installer, helper): sshd is asked directly —
+//     see queryEffectiveSSHPasswordAuth.
+//   - Unprivileged (the TUI): the answer comes from the
+//     staging board, where every SSH-config write records the
+//     observation it made right after restarting sshd (see
+//     StageSSHAuthFact). The staged answer is an observation
+//     of sshd's real state, not an echo of this app's config —
+//     it goes stale only if something outside this app edits
+//     sshd's config, and root-side edits are outside the
+//     model anyway.
+//
+// Callers MUST treat an error as "password auth unavailable"
+// and refuse the risky action — never as unknown-so-proceed.
+// A missing staged fact therefore biases toward over-refusal,
+// the safe direction.
+func EffectiveSSHPasswordAuth() (bool, error) {
+	if os.Geteuid() == 0 {
+		return queryEffectiveSSHPasswordAuth()
+	}
+	v, err := helper.ReadBoardString(paths.StateSSHPasswordAuth)
+	if err != nil {
+		return false, err
+	}
+	switch v {
+	case "yes":
+		return true, nil
+	case "no":
+		return false, nil
+	}
+	return false, fmt.Errorf(
+		"staged password-auth fact is malformed (%q)", v)
+}
+
+// queryEffectiveSSHPasswordAuth asks sshd itself:
 //
 //	sshd -T -C user=<admin>,host=localhost,addr=127.0.0.1
 //
@@ -193,12 +254,8 @@ func SetSSHPasswordAuth(
 // to source ADDRESSES is evaluated against 127.0.0.1. That
 // residual biases toward over-refusal; user/group-targeted
 // rules (the hardening pattern that occurs in practice)
-// resolve exactly.
-//
-// Callers MUST treat an error as "password auth
-// unavailable" and refuse the risky action — never as
-// unknown-so-proceed.
-func EffectiveSSHPasswordAuth() (bool, error) {
+// resolve exactly. Root only — sshd -T reads host keys.
+func queryEffectiveSSHPasswordAuth() (bool, error) {
 	out, err := system.SudoRunOutput("sshd", "-T",
 		"-C", "user="+paths.AdminUser+
 			",host=localhost,addr=127.0.0.1")

--- a/internal/installer/sshkeys.go
+++ b/internal/installer/sshkeys.go
@@ -178,6 +178,13 @@ func AppendAuthorizedKey(line string) error {
 // user afterwards; as the admin user the file is simply ours.
 func writeAuthorizedKeys(content []byte) error {
 	dir := filepath.Dir(paths.AuthorizedKeysFile)
+	// ~/.ssh may not exist yet: a password-only install copies no
+	// keys and never creates it, so the first key added from the
+	// console has to create the directory (0700, owned by whoever
+	// runs this: the admin user from the TUI, root at install).
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create %s: %w", dir, err)
+	}
 	tmp, err := os.CreateTemp(dir, ".authorized_keys.tmp-")
 	if err != nil {
 		return fmt.Errorf("write authorized_keys: %w", err)

--- a/internal/installer/sshkeys.go
+++ b/internal/installer/sshkeys.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/virtualprivatenode/vpn/internal/paths"
@@ -93,13 +94,18 @@ func ValidateSSHKey(line string) error {
 // ListAuthorizedKeys reads and parses all keys from the
 // admin user's authorized_keys file. Returns an empty
 // slice (not an error) if the file does not exist.
+//
+// No privilege is involved anywhere in this file: the
+// authorized_keys file belongs to the admin user, so the TUI
+// (running as that user) reads and writes it directly, and
+// the root-run installer can too. The one root-only piece of
+// the key story — the effective password-auth answer that
+// guards last-key removal — comes from
+// EffectiveSSHPasswordAuth (sshd.go).
 func ListAuthorizedKeys() ([]SSHKeyInfo, error) {
-	data, err := system.SudoReadFile(
-		paths.AuthorizedKeysFile)
+	data, err := os.ReadFile(paths.AuthorizedKeysFile)
 	if err != nil {
-		if os.IsNotExist(err) ||
-			strings.Contains(err.Error(),
-				"No such file") {
+		if os.IsNotExist(err) {
 			return nil, nil
 		}
 		return nil, fmt.Errorf(
@@ -151,8 +157,7 @@ func AppendAuthorizedKey(line string) error {
 
 	// Read raw file to preserve comments and formatting.
 	var content string
-	data, err := system.SudoReadFile(
-		paths.AuthorizedKeysFile)
+	data, err := os.ReadFile(paths.AuthorizedKeysFile)
 	if err == nil {
 		content = string(data)
 	}
@@ -164,16 +169,47 @@ func AppendAuthorizedKey(line string) error {
 	}
 	content += line + "\n"
 
-	if err := system.SudoWriteFile(
-		paths.AuthorizedKeysFile,
-		[]byte(content), 0600); err != nil {
-		return fmt.Errorf(
-			"write authorized_keys: %w", err)
-	}
+	return writeAuthorizedKeys([]byte(content))
+}
 
-	return system.SudoRun("chown",
-		paths.AdminUser+":"+paths.AdminUser,
-		paths.AuthorizedKeysFile)
+// writeAuthorizedKeys writes the admin user's authorized_keys
+// atomically: same-dir temp, chmod 0600, rename. When running
+// as root (install-time), ownership is handed to the admin
+// user afterwards; as the admin user the file is simply ours.
+func writeAuthorizedKeys(content []byte) error {
+	dir := filepath.Dir(paths.AuthorizedKeysFile)
+	tmp, err := os.CreateTemp(dir, ".authorized_keys.tmp-")
+	if err != nil {
+		return fmt.Errorf("write authorized_keys: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+
+	if _, err := tmp.Write(content); err != nil {
+		tmp.Close()
+		return fmt.Errorf("write authorized_keys: %w", err)
+	}
+	if err := tmp.Chmod(0o600); err != nil {
+		tmp.Close()
+		return fmt.Errorf("write authorized_keys: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return fmt.Errorf("write authorized_keys: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("write authorized_keys: %w", err)
+	}
+	if err := os.Rename(tmpPath,
+		paths.AuthorizedKeysFile); err != nil {
+		return fmt.Errorf("write authorized_keys: %w", err)
+	}
+	if os.Geteuid() == 0 {
+		return system.SudoRun("chown",
+			paths.AdminUser+":"+paths.AdminUser,
+			paths.AuthorizedKeysFile)
+	}
+	return nil
 }
 
 // RemoveAuthorizedKey removes the key matching the given
@@ -191,8 +227,7 @@ func AppendAuthorizedKey(line string) error {
 // query runs only when the last key is being removed, so
 // ordinary removals cost no extra privileged call.
 func RemoveAuthorizedKey(fingerprint string) error {
-	data, err := system.SudoReadFile(
-		paths.AuthorizedKeysFile)
+	data, err := os.ReadFile(paths.AuthorizedKeysFile)
 	if err != nil {
 		return fmt.Errorf(
 			"read authorized_keys: %w", err)
@@ -253,14 +288,5 @@ func RemoveAuthorizedKey(fingerprint string) error {
 
 	content := strings.Join(kept, "\n")
 
-	if err := system.SudoWriteFile(
-		paths.AuthorizedKeysFile,
-		[]byte(content), 0600); err != nil {
-		return fmt.Errorf(
-			"write authorized_keys: %w", err)
-	}
-
-	return system.SudoRun("chown",
-		paths.AdminUser+":"+paths.AdminUser,
-		paths.AuthorizedKeysFile)
+	return writeAuthorizedKeys([]byte(content))
 }

--- a/internal/installer/staging.go
+++ b/internal/installer/staging.go
@@ -1,0 +1,261 @@
+// internal/installer/staging.go
+
+package installer
+
+// Staging-board writers. Each function refreshes ONE fact under
+// /etc/vpn/state from current reality, running as root (the
+// installer during `vpn install`, the helper afterwards). The
+// helper's freshness matrix (internal/helperd/matrix.go) maps
+// operations to the facts they invalidate and calls these; the
+// install's staging step calls StageBoardAll once so a finished
+// install always leaves a complete, current board.
+
+import (
+	"bytes"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/virtualprivatenode/vpn/internal/config"
+	"github.com/virtualprivatenode/vpn/internal/helper"
+	"github.com/virtualprivatenode/vpn/internal/logger"
+	"github.com/virtualprivatenode/vpn/internal/paths"
+	"github.com/virtualprivatenode/vpn/internal/system"
+)
+
+// StageOnionHostname copies a Tor hidden-service hostname file
+// to the board. Tor creates hostname files asynchronously after
+// a restart, so this waits briefly for the file to appear. A
+// hostname that never appears is treated as "this hidden
+// service is not configured": the board entry is removed, and a
+// screen that needs it reports unavailable rather than showing
+// a stale address.
+func StageOnionHostname(src, dst string) error {
+	deadline := time.Now().Add(20 * time.Second)
+	for {
+		data, err := os.ReadFile(src)
+		if err == nil && len(bytes.TrimSpace(data)) > 0 {
+			return helper.WriteBoard(dst,
+				append(bytes.TrimSpace(data), '\n'))
+		}
+		if time.Now().After(deadline) {
+			logger.System(
+				"staging: %s absent after 20s — removing the "+
+					"staged copy (service not configured?)", src)
+			return helper.RemoveBoard(dst)
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+}
+
+// StageLNDTLSCert copies LND's TLS certificate (the public
+// half only — tls.key never moves) to the board. LND rewrites
+// the cert during startup when its parameters change, so this
+// polls until the file parses as a stable certificate: two
+// consecutive reads, half a second apart, must agree and parse.
+func StageLNDTLSCert() error {
+	deadline := time.Now().Add(60 * time.Second)
+	var prev []byte
+	for {
+		data, err := os.ReadFile(paths.LNDTLSCert)
+		if err == nil && certParses(data) {
+			if prev != nil && bytes.Equal(prev, data) {
+				return helper.WriteBoard(
+					paths.StateLNDTLSCert, data)
+			}
+			prev = data
+		} else {
+			prev = nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf(
+				"LND TLS certificate at %s not readable/stable "+
+					"after 60s", paths.LNDTLSCert)
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+}
+
+// certParses reports whether data holds a parseable PEM
+// certificate — the guard against copying a half-written file.
+func certParses(data []byte) bool {
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return false
+	}
+	_, err := x509.ParseCertificate(block.Bytes)
+	return err == nil
+}
+
+// StageLNDMacaroon copies the admin macaroon to the board. It
+// requires the macaroon to exist: the callers are the moments
+// that create it (wallet creation) or that follow its known
+// existence. For the install-time case where no wallet exists
+// yet, see StageBoardAll, which skips it.
+func StageLNDMacaroon() error {
+	network, err := macaroonNetworkDir()
+	if err != nil {
+		return err
+	}
+	src := paths.LNDMacaroon(network)
+	deadline := time.Now().Add(30 * time.Second)
+	for {
+		data, err := os.ReadFile(src)
+		if err == nil && len(data) > 0 {
+			return helper.WriteBoard(paths.StateLNDMacaroon, data)
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf(
+				"admin macaroon at %s not readable after 30s "+
+					"(%v)", src, err)
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+}
+
+// macaroonNetworkDir resolves the network directory in LND's
+// macaroon path from the node's config.
+func macaroonNetworkDir() (string, error) {
+	cfg, err := config.Load()
+	if err != nil {
+		return "", fmt.Errorf("read node config: %w", err)
+	}
+	if cfg.IsMainnet() {
+		return "mainnet", nil
+	}
+	return cfg.Network, nil
+}
+
+// StageSyncthingAPIKey extracts the GUI API key from
+// Syncthing's config and stages it. With the key on the board,
+// every runtime device operation (pair, unpair, folder
+// sharing) is plain localhost REST with no privilege at all.
+func StageSyncthingAPIKey() error {
+	key, err := getSyncthingAPIKey()
+	if err != nil {
+		return fmt.Errorf("read Syncthing API key: %w", err)
+	}
+	return helper.WriteBoard(
+		paths.StateSyncthingAPIKey, []byte(key+"\n"))
+}
+
+// StageSyncthingDeviceID stages this node's Syncthing device
+// ID (shown during pairing; derived from Syncthing's TLS
+// identity, so it changes only when Syncthing is reinstalled).
+func StageSyncthingDeviceID() error {
+	id := GetSyncthingDeviceID()
+	if id == "" {
+		return fmt.Errorf("could not read the Syncthing device ID")
+	}
+	return helper.WriteBoard(
+		paths.StateSyncthingDevID, []byte(id+"\n"))
+}
+
+// StageSSHAuthFact records sshd's EFFECTIVE password-auth
+// answer for the admin user ("yes"/"no"), by asking sshd itself
+// (sshd -T with a simulated connection). Staged after every
+// SSH-config write, it is what unprivileged code consults where
+// it once ran the query via sudo. The staged answer is an
+// observation taken AFTER the write it follows — stronger than
+// trusting our own config, one step short of querying live
+// (which needs root). Consumers treat a missing or unreadable
+// fact as "unavailable" and refuse risky actions.
+func StageSSHAuthFact() error {
+	enabled, err := queryEffectiveSSHPasswordAuth()
+	if err != nil {
+		return fmt.Errorf(
+			"observe sshd password-auth state: %w", err)
+	}
+	v := "no"
+	if enabled {
+		v = "yes"
+	}
+	return helper.WriteBoard(
+		paths.StateSSHPasswordAuth, []byte(v+"\n"))
+}
+
+// StageBoardAll builds the complete board at install time:
+// every fact that exists on this box right now. Facts whose
+// source does not exist yet are SKIPPED, not failed — a fresh
+// box has no wallet macaroon until the operator creates the
+// wallet (that moment stages it), and no Syncthing facts until
+// Syncthing is installed.
+func StageBoardAll() error {
+	if err := helper.FixBoardOwnership(); err != nil {
+		return err
+	}
+
+	type fact struct {
+		name string
+		fn   func() error
+		skip func() bool // true = source legitimately absent
+	}
+	cfg, cfgErr := config.Load()
+	haveSyncthing := cfgErr == nil && cfg.SyncthingInstalled
+	haveWallet := false
+	if network, err := macaroonNetworkDir(); err == nil {
+		_, statErr := os.Stat(paths.LNDMacaroon(network))
+		haveWallet = statErr == nil
+	}
+
+	facts := []fact{
+		{"onion-bitcoin-p2p", func() error {
+			return StageOnionHostname(
+				paths.TorBitcoinP2P+"/hostname",
+				paths.StateOnionBitcoinP2P)
+		}, nil},
+		{"onion-lnd-grpc", func() error {
+			return StageOnionHostname(
+				paths.TorLNDGRPC+"/hostname",
+				paths.StateOnionLNDGRPC)
+		}, nil},
+		{"onion-lnd-rest", func() error {
+			return StageOnionHostname(
+				paths.TorLNDRESTHostname,
+				paths.StateOnionLNDREST)
+		}, nil},
+		{"onion-syncthing", func() error {
+			return StageOnionHostname(
+				paths.TorSyncthingHostname,
+				paths.StateOnionSyncthing)
+		}, func() bool { return !haveSyncthing }},
+		{"lnd-tls-cert", StageLNDTLSCert, nil},
+		{"lnd-admin-macaroon", StageLNDMacaroon,
+			func() bool { return !haveWallet }},
+		{"syncthing-api-key", StageSyncthingAPIKey,
+			func() bool { return !haveSyncthing }},
+		{"syncthing-device-id", StageSyncthingDeviceID,
+			func() bool { return !haveSyncthing }},
+		{"ssh-password-auth", StageSSHAuthFact, nil},
+	}
+	for _, f := range facts {
+		if f.skip != nil && f.skip() {
+			logger.Install(
+				"staging: %s skipped (source not present yet)",
+				f.name)
+			continue
+		}
+		if err := f.fn(); err != nil {
+			return fmt.Errorf("stage %s: %w", f.name, err)
+		}
+	}
+	logger.Install("staging board complete at %s", paths.StateDir)
+	return nil
+}
+
+// PackageUpdateSteps is the package-update operation as steps
+// (the helper streams their completion to the TUI's renderer).
+// Environment (non-interactive frontend, needrestart auto) is
+// process-level, set at helper start.
+func PackageUpdateSteps() []InstallStep {
+	return []InstallStep{
+		{Name: "Refreshing package lists",
+			Fn: func() error {
+				return system.SudoRun("apt-get", "update", "-qq")
+			}},
+		{Name: "Upgrading packages",
+			Fn: upgradeBasePackages},
+	}
+}

--- a/internal/installer/staging.go
+++ b/internal/installer/staging.go
@@ -3,7 +3,7 @@
 package installer
 
 // Staging-board writers. Each function refreshes ONE fact under
-// /etc/vpn/state from current reality, running as root (the
+// /var/lib/vpn/state from current reality, running as root (the
 // installer during `vpn install`, the helper afterwards). The
 // helper's freshness matrix (internal/helperd/matrix.go) maps
 // operations to the facts they invalidate and calls these; the

--- a/internal/installer/staging_test.go
+++ b/internal/installer/staging_test.go
@@ -1,0 +1,51 @@
+// internal/installer/staging_test.go
+
+package installer
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+)
+
+// certParses guards the TLS-cert stager against copying a
+// half-written file: only a complete, parseable certificate
+// may reach the board.
+func TestCertParses(t *testing.T) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test"},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+	der, err := x509.CreateCertificate(
+		rand.Reader, &tmpl, &tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	full := pem.EncodeToMemory(
+		&pem.Block{Type: "CERTIFICATE", Bytes: der})
+
+	if !certParses(full) {
+		t.Error("valid certificate rejected")
+	}
+	if certParses(full[:len(full)/2]) {
+		t.Error("truncated certificate accepted")
+	}
+	if certParses([]byte("not a pem")) {
+		t.Error("junk accepted")
+	}
+	if certParses(nil) {
+		t.Error("empty input accepted")
+	}
+}

--- a/internal/installer/strand_test.go
+++ b/internal/installer/strand_test.go
@@ -1,0 +1,33 @@
+// internal/installer/strand_test.go
+
+package installer
+
+import "testing"
+
+// The unattended zero-key strand guard: refuse exactly when
+// completing would leave no SSH way in and nobody consented to
+// that by name. Notably NOT refused: password auth on (the
+// password is a network credential then), any key present, or
+// explicit --allow-console-only consent.
+func TestStrandsBox(t *testing.T) {
+	cases := []struct {
+		keys                           int
+		passwordAuth, allowConsoleOnly bool
+		want                           bool
+	}{
+		{0, false, false, true},  // the strand
+		{0, false, true, false},  // consented by name
+		{0, true, false, false},  // password is a way in
+		{1, false, false, false}, // a key is a way in
+		{3, true, true, false},
+	}
+	for _, c := range cases {
+		got := strandsBox(c.keys, c.passwordAuth,
+			c.allowConsoleOnly)
+		if got != c.want {
+			t.Errorf("strandsBox(%d,%v,%v) = %v, want %v",
+				c.keys, c.passwordAuth, c.allowConsoleOnly,
+				got, c.want)
+		}
+	}
+}

--- a/internal/installer/syncthing.go
+++ b/internal/installer/syncthing.go
@@ -14,6 +14,7 @@ import (
 	"golang.org/x/crypto/bcrypt"
 
 	"github.com/virtualprivatenode/vpn/internal/config"
+	"github.com/virtualprivatenode/vpn/internal/helper"
 	"github.com/virtualprivatenode/vpn/internal/logger"
 	"github.com/virtualprivatenode/vpn/internal/paths"
 	"github.com/virtualprivatenode/vpn/internal/system"
@@ -141,8 +142,10 @@ func configureSyncthingAuth(password string) error {
 	//    then overwritten by the authored template. Explicit
 	//    binary path — never PATH resolution — so a leftover
 	//    apt-installed /usr/bin/syncthing can never be the one
-	//    that generates the identity.
-	if err := system.SudoRun("-u", systemUser,
+	//    that generates the identity. runuser (util-linux)
+	//    drops from root to the service user; this box has no
+	//    sudo rules to borrow.
+	if err := system.SudoRun("runuser", "-u", systemUser, "--",
 		"/usr/local/bin/syncthing",
 		"generate", "--home="+paths.SyncthingDir); err != nil {
 		return fmt.Errorf("syncthing generate: %w", err)
@@ -473,13 +476,23 @@ func registerBackupFolder() error {
 
 // ── Syncthing Device Pairing ─────────────────────────────
 
-// GetSyncthingDeviceID returns the VPS Syncthing Device ID
-// by parsing the config XML. This works even when Syncthing
-// is stopped since the ID is derived from the TLS certificate
-// and stored in the config file.
+// GetSyncthingDeviceID returns this node's Syncthing device
+// ID. As root it parses Syncthing's config XML (works even
+// with the daemon stopped — the ID derives from the TLS cert);
+// unprivileged it reads the staged copy on the board, which
+// the install (and any reinstall) refreshes.
 func GetSyncthingDeviceID() string {
-	output, err := system.SudoRunOutput("cat",
-		paths.SyncthingConfigXML)
+	if os.Geteuid() != 0 {
+		id, err := helper.ReadBoardString(
+			paths.StateSyncthingDevID)
+		if err != nil {
+			logger.Status("syncthing device ID: %v", err)
+			return ""
+		}
+		return id
+	}
+
+	output, err := os.ReadFile(paths.SyncthingConfigXML)
 	if err != nil {
 		return ""
 	}
@@ -494,7 +507,7 @@ func GetSyncthingDeviceID() string {
 	}
 
 	var c syncCfg
-	if xml.Unmarshal([]byte(output), &c) != nil {
+	if xml.Unmarshal(output, &c) != nil {
 		return ""
 	}
 
@@ -542,9 +555,17 @@ func PairSyncthingDevice(deviceID string) error {
 	return nil
 }
 
+// getSyncthingAPIKey returns the REST API key. As root it
+// parses Syncthing's config; unprivileged it reads the staged
+// board copy — which is what makes every runtime device
+// operation (pair, unpair, folder share) plain localhost REST
+// with no privilege involved.
 func getSyncthingAPIKey() (string, error) {
-	output, err := system.SudoRunOutput("cat",
-		paths.SyncthingConfigXML)
+	if os.Geteuid() != 0 {
+		return helper.ReadBoardString(paths.StateSyncthingAPIKey)
+	}
+
+	output, err := os.ReadFile(paths.SyncthingConfigXML)
 	if err != nil {
 		return "", err
 	}
@@ -557,7 +578,7 @@ func getSyncthingAPIKey() (string, error) {
 		GUI     guiKey   `xml:"gui"`
 	}
 	var cfg cfgFile
-	if err := xml.Unmarshal([]byte(output), &cfg); err != nil {
+	if err := xml.Unmarshal(output, &cfg); err != nil {
 		return "", err
 	}
 	if cfg.GUI.APIKey == "" {

--- a/internal/installer/syncthing.go
+++ b/internal/installer/syncthing.go
@@ -221,8 +221,18 @@ func configureSyncthingAuth(password string) error {
 // schema assumption broke; refusing to start converts a silent
 // leak into a loud install failure.
 func verifySyncthingConfig() error {
-	// (a) binary version
+	// (a) binary version. Probed through runuser as the service
+	//     user, exactly like `generate` above: not for privilege
+	//     but for environment. Syncthing v2 panics during
+	//     package init when $HOME is undefined
+	//     (lib/locations.userHomeDir), exiting 2 before any
+	//     argument is parsed, and the root helper that runs this
+	//     step is a socket-activated systemd service, which sets
+	//     no $HOME. runuser sets $HOME from the passwd entry, so
+	//     the probe works in any environment that can run the
+	//     daemon itself.
 	verOut, err := system.RunContext(10*time.Second,
+		"runuser", "-u", systemUser, "--",
 		"/usr/local/bin/syncthing", "--version")
 	if err != nil {
 		return fmt.Errorf("syncthing --version: %w", err)

--- a/internal/installer/system.go
+++ b/internal/installer/system.go
@@ -189,9 +189,21 @@ bantime = 600
 // Tor's SOCKS proxy. This ensures apt-get install/upgrade commands
 // (GPG, PostgreSQL, Syncthing, fail2ban, unattended-upgrades) don't
 // leak the server's IP to Debian mirrors or third-party repositories.
+//
+// The Acquire timeout and retry lines bound apt's DOWNLOAD phase —
+// its kill-safe phase — which matters most over Tor, where a stalled
+// circuit could otherwise hold a package operation (and with it the
+// root helper's serialized queue) indefinitely. The INSTALL phase is
+// deliberately left unbounded here: interrupting dpkg mid-transaction
+// corrupts package state, which is exactly why the package-update
+// budget is generous. (The pre-Tor apt operations run before this
+// file exists and rely on apt's stock 120-second timeout default.)
 func configureAptTor() error {
 	content := `Acquire::http::Proxy "socks5h://127.0.0.1:9050";
 Acquire::https::Proxy "socks5h://127.0.0.1:9050";
+Acquire::http::Timeout "60";
+Acquire::https::Timeout "60";
+Acquire::Retries "3";
 `
 	return system.SudoWriteFile("/etc/apt/apt.conf.d/99-tor-proxy",
 		[]byte(content), 0644)

--- a/internal/installer/userpassword.go
+++ b/internal/installer/userpassword.go
@@ -5,8 +5,10 @@ package installer
 import (
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 
+	"github.com/virtualprivatenode/vpn/internal/helper"
 	"github.com/virtualprivatenode/vpn/internal/system"
 )
 
@@ -61,16 +63,18 @@ func (LoginPassword) String() string { return "[redacted]" }
 // GoString implements fmt.GoStringer so %#v is covered too.
 func (LoginPassword) GoString() string { return "[redacted]" }
 
-// SetUserPassword changes the given user's login password
-// via chpasswd (root-privileged through the system seam).
-// The password is piped to chpasswd's stdin so it never
-// appears in argv (which would leak via /proc/*/cmdline or
-// `ps`).
+// SetUserPassword changes the given user's login password.
+// As root it pipes to chpasswd's stdin directly (the password
+// never appears in argv, which would leak via /proc/*/cmdline
+// or `ps`); from the unprivileged TUI it requests the helper's
+// typed set-user-password operation, which re-validates with
+// this same package's constructor and runs the identical
+// chpasswd path root-side.
 //
-// The password arrives as a LoginPassword, so validation
-// has already happened at construction; the zero-value
-// check below closes the one remaining hole (a zero
-// LoginPassword was never validated).
+// The password arrives as a LoginPassword, so validation has
+// already happened at construction; the zero-value check below
+// closes the one remaining hole (a zero LoginPassword was
+// never validated).
 func SetUserPassword(
 	username string, password LoginPassword,
 ) error {
@@ -84,6 +88,14 @@ func SetUserPassword(
 		return errors.New(
 			"password was not validated " +
 				"(zero LoginPassword)")
+	}
+
+	if os.Geteuid() != 0 {
+		return helper.Call(helper.VerbSetUserPassword,
+			helper.SetUserPasswordParams{
+				User:     username,
+				Password: password.v,
+			}, nil)
 	}
 
 	out, err := system.SudoRunStdin(

--- a/internal/lndrpc/client.go
+++ b/internal/lndrpc/client.go
@@ -2,10 +2,11 @@
 
 // Package lndrpc provides a gRPC client for LND.
 //
-// The client reads the admin macaroon once at startup via sudo
-// (using a temp file that's immediately deleted) and holds it
-// in memory for the duration of the process. The macaroon is
-// injected into every gRPC call as metadata.
+// The client reads the TLS certificate and admin macaroon from
+// the staging board — root-staged copies the admin user reads
+// directly, no privileged operation on the read path — and
+// holds the macaroon in memory for the duration of the process.
+// The macaroon is injected into every gRPC call as metadata.
 //
 // Connection uses TLS to localhost. The macaroon never crosses
 // the network. When the TUI process exits, the macaroon is gone
@@ -30,9 +31,9 @@ import (
 
 	"github.com/lightningnetwork/lnd/lnrpc"
 
+	"github.com/virtualprivatenode/vpn/internal/helper"
 	"github.com/virtualprivatenode/vpn/internal/logger"
 	"github.com/virtualprivatenode/vpn/internal/paths"
-	"github.com/virtualprivatenode/vpn/internal/system"
 )
 
 // Client wraps an LND gRPC connection with macaroon authentication.
@@ -64,8 +65,9 @@ func (c *Client) connect() error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	// Read TLS cert
-	certData, err := system.SudoReadFile(paths.LNDTLSCert)
+	// Read the staged TLS cert copy (fail-noisy: a missing
+	// staged fact names itself and points at the journal).
+	certData, err := helper.ReadBoard(paths.StateLNDTLSCert)
 	if err != nil {
 		return fmt.Errorf("read TLS cert: %w", err)
 	}
@@ -77,9 +79,9 @@ func (c *Client) connect() error {
 
 	tlsCreds := credentials.NewClientTLSFromCert(certPool, "")
 
-	// Read macaroon
-	macaroonPath := paths.LNDMacaroon(c.networkDir())
-	macBytes, err := system.SudoReadFile(macaroonPath)
+	// Read the staged admin macaroon copy (staged at wallet
+	// creation; re-staged whenever an operation invalidates it).
+	macBytes, err := helper.ReadBoard(paths.StateLNDMacaroon)
 	if err != nil {
 		return fmt.Errorf("read macaroon: %w", err)
 	}
@@ -152,15 +154,6 @@ func (c *Client) macaroonCtx() context.Context {
 // callCtx returns a context with macaroon and a timeout.
 func (c *Client) callCtx(timeout time.Duration) (context.Context, context.CancelFunc) {
 	return context.WithTimeout(c.macaroonCtx(), timeout)
-}
-
-// networkDir returns the macaroon network directory name.
-// LND uses "mainnet" not "mainnet" in the path for mainnet.
-func (c *Client) networkDir() string {
-	if c.network == "" {
-		return "mainnet"
-	}
-	return c.network
 }
 
 // rpc returns the Lightning client, or nil if not connected.

--- a/internal/lndrpc/client.go
+++ b/internal/lndrpc/client.go
@@ -22,6 +22,7 @@ import (
 	"crypto/x509"
 	"encoding/hex"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -64,7 +65,21 @@ func New(network string) *Client {
 func (c *Client) connect() error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	return c.dial(true)
+}
 
+// dial establishes the connection; the caller holds c.mu.
+//
+// allowHeal enables the staged-certificate self-heal: LND can
+// regenerate its TLS certificate OUTSIDE any helper operation —
+// an automatic restart after a crash, a reboot, a config change
+// applied by a reinstall — and the staged board copy then no
+// longer matches the certificate LND serves. That staleness
+// reliably surfaces exactly here, as a TLS verification failure
+// on the test call. On one, the client asks the helper to
+// re-stage the LND credentials (rate-limited process-wide) and
+// dials again once with the refreshed board copy.
+func (c *Client) dial(allowHeal bool) error {
 	// Read the staged TLS cert copy (fail-noisy: a missing
 	// staged fact names itself and points at the journal).
 	certData, err := helper.ReadBoard(paths.StateLNDTLSCert)
@@ -107,13 +122,66 @@ func (c *Client) connect() error {
 	defer cancel()
 
 	_, err = c.lightning.GetInfo(ctx, &lnrpc.GetInfoRequest{})
-	if err != nil {
-		logger.Status("LND gRPC connected, waiting for RPC ready: %v", err)
-	} else {
+	if err == nil {
 		logger.Status("LND gRPC connected and ready")
+		return nil
 	}
-
+	if allowHeal && isCertificateError(err) &&
+		requestCredentialRestage() {
+		logger.Status("LND gRPC: staged TLS certificate looks "+
+			"stale (%v) — re-staged, reconnecting", err)
+		c.conn.Close()
+		c.conn = nil
+		c.lightning = nil
+		return c.dial(false)
+	}
+	logger.Status("LND gRPC connected, waiting for RPC ready: %v", err)
 	return nil
+}
+
+// isCertificateError reports whether a gRPC connect error looks
+// like a TLS certificate verification failure (as opposed to a
+// down service, a locked wallet, or a plain timeout). Matching
+// on the error text is unavoidable — grpc flattens the tls/x509
+// error chain into a string. Pure — unit-tested.
+func isCertificateError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "x509") ||
+		strings.Contains(msg, "certificate")
+}
+
+// Certificate self-heal state: at most one re-stage request per
+// interval, process-wide — a wrong classification must not turn
+// every reconnect poll into helper traffic.
+var (
+	certRestageMu sync.Mutex
+	certRestageAt time.Time
+)
+
+const certRestageInterval = 5 * time.Minute
+
+// requestCredentialRestage asks the helper to refresh the staged
+// LND credentials from current reality. Reports whether a
+// re-stage actually happened (rate limit passed and the helper
+// succeeded), so the caller only re-dials when the board copy
+// could have changed.
+func requestCredentialRestage() bool {
+	certRestageMu.Lock()
+	defer certRestageMu.Unlock()
+	if !certRestageAt.IsZero() &&
+		time.Since(certRestageAt) < certRestageInterval {
+		return false
+	}
+	certRestageAt = time.Now()
+	if err := helper.Call(
+		helper.VerbStageLNDCredentials, nil, nil); err != nil {
+		logger.Status("stage-lnd-credentials: %v", err)
+		return false
+	}
+	return true
 }
 
 // Reconnect attempts to re-establish the gRPC connection.

--- a/internal/lndrpc/client_test.go
+++ b/internal/lndrpc/client_test.go
@@ -3,6 +3,7 @@
 package lndrpc
 
 import (
+	"fmt"
 	"testing"
 )
 
@@ -81,4 +82,43 @@ func TestNilClientSafety(t *testing.T) {
 	if _, err := c.OpenChannel("a", 100000, false, false, nil, false, 0); err == nil {
 		t.Error("should error")
 	}
+}
+
+// The staged-certificate self-heal keys off this classifier: a
+// TLS verification failure means the board copy may be stale; a
+// down service or a locked wallet must not trigger a re-stage.
+func TestIsCertificateError(t *testing.T) {
+	certErrs := []string{
+		"rpc error: code = Unavailable desc = connection error: " +
+			"desc = \"transport: authentication handshake failed: " +
+			"tls: failed to verify certificate: x509: " +
+			"certificate signed by unknown authority\"",
+		"x509: certificate is valid for 127.0.0.1, not ::1",
+		"tls: bad certificate",
+	}
+	for _, msg := range certErrs {
+		if !isCertificateError(errFromString(msg)) {
+			t.Errorf("not classified as certificate error: %q", msg)
+		}
+	}
+	otherErrs := []string{
+		"rpc error: code = Unavailable desc = connection refused",
+		"rpc error: code = Unimplemented desc = unknown service " +
+			"lnrpc.Lightning",
+		"wallet locked, unlock it to enable full RPC access",
+		"context deadline exceeded",
+	}
+	for _, msg := range otherErrs {
+		if isCertificateError(errFromString(msg)) {
+			t.Errorf("wrongly classified as certificate error: %q",
+				msg)
+		}
+	}
+	if isCertificateError(nil) {
+		t.Error("nil classified as certificate error")
+	}
+}
+
+func errFromString(msg string) error {
+	return fmt.Errorf("%s", msg)
 }

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -34,6 +34,39 @@ const (
 	BitcoinConf = "/etc/bitcoin/bitcoin.conf"
 	BitcoinDir  = "/etc/bitcoin"
 
+	// StateDir is the staging board: root-written files that
+	// carry privileged facts (onion hostnames, staged
+	// credentials) to the unprivileged admin user. The
+	// directory is root:vpn 0750; each file root:vpn 0640.
+	// Root (the installer and the helper) writes; the admin
+	// user reads. Every file is re-written by whatever
+	// operation changes the fact it carries — a reader that
+	// finds a file missing or unreadable reports the feature
+	// unavailable and logs why, never guesses.
+	//
+	// The board lives under /var/lib/vpn — NOT under /etc/vpn
+	// — deliberately: /etc/vpn is owned by the admin user (the
+	// TUI writes config.json there), and a directory owner can
+	// replace a subdirectory with a symlink. Root-side board
+	// writes under an admin-owned parent would hand a
+	// compromised admin account a "make root chown an
+	// arbitrary directory" primitive. Every ancestor of the
+	// board is root-owned, so that class cannot arise.
+	VarLibVPN = "/var/lib/vpn"
+	StateDir  = VarLibVPN + "/state"
+
+	// Staging board files. One fact per file.
+	StateBitcoindRPCPass = StateDir + "/bitcoind-rpc.pass"
+	StateLNDTLSCert      = StateDir + "/lnd-tls.cert"
+	StateLNDMacaroon     = StateDir + "/lnd-admin.macaroon"
+	StateOnionBitcoinP2P = StateDir + "/onion-bitcoin-p2p"
+	StateOnionLNDGRPC    = StateDir + "/onion-lnd-grpc"
+	StateOnionLNDREST    = StateDir + "/onion-lnd-rest"
+	StateOnionSyncthing  = StateDir + "/onion-syncthing"
+	StateSyncthingAPIKey = StateDir + "/syncthing-api-key"
+	StateSyncthingDevID  = StateDir + "/syncthing-device-id"
+	StateSSHPasswordAuth = StateDir + "/ssh-password-auth"
+
 	LNDConf = "/etc/lnd/lnd.conf"
 	LNDDir  = "/etc/lnd"
 
@@ -93,6 +126,16 @@ const (
 	SyncthingService  = "/etc/systemd/system/syncthing.service"
 	BackupWatchPath   = "/etc/systemd/system/lnd-backup-watch.path"
 	BackupCopyService = "/etc/systemd/system/lnd-backup-copy.service"
+
+	// The root helper's socket-activated units. The socket
+	// node's ownership and mode (root:vpn 0660, created by
+	// systemd before the helper ever runs) ARE the
+	// authentication for privileged operations; the service
+	// is started by traffic and exits when idle.
+	HelperSocket         = "/run/vpn-helperd.sock"
+	HelperSocketUnit     = "/etc/systemd/system/vpn-helperd.socket"
+	HelperServiceUnit    = "/etc/systemd/system/vpn-helperd.service"
+	HelperSocketUnitName = "vpn-helperd.socket"
 )
 
 // ── Logs ─────────────────────────────────────────────────
@@ -152,9 +195,12 @@ const (
 	AdminBashProfile   = AdminHome + "/.bash_profile"
 	AuthorizedKeysFile = AdminHome + "/.ssh/authorized_keys"
 
-	// AdminSudoers is the NOPASSWD rule the installer writes
-	// for the admin user. Commit 7 (root helper) deletes it —
-	// nothing replaces it (ruling iii: zero sudoers residue).
+	// AdminSudoers is where older builds granted the admin
+	// user NOPASSWD sudo. The install now DELETES this file
+	// and writes no replacement: the admin user has no sudo
+	// rights at all. Privileged operations go through the
+	// root helper's socket instead (vpn helperd), which
+	// serves a fixed menu of typed operations — not a shell.
 	AdminSudoers = "/etc/sudoers.d/" + AdminUser
 
 	// BinaryPath is where the installer places the running

--- a/internal/system/exec.go
+++ b/internal/system/exec.go
@@ -23,35 +23,48 @@ func Run(name string, args ...string) error {
 	return nil
 }
 
-// maybeSudo prepends sudo to a command line unless the process
-// already runs as root. `vpn install` runs under root dispatch
-// (commit 6), where a sudo prefix would be pointless AND would
-// make the install depend on sudo being installed before the
-// base-package step has run; the TUI runs as the unprivileged
-// admin user, where the sudo prefix is load-bearing (until the
-// commit-7 root helper replaces this seam entirely).
-func maybeSudo(name string, args []string) (string, []string) {
+// requireRoot guards every privileged wrapper below. These
+// wrappers run commands DIRECTLY, with the privilege the process
+// already has — there is no sudo on this box to borrow (the
+// admin user has no sudo rights at all). Two process shapes are
+// allowed to call them: `sudo vpn install` (root by dispatch)
+// and `vpn helperd` (root via its systemd unit). Any other
+// caller is a programming error: an unprivileged code path that
+// should have gone through the helper client instead. Failing
+// loudly here — instead of quietly prefixing sudo and hoping —
+// is deliberate: it makes "no generic root escape from the TUI"
+// a property the binary enforces, not a convention.
+func requireRoot(name string) error {
 	if os.Geteuid() == 0 {
-		return name, args
+		return nil
 	}
-	return "sudo", append([]string{name}, args...)
+	return fmt.Errorf(
+		"%s requires root: this operation must go through "+
+			"the node's root helper (vpn helperd), not run "+
+			"directly — this is a bug worth reporting", name)
 }
 
-// SudoRun executes a command with root privilege: via sudo when
-// unprivileged, directly when already root.
+// SudoRun executes a command that needs root. The name is
+// historical (kept so 100+ call sites read unchanged): it no
+// longer ever invokes sudo — it requires the process itself to
+// be root and refuses otherwise.
 func SudoRun(name string, args ...string) error {
-	n, a := maybeSudo(name, args)
-	return Run(n, a...)
+	if err := requireRoot(name); err != nil {
+		return err
+	}
+	return Run(name, args...)
 }
 
-// SudoRunStdin executes a command with root privilege, feeding
-// stdin from the given string. The payload never appears in argv
+// SudoRunStdin executes a root-requiring command, feeding stdin
+// from the given string. The payload never appears in argv
 // (which would leak via /proc/*/cmdline). Returns trimmed
 // combined output alongside any error, for caller-side message
 // formatting.
 func SudoRunStdin(stdin, name string, args ...string) (string, error) {
-	n, a := maybeSudo(name, args)
-	cmd := exec.Command(n, a...)
+	if err := requireRoot(name); err != nil {
+		return "", err
+	}
+	cmd := exec.Command(name, args...)
 	cmd.Stdin = strings.NewReader(stdin)
 	out, err := cmd.CombinedOutput()
 	return strings.TrimSpace(string(out)), err
@@ -68,11 +81,13 @@ func RunOutput(name string, args ...string) (string, error) {
 	return strings.TrimSpace(string(output)), nil
 }
 
-// SudoRunOutput executes a command with root privilege and
-// returns stdout.
+// SudoRunOutput executes a root-requiring command and returns
+// stdout.
 func SudoRunOutput(name string, args ...string) (string, error) {
-	n, a := maybeSudo(name, args)
-	return RunOutput(n, a...)
+	if err := requireRoot(name); err != nil {
+		return "", err
+	}
+	return RunOutput(name, args...)
 }
 
 // RunContext executes a command with a timeout.
@@ -88,11 +103,13 @@ func RunContext(timeout time.Duration, name string, args ...string) (string, err
 	return strings.TrimSpace(string(output)), nil
 }
 
-// SudoRunContext executes a command with root privilege and a
+// SudoRunContext executes a root-requiring command with a
 // timeout.
 func SudoRunContext(timeout time.Duration, name string, args ...string) (string, error) {
-	n, a := maybeSudo(name, args)
-	return RunContext(timeout, n, a...)
+	if err := requireRoot(name); err != nil {
+		return "", err
+	}
+	return RunContext(timeout, name, args...)
 }
 
 // RunCombinedOutput executes a command and returns combined stdout+stderr.
@@ -106,11 +123,13 @@ func RunCombinedOutput(name string, args ...string) (string, error) {
 	return strings.TrimSpace(string(output)), nil
 }
 
-// SudoRunCombinedOutput executes a command with root privilege
-// and returns combined stdout+stderr.
+// SudoRunCombinedOutput executes a root-requiring command and
+// returns combined stdout+stderr.
 func SudoRunCombinedOutput(name string, args ...string) (string, error) {
-	n, a := maybeSudo(name, args)
-	return RunCombinedOutput(n, a...)
+	if err := requireRoot(name); err != nil {
+		return "", err
+	}
+	return RunCombinedOutput(name, args...)
 }
 
 // RunSilent executes a command and discards all output.
@@ -121,11 +140,13 @@ func RunSilent(name string, args ...string) error {
 	return cmd.Run()
 }
 
-// SudoRunSilent executes a command with root privilege and
-// discards all output.
+// SudoRunSilent executes a root-requiring command and discards
+// all output.
 func SudoRunSilent(name string, args ...string) error {
-	n, a := maybeSudo(name, args)
-	return RunSilent(n, a...)
+	if err := requireRoot(name); err != nil {
+		return err
+	}
+	return RunSilent(name, args...)
 }
 
 // SudoWriteFile atomically writes content to a root-owned path
@@ -211,36 +232,15 @@ func torWrapper() string {
 	return ""
 }
 
-// SudoReadFile reads a file that requires root access. As root
-// it reads directly (the error preserves os.IsNotExist for
-// callers that treat a missing file as empty); unprivileged it
-// stages a copy via sudo. Uses os.CreateTemp for secure temp
-// file creation.
+// SudoReadFile reads a root-readable file. It preserves
+// os.IsNotExist in the error for callers that treat a missing
+// file as empty. Like every wrapper above, it requires the
+// process to already be root: the unprivileged read path for
+// privileged facts is the staging board (/etc/vpn/state), not a
+// privileged copy staged on demand.
 func SudoReadFile(path string) ([]byte, error) {
 	if os.Geteuid() == 0 {
 		return os.ReadFile(path)
 	}
-	tmpFile, err := os.CreateTemp("", "vpn-read-")
-	if err != nil {
-		return nil, fmt.Errorf("create temp file: %w", err)
-	}
-	tmpPath := tmpFile.Name()
-	tmpFile.Close()
-	defer os.Remove(tmpPath)
-
-	if err := SudoRun("cp", path, tmpPath); err != nil {
-		return nil, fmt.Errorf("sudo cp %s: %w", path, err)
-	}
-	if err := SudoRun("chmod", "0600", tmpPath); err != nil {
-		return nil, fmt.Errorf("chmod tmp: %w", err)
-	}
-	if err := SudoRun("chown",
-		fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid()), tmpPath); err != nil {
-		return nil, fmt.Errorf("chown tmp: %w", err)
-	}
-	data, err := os.ReadFile(tmpPath)
-	if err != nil {
-		return nil, fmt.Errorf("read tmp: %w", err)
-	}
-	return data, nil
+	return nil, requireRoot("read " + path)
 }

--- a/internal/system/exec.go
+++ b/internal/system/exec.go
@@ -263,8 +263,8 @@ func torWrapper() string {
 // os.IsNotExist in the error for callers that treat a missing
 // file as empty. Like every wrapper above, it requires the
 // process to already be root: the unprivileged read path for
-// privileged facts is the staging board (/etc/vpn/state), not a
-// privileged copy staged on demand.
+// privileged facts is the staging board (/var/lib/vpn/state),
+// not a privileged copy staged on demand.
 func SudoReadFile(path string) ([]byte, error) {
 	if os.Geteuid() == 0 {
 		return os.ReadFile(path)

--- a/internal/system/exec.go
+++ b/internal/system/exec.go
@@ -192,7 +192,9 @@ func Download(url, dest string) error {
 }
 
 // DownloadRequireTor fetches a URL and fails if torsocks is not available.
-// Retries up to 3 times to handle intermittent Tor DNS resolution failures.
+// Retries up to 3 times to handle intermittent Tor DNS resolution failures
+// (each attempt carries its own tool-level bounds too — see doDownload —
+// so the total is bounded either way).
 func DownloadRequireTor(url, dest string) error {
 	var lastErr error
 	for attempt := 0; attempt < 3; attempt++ {
@@ -207,21 +209,46 @@ func DownloadRequireTor(url, dest string) error {
 	return lastErr
 }
 
+// doDownload runs one fetch with explicit time and retry bounds.
+// The bounds exist for the helper's sake: verb-reachable
+// downloads (self-update, the Syncthing install) run
+// synchronously inside the serialized root helper, and the
+// helper's per-operation deadline bounds only its socket I/O —
+// a subprocess must bound itself. Left at their defaults the
+// tools do not: wget retries up to 20 times with a 900 second
+// read timeout, and curl has no overall cap at all once
+// connected.
+//
+//   - wget: --timeout applies per phase (DNS, connect, read),
+//     so a black-holed transfer dies within a minute instead of
+//     hanging; --tries bounds attempts while still absorbing
+//     transient failures — a single Tor exit-side resolution
+//     failure is common enough that a single-shot fetch
+//     abandons runs a retry would have saved.
+//   - curl (fallback): --connect-timeout bounds setup and
+//     --max-time caps the whole transfer, sized generously for
+//     a large release download over a slow Tor circuit.
 func doDownload(url, dest string, requireTor bool) error {
 	wrapper := torWrapper()
 	if requireTor && wrapper == "" {
 		return fmt.Errorf("torsocks not available — cannot download over Tor")
 	}
 	if _, err := exec.LookPath("wget"); err == nil {
+		wgetArgs := []string{"--timeout=60", "--tries=3",
+			"-q", "-O", dest, url}
 		if wrapper != "" {
-			return Run(wrapper, "wget", "-q", "-O", dest, url)
+			return Run(wrapper, append([]string{"wget"},
+				wgetArgs...)...)
 		}
-		return Run("wget", "-q", "-O", dest, url)
+		return Run("wget", wgetArgs...)
 	}
+	curlArgs := []string{"-sL", "--connect-timeout", "60",
+		"--max-time", "1800", "-o", dest, url}
 	if wrapper != "" {
-		return Run(wrapper, "curl", "-sL", "-o", dest, url)
+		return Run(wrapper, append([]string{"curl"},
+			curlArgs...)...)
 	}
-	return Run("curl", "-sL", "-o", dest, url)
+	return Run("curl", curlArgs...)
 }
 
 // torWrapper returns "torsocks" if available, empty string otherwise.

--- a/internal/system/info.go
+++ b/internal/system/info.go
@@ -60,8 +60,17 @@ func Memory() MemInfo {
 	}
 }
 
+// DirSize measures a directory tree with du. Root only: the
+// data directories it is used on belong to service users. The
+// unprivileged status screen gets the LND size through the
+// helper's dir-size operation (which calls this as root) and
+// the Bitcoin size from bitcoind's own RPC — it never calls
+// this directly.
 func DirSize(path string) string {
-	out, err := exec.Command("sudo", "du", "-sh", path).CombinedOutput()
+	if os.Geteuid() != 0 {
+		return "N/A"
+	}
+	out, err := exec.Command("du", "-sh", path).CombinedOutput()
 	if err != nil {
 		return "N/A"
 	}

--- a/internal/welcome/cmds.go
+++ b/internal/welcome/cmds.go
@@ -37,10 +37,10 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/virtualprivatenode/vpn/internal/config"
+	"github.com/virtualprivatenode/vpn/internal/helper"
 	"github.com/virtualprivatenode/vpn/internal/installer"
 	"github.com/virtualprivatenode/vpn/internal/lndrpc"
 	"github.com/virtualprivatenode/vpn/internal/logger"
-	"github.com/virtualprivatenode/vpn/internal/system"
 )
 
 // ── Polling & version ────────────────────────────────────
@@ -507,6 +507,10 @@ func showNodeURIsCmd(uris []string) tea.Cmd {
 
 // ── System actions ───────────────────────────────────────
 
+// runSvcActionCmd requests a service start/stop/restart from
+// the root helper. The helper validates the unit and action
+// against closed sets and verifies the unit's state afterward;
+// this side just reports the outcome.
 func runSvcActionCmd(action, svc string) tea.Cmd {
 	var verb string
 	switch action {
@@ -520,35 +524,25 @@ func runSvcActionCmd(action, svc string) tea.Cmd {
 		return nil
 	}
 	return func() tea.Msg {
-		system.SudoRun("systemctl", verb, svc)
+		if err := helper.Call(helper.VerbServiceAction,
+			helper.ServiceActionParams{
+				Unit: svc, Action: verb,
+			}, nil); err != nil {
+			logger.Install("%s %s: %v", verb, svc, err)
+		}
 		return svcActionDoneMsg{}
 	}
 }
 
+// runUpdatePackagesCmd requests the helper's package-update
+// operation (apt refresh + upgrade, non-interactive, with a
+// dpkg consistency check after). The helper streams step
+// progress; this button's UX is a single busy state, so the
+// call simply blocks until the terminator.
 func runUpdatePackagesCmd() tea.Cmd {
-	// Non-interactive environment so beginner users
-	// never see mid-upgrade prompts:
-	//   - DEBIAN_FRONTEND=noninteractive suppresses
-	//     debconf dialogs entirely
-	//   - NEEDRESTART_MODE=a tells needrestart (default
-	//     on Debian 13) to auto-restart services instead
-	//     of showing its blue ncurses picker
-	//   - --force-confdef + --force-confold keeps the
-	//     existing config file on any conffile conflict,
-	//     skipping the pink dpkg prompt
-	// This matches the bootstrap script's Phase 1
-	// upgrade command exactly.
 	return func() tea.Msg {
 		logger.Install("Update packages started")
-		err := system.SudoRun("bash", "-c",
-			"DEBIAN_FRONTEND=noninteractive "+
-				"NEEDRESTART_MODE=a "+
-				"apt-get update -qq && "+
-				"DEBIAN_FRONTEND=noninteractive "+
-				"NEEDRESTART_MODE=a "+
-				"apt-get upgrade -y -qq "+
-				"-o Dpkg::Options::=--force-confdef "+
-				"-o Dpkg::Options::=--force-confold")
+		err := helper.Call(helper.VerbPackageUpdate, nil, nil)
 		if err != nil {
 			logger.Install("Update packages failed: %v", err)
 		} else {
@@ -559,8 +553,13 @@ func runUpdatePackagesCmd() tea.Cmd {
 }
 
 func runRebootCmd() tea.Cmd {
-	c := exec.Command("sudo", "reboot")
-	return tea.ExecProcess(c, func(err error) tea.Msg {
+	return func() tea.Msg {
+		// The helper answers, then reboots — the connection
+		// outliving the box is not expected, so any error here
+		// is only logged.
+		if err := helper.Call(helper.VerbReboot, nil, nil); err != nil {
+			logger.Install("reboot: %v", err)
+		}
 		return svcActionDoneMsg{}
-	})
+	}
 }

--- a/internal/welcome/helper_steps.go
+++ b/internal/welcome/helper_steps.go
@@ -1,0 +1,57 @@
+// internal/welcome/helper_steps.go
+
+package welcome
+
+import (
+	"fmt"
+
+	"github.com/virtualprivatenode/vpn/internal/helper"
+	"github.com/virtualprivatenode/vpn/internal/installer"
+)
+
+// buildHelperSteps adapts one streaming helper operation to the
+// step list InstallProgressScreen renders. The operation runs
+// entirely on the root side as ONE serialized request; each
+// local step's Fn simply blocks until the root side reports
+// that step complete, so the widget shows real progress without
+// this process performing any of the work.
+//
+// The names must mirror the helper's own step list for the verb
+// (the shared lists in internal/helper/wire.go; a helper-side
+// unit test keeps them aligned). The final step also consumes
+// the terminator and decodes the operation's result into
+// result (which may be nil).
+func buildHelperSteps(
+	verb string, params any, names []string, result any,
+) []installer.InstallStep {
+	var session *helper.Session
+	steps := make([]installer.InstallStep, len(names))
+	for i := range names {
+		i := i
+		steps[i] = installer.InstallStep{
+			Name: names[i],
+			Fn: func() error {
+				if i == 0 {
+					s, err := helper.Start(verb, params)
+					if err != nil {
+						return err
+					}
+					session = s
+				}
+				if session == nil {
+					return fmt.Errorf(
+						"%s: no helper session (defect)", verb)
+				}
+				if err := session.WaitStep(i); err != nil {
+					session.Close()
+					return err
+				}
+				if i == len(names)-1 {
+					return session.Wait(result)
+				}
+				return nil
+			},
+		}
+	}
+	return steps
+}

--- a/internal/welcome/helpers.go
+++ b/internal/welcome/helpers.go
@@ -2,66 +2,65 @@ package welcome
 
 import (
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
 	"charm.land/bubbles/v2/viewport"
 	"charm.land/lipgloss/v2"
+	"github.com/virtualprivatenode/vpn/internal/bitcoin"
 	"github.com/virtualprivatenode/vpn/internal/config"
+	"github.com/virtualprivatenode/vpn/internal/helper"
 	"github.com/virtualprivatenode/vpn/internal/lndrpc"
 	"github.com/virtualprivatenode/vpn/internal/logger"
 	"github.com/virtualprivatenode/vpn/internal/paths"
-	"github.com/virtualprivatenode/vpn/internal/system"
 	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
+// onionBoardFile maps a Tor hidden-service hostname path to
+// its staged copy on the board — the unprivileged read path
+// for onion addresses (the originals are readable only by
+// root and the tor user).
+var onionBoardFile = map[string]string{
+	paths.TorBitcoinP2P + "/hostname": paths.StateOnionBitcoinP2P,
+	paths.TorLNDGRPC + "/hostname":    paths.StateOnionLNDGRPC,
+	paths.TorLNDRESTHostname:          paths.StateOnionLNDREST,
+	paths.TorSyncthingHostname:        paths.StateOnionSyncthing,
+}
+
 func readOnion(path string) string {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		output, err := system.SudoRunOutput("cat", path)
-		if err != nil {
-			return ""
-		}
-		return strings.TrimSpace(output)
+	board, ok := onionBoardFile[path]
+	if !ok {
+		logger.Status("readOnion: no staged copy mapped for %s", path)
+		return ""
 	}
-	return strings.TrimSpace(string(data))
+	v, err := helper.ReadBoardString(board)
+	if err != nil {
+		// Fail-noisy: the screen renders the address as
+		// unavailable; the log names the missing fact.
+		logger.Status("%v", err)
+		return ""
+	}
+	return v
 }
 
 func readMacaroonHex(cfg *config.AppConfig) string {
-	network := cfg.Network
-	if cfg.IsMainnet() {
-		network = "mainnet"
-	}
-	path := paths.LNDMacaroon(network)
-
-	data, err := os.ReadFile(path)
+	data, err := helper.ReadBoard(paths.StateLNDMacaroon)
 	if err != nil {
-		data, err = system.SudoReadFile(path)
-		if err != nil {
-			logger.Status("Warning: failed to read macaroon: %v", err)
-			return ""
-		}
+		logger.Status("Warning: failed to read macaroon: %v", err)
+		return ""
 	}
 	return hex.EncodeToString(data)
 }
 
 // ── Fee estimation via bitcoin-cli ───────────────────────
 
-type smartFeeResponse struct {
-	FeeRate float64  `json:"feerate"`
-	Errors  []string `json:"errors"`
-	Blocks  int      `json:"blocks"`
-}
-
 func fetchFeeTiers(cfg *config.AppConfig) feeTiersMsg {
 	targets := [4]int{1, 3, 6, 25}
 	labels := [4]string{"~1 blk", "~3 blk", "~6 blk", "~25 blk"}
 	var tiers [4]feeTier
 
-	cliName := "bitcoin-cli"
+	rpcPort := cfg.NetworkConfig().RPCPort
 
 	for i, target := range targets {
 		tiers[i] = feeTier{
@@ -69,37 +68,13 @@ func fetchFeeTiers(cfg *config.AppConfig) feeTiersMsg {
 			Label:  labels[i],
 		}
 
-		output, err := system.RunContext(
-			5*time.Second,
-			"sudo", "-u", "bitcoin",
-			cliName,
-			fmt.Sprintf("-datadir=%s", paths.BitcoinDataDir),
-			fmt.Sprintf("-conf=%s", paths.BitcoinConf),
-			"estimatesmartfee",
-			fmt.Sprintf("%d", target),
-		)
+		// Direct RPC with the node's own staged credential —
+		// no privileged call anywhere on the fee path.
+		satPerVB, err := bitcoin.EstimateSmartFee(rpcPort, target)
 		if err != nil {
 			continue
 		}
-
-		var resp smartFeeResponse
-		if err := json.Unmarshal(
-			[]byte(strings.TrimSpace(output)),
-			&resp,
-		); err != nil {
-			continue
-		}
-
-		if resp.FeeRate > 0 && len(resp.Errors) == 0 {
-			// bitcoin-cli returns BTC/kB
-			// Convert to sat/vB:
-			// BTC/kB × 100,000,000 / 1000 = sat/vB
-			satPerVB := resp.FeeRate * 100000
-			if satPerVB < 1 {
-				satPerVB = 1
-			}
-			tiers[i].SatPerVB = satPerVB
-		}
+		tiers[i].SatPerVB = satPerVB
 	}
 
 	// Check if we got at least one valid tier

--- a/internal/welcome/screen_addon_syncthing_install.go
+++ b/internal/welcome/screen_addon_syncthing_install.go
@@ -5,7 +5,9 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/virtualprivatenode/vpn/internal/config"
+	"github.com/virtualprivatenode/vpn/internal/helper"
 	"github.com/virtualprivatenode/vpn/internal/installer"
+	"github.com/virtualprivatenode/vpn/internal/logger"
 	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
@@ -31,8 +33,8 @@ type SyncthingInstallScreen struct {
 	// Progress step — embedded screen
 	progress *InstallProgressScreen
 
-	// Generated during confirm → progress transition
-	syncPassword string
+	// Filled by the helper operation's result on success
+	result helper.SyncthingInstallResult
 }
 
 func NewSyncthingInstallScreen(
@@ -112,17 +114,19 @@ func (s *SyncthingInstallScreen) startInstall() (
 ) {
 	cfg := s.ctx.Cfg
 
-	// Set installed flag before building steps so Tor
-	// and firewall configs include Syncthing services.
+	// Set installed for this session's screens; the on-disk
+	// save happens only on success. The install itself —
+	// download, verification, service, Tor rebuild, staging —
+	// runs on the root side of the helper boundary as one
+	// operation; the generated web-UI password comes back in
+	// the operation's result.
 	cfg.SyncthingInstalled = true
 
-	steps, password, err := installer.SyncthingInstallSteps(cfg)
-	if err != nil {
-		// Revert flag on error
-		cfg.SyncthingInstalled = false
-		return s, nil
-	}
-	s.syncPassword = password
+	steps := buildHelperSteps(
+		helper.VerbSyncthingInstall, nil,
+		helper.SyncthingInstallStepNames(
+			installer.SyncthingVersionStr()),
+		&s.result)
 
 	s.progress = NewInstallProgressScreen(
 		s.ctx, steps, s.onInstallDone, s.onInstallFail)
@@ -133,7 +137,7 @@ func (s *SyncthingInstallScreen) startInstall() (
 func (s *SyncthingInstallScreen) onInstallDone() tea.Cmd {
 	return func() tea.Msg {
 		cfg := s.ctx.Cfg
-		cfg.SyncthingPassword = s.syncPassword
+		cfg.SyncthingPassword = s.result.Password
 		config.Save(cfg)
 		return refreshStatusMsg{}
 	}
@@ -143,8 +147,16 @@ func (s *SyncthingInstallScreen) onInstallFail() tea.Cmd {
 	return func() tea.Msg {
 		cfg := s.ctx.Cfg
 		cfg.SyncthingInstalled = false
-		installer.RebuildTorConfig(cfg)
-		installer.RestartTor()
+		// Roll the Tor config back to the pre-install shape
+		// (the failed operation may have added Syncthing's
+		// hidden service before dying).
+		if err := helper.Call(helper.VerbRebuildTorConfig,
+			helper.RebuildTorConfigParams{
+				LND:       cfg.HasLND(),
+				Syncthing: false,
+			}, nil); err != nil {
+			logger.Install("syncthing rollback: %v", err)
+		}
 		config.Save(cfg)
 		return refreshStatusMsg{}
 	}

--- a/internal/welcome/screen_channels_node_info.go
+++ b/internal/welcome/screen_channels_node_info.go
@@ -31,7 +31,8 @@ import (
 //
 // Button row is dynamic based on which URI types LND
 // advertises:
-//   - 0 URIs:     (no buttons) + warning text
+//   - 0 URIs:     (no buttons) + status text (sync-aware:
+//     expected during chain sync, a warning once synced)
 //   - clearnet:   [ Show QR (Clearnet) ] [ Copy URIs ]
 //   - tor:        [ Show QR (Tor) ] [ Copy URIs ]
 //   - both:       [ Show QR (Clearnet) ] [ Show QR (Tor) ] [ Copy URIs ]
@@ -338,13 +339,26 @@ func (s *NodeInfoScreen) View(w, h int) string {
 	// view where the terminal can display them
 	// cleanly and the user can select with native
 	// mouse selection. Here we either explain how to
-	// access them or warn that none are advertised.
+	// access them or explain why none are advertised.
+	// Sync-aware: LND advertises URIs only once its
+	// chain backend is synced, so during initial
+	// block download an empty list is the expected
+	// state, not a misconfiguration — the warning is
+	// reserved for a synced node.
 	if len(status.lndURIs) == 0 {
-		p.warn(
-			"No URIs advertised by LND — configure")
-		p.warn(
-			"listen addresses to make your node")
-		p.warn("reachable.")
+		if !status.lndSyncedChain {
+			p.dim(
+				"No URIs advertised yet — LND starts")
+			p.dim(
+				"advertising addresses once the chain")
+			p.dim("finishes syncing.")
+		} else {
+			p.warn(
+				"No URIs advertised by LND — configure")
+			p.warn(
+				"listen addresses to make your node")
+			p.warn("reachable.")
+		}
 	} else {
 		p.dim(
 			"Press Copy URIs to view your node URIs")

--- a/internal/welcome/screen_system_home.go
+++ b/internal/welcome/screen_system_home.go
@@ -10,6 +10,7 @@ import (
 	"charm.land/lipgloss/v2"
 
 	"github.com/virtualprivatenode/vpn/internal/bitcoin"
+	"github.com/virtualprivatenode/vpn/internal/helper"
 	"github.com/virtualprivatenode/vpn/internal/installer"
 	"github.com/virtualprivatenode/vpn/internal/theme"
 )
@@ -167,7 +168,7 @@ func (s *SystemHomeScreen) HandleKey(
 		if s.focusZone == sysHomeZoneServices {
 			svc := s.svcName(s.svcCursor)
 			c := exec.Command("bash", "-c",
-				"clear && sudo journalctl -u "+svc+
+				"clear && journalctl -u "+svc+
 					" -n 100 --no-pager"+
 					" && echo && echo "+
 					"'  Press Enter to return...'"+
@@ -327,10 +328,18 @@ func (s *SystemHomeScreen) View(
 	headerLines = append(headerLines,
 		centerPad(theme.Action.Render(verText), w))
 
-	hasUpdate := s.hasUpdate()
-	if hasUpdate {
+	if s.hasUpdate() {
 		updateText := "Update available: v" +
 			s.ctx.LatestVersion
+		if !s.updateInstallable() {
+			// Cross-major (or unparseable) release: announced,
+			// never one-click installed — the release notes come
+			// first. The helper refuses it independently; this
+			// is the rendering half of the same gate.
+			updateText = "Major release v" +
+				s.ctx.LatestVersion +
+				" available — see the release notes"
+		}
 		headerLines = append(headerLines,
 			centerPad(
 				lipgloss.NewStyle().
@@ -702,9 +711,20 @@ func (s *SystemHomeScreen) hasUpdate() bool {
 		s.ctx.LatestVersion != s.ctx.Version
 }
 
+// updateInstallable reports whether the available update may be
+// installed from here: same major version only. A cross-major
+// release is a read-the-release-notes event; the Update Node
+// action does not exist for it (and the root helper refuses it
+// independently — this check is rendering, not the gate).
+func (s *SystemHomeScreen) updateInstallable() bool {
+	same, err := helper.SameMajor(
+		s.ctx.Version, s.ctx.LatestVersion)
+	return err == nil && same
+}
+
 func (s *SystemHomeScreen) buttonActions() []sysBtn {
 	actions := []sysBtn{sysBtnUpdatePkg, sysBtnSSHKeys}
-	if s.hasUpdate() {
+	if s.hasUpdate() && s.updateInstallable() {
 		actions = append(actions, sysBtnUpdateNode)
 	}
 	if s.ctx.Status != nil &&

--- a/internal/welcome/screen_system_p2p_upgrade.go
+++ b/internal/welcome/screen_system_p2p_upgrade.go
@@ -8,7 +8,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/virtualprivatenode/vpn/internal/config"
-	"github.com/virtualprivatenode/vpn/internal/installer"
+	"github.com/virtualprivatenode/vpn/internal/helper"
 	"github.com/virtualprivatenode/vpn/internal/system"
 	"github.com/virtualprivatenode/vpn/internal/theme"
 )
@@ -283,12 +283,21 @@ func (s *P2PUpgradeScreen) startInstall() (
 ) {
 	cfg := s.ctx.Cfg
 
-	// Set hybrid before building steps so LND config
-	// and firewall include clearnet listeners.
+	// Set hybrid so this session's screens reflect the mode
+	// being applied; the on-disk save happens only on success.
 	cfg.P2PMode = "hybrid"
 
-	steps := installer.P2PUpgradeSteps(
-		cfg, s.publicIP)
+	// The mode switch (LND config, firewall, LND restart, and
+	// re-staging the regenerated TLS certificate) runs on the
+	// root side of the helper boundary as one operation. The
+	// helper derives the box's public address itself — the IP
+	// this screen showed the operator is display, not an input
+	// it will accept.
+	steps := buildHelperSteps(
+		helper.VerbSetP2PMode,
+		helper.SetP2PModeParams{Mode: "hybrid"},
+		helper.SetP2PModeStepNames(),
+		nil)
 
 	s.progress = NewInstallProgressScreen(
 		s.ctx, steps,

--- a/internal/welcome/screen_system_self_update.go
+++ b/internal/welcome/screen_system_self_update.go
@@ -4,7 +4,7 @@ import (
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/virtualprivatenode/vpn/internal/installer"
+	"github.com/virtualprivatenode/vpn/internal/helper"
 	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
@@ -110,8 +110,16 @@ func (s *SelfUpdateScreen) HandleKey(
 func (s *SelfUpdateScreen) startInstall() (
 	Screen, tea.Cmd,
 ) {
-	steps := installer.SelfUpdateSteps(
-		s.ctx.LatestVersion)
+	// The whole update — download, GPG and checksum
+	// verification, binary install — runs on the ROOT side of
+	// the helper boundary as one operation; these steps only
+	// mirror its progress. The helper independently enforces
+	// the same-major gate this screen renders.
+	steps := buildHelperSteps(
+		helper.VerbSelfUpdate,
+		helper.SelfUpdateParams{Version: s.ctx.LatestVersion},
+		helper.SelfUpdateStepNames(s.ctx.LatestVersion),
+		nil)
 
 	s.progress = NewInstallProgressScreen(
 		s.ctx, steps, s.onDone, nil)

--- a/internal/welcome/screen_system_wallet_create.go
+++ b/internal/welcome/screen_system_wallet_create.go
@@ -7,7 +7,9 @@ import (
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/virtualprivatenode/vpn/internal/helper"
 	"github.com/virtualprivatenode/vpn/internal/installer"
+	"github.com/virtualprivatenode/vpn/internal/paths"
 	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
@@ -77,6 +79,10 @@ type walletExecDoneMsg struct{ err error }
 // this tab in place into an AutoUnlockScreen. See
 // update.go for the handler.
 type walletCreatedMsg struct{}
+
+// walletStageFailedMsg reports that the wallet exists but the
+// helper could not stage its credentials for this console.
+type walletStageFailedMsg struct{ err error }
 
 type WalletCreateScreen struct {
 	ctx  *ScreenContext
@@ -211,12 +217,27 @@ func (s *WalletCreateScreen) HandleMsg(
 				"wallet creation failed: %v", m.err)
 			return s, nil
 		}
-		// Success. Model handles walletCreatedMsg by
-		// creating the lndClient and transforming this
-		// tab into the auto-unlock screen.
+		// Success. Wallet creation just minted this node's
+		// admin macaroon — have the helper stage copies for
+		// this console BEFORE the Model builds the gRPC
+		// client that reads them.
 		return s, func() tea.Msg {
+			if err := helper.Call(
+				helper.VerbStageLNDCredentials,
+				nil, nil); err != nil {
+				return walletStageFailedMsg{err: err}
+			}
 			return walletCreatedMsg{}
 		}
+
+	case walletStageFailedMsg:
+		s.step = walletErr
+		s.resultErr = fmt.Errorf(
+			"the wallet was created, but its credentials "+
+				"could not be staged for this console: %v — "+
+				"the console cannot reach the wallet until "+
+				"that is resolved", m.err)
+		return s, nil
 	}
 	return s, nil
 }
@@ -294,8 +315,9 @@ echo
 echo "  Your seed phrase will appear in this terminal."
 echo "  Make sure nobody is looking over your shoulder."
 echo
-sudo -u bitcoin lncli ` +
-		`--lnddir=/var/lib/lnd ` +
+/usr/local/bin/lncli ` +
+		`--rpcserver=localhost:10009 ` +
+		`--tlscertpath=` + paths.StateLNDTLSCert + ` ` +
 		`--network=` + net.LNCLINetwork + ` create && {
   trap '' INT
   echo

--- a/internal/welcome/status.go
+++ b/internal/welcome/status.go
@@ -3,11 +3,13 @@ package welcome
 import (
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/virtualprivatenode/vpn/internal/bitcoin"
 	"github.com/virtualprivatenode/vpn/internal/config"
+	"github.com/virtualprivatenode/vpn/internal/helper"
 	"github.com/virtualprivatenode/vpn/internal/lndrpc"
-	"github.com/virtualprivatenode/vpn/internal/paths"
+	"github.com/virtualprivatenode/vpn/internal/logger"
 	"github.com/virtualprivatenode/vpn/internal/system"
 
 	tea "charm.land/bubbletea/v2"
@@ -33,13 +35,22 @@ func fetchStatus(cfg *config.AppConfig, lndClient *lndrpc.Client) tea.Cmd {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			info := bitcoin.GetBlockchainInfo()
+			info := bitcoin.GetBlockchainInfo(
+				cfg.NetworkConfig().RPCPort)
 			mu.Lock()
 			s.btcResponding = info.Responding
 			s.btcBlocks = info.Blocks
 			s.btcHeaders = info.Headers
 			s.btcProgress = info.Progress
 			s.btcSynced = info.Synced
+			// bitcoind reports its own data footprint
+			// (size_on_disk) — no privileged measurement of
+			// the data dir is needed for this card.
+			if info.Responding {
+				s.btcSize = bitcoin.FormatSize(info.SizeOnDisk)
+			} else {
+				s.btcSize = "N/A"
+			}
 			mu.Unlock()
 		}()
 
@@ -48,10 +59,9 @@ func fetchStatus(cfg *config.AppConfig, lndClient *lndrpc.Client) tea.Cmd {
 			defer wg.Done()
 			disk := system.Disk("/")
 			mem := system.Memory()
-			btcSize := system.DirSize(paths.BitcoinDataDir)
 			var lndSize string
 			if cfg.HasLND() {
-				lndSize = system.DirSize(paths.LNDDataDir)
+				lndSize = cachedLNDSize()
 			}
 			mu.Lock()
 			s.diskTotal = disk.Total
@@ -60,7 +70,6 @@ func fetchStatus(cfg *config.AppConfig, lndClient *lndrpc.Client) tea.Cmd {
 			s.ramTotal = mem.Total
 			s.ramUsed = mem.Used
 			s.ramPct = mem.Percent
-			s.btcSize = btcSize
 			s.lndSize = lndSize
 			mu.Unlock()
 		}()
@@ -182,4 +191,38 @@ func fetchStatus(cfg *config.AppConfig, lndClient *lndrpc.Client) tea.Cmd {
 
 		return s
 	}
+}
+
+// ── LND data-dir size (helper-measured, cached) ─────────
+//
+// The LND data dir belongs to the service user, so its size is
+// measured by the root helper (dir-size operation). Directory
+// sizes change slowly and the status poll is frequent, so the
+// answer — including a failed answer — is cached for five
+// minutes: the display stays fresh enough while the helper
+// isn't woken on every poll tick.
+
+var (
+	lndSizeMu  sync.Mutex
+	lndSizeVal string
+	lndSizeAt  time.Time
+)
+
+func cachedLNDSize() string {
+	lndSizeMu.Lock()
+	defer lndSizeMu.Unlock()
+	if !lndSizeAt.IsZero() &&
+		time.Since(lndSizeAt) < 5*time.Minute {
+		return lndSizeVal
+	}
+	var res helper.DirSizeResult
+	if err := helper.Call(helper.VerbDirSize,
+		helper.DirSizeParams{Which: "lnd"}, &res); err != nil {
+		logger.Status("lnd dir size: %v", err)
+		lndSizeVal = "N/A"
+	} else {
+		lndSizeVal = res.Size
+	}
+	lndSizeAt = time.Now()
+	return lndSizeVal
 }


### PR DESCRIPTION
Removes the admin user's passwordless sudo and replaces it with a small root helper daemon. The console runs with no privileges at all; every privileged change goes through a fixed menu of thirteen typed verbs over a local unix socket owned by root and the admin group.

The helper is socket activated and exits after two minutes of idle. It verifies the caller's credentials on the socket, serializes requests, applies a deadline to every verb, and writes an audit line for each request and outcome to the system journal. Requests are decoded strictly: unknown verbs and unknown parameters are rejected before anything runs.

Privileged facts the console needs to read are published to a staging board under /var/lib/vpn/state, readable by the admin group. Each verb restages the board facts it can change, so the board follows privileged state mechanically. The console repairs a stale staged TLS certificate when it sees a certificate failure, at most once per five minutes.

The installer gains first boot steps for the journal access group, the helper units, and the initial board snapshot. The old NOPASSWD sudoers rule is removed, including any rule left by earlier installs. Shell wrappers let the admin user run bitcoin cli and lncli without sudo; console tooling authenticates to bitcoind with rpcauth while LND stays on the cookie file.

Also folded in during verification on live boxes:

* ssh password authentication can be disabled while a key is present; the helper reads the key list with home directories mounted read only instead of hidden
* adding the first ssh key creates the ssh directory, so a password only install can bootstrap its first key from the console
* the syncthing version check works from the helper environment, which is not a login shell and sets no HOME
* migration restarts services instead of only starting them, so a rewritten unit and configuration actually take effect
* the wallet unlock unit is written whenever carried configuration enables automatic unlock, so unlock survives restarts and reboots
* network steps bound their downloads with timeouts and retries for both the package manager and direct fetches
* the node info screen explains that addresses appear once the chain finishes syncing instead of implying a configuration problem
* installs that end with no ssh access no longer print an ssh hint that cannot work
* comment corrections to the staging board paths and the wire protocol event documentation

The install run takes a lock so concurrent runs cannot interleave, a console only install is possible behind an explicit flag when no ssh way in exists, the installer warns on wrong sudoers.d file modes, ssh keys are installed before hardening is applied, and self update refuses a release with a different major version on both the console side and the helper side.