### PR TITLE
fix: lnd loopback endpoints are defined once and dialed by address

### DIFF
--- a/internal/installer/bitcoin.go
+++ b/internal/installer/bitcoin.go
@@ -117,6 +117,10 @@ zmqpubrawtx=tcp://127.0.0.1:%d
 // credential, staging the matching password on the board in
 // the same operation — the hashed line and the cleartext are
 // only ever replaced together, so they cannot drift apart.
+// Together is not atomic: a failure between the two writes
+// leaves them divergent, but detectably so — the install
+// aborts loudly and RPC auth keeps failing with a clear
+// mismatch message until a rerun replaces the pair.
 func writeBitcoinConfig(cfg *config.AppConfig) error {
 	rpcauthLine, err := writeRPCAuthCredential()
 	if err != nil {

--- a/internal/installer/lnd.go
+++ b/internal/installer/lnd.go
@@ -82,12 +82,18 @@ func createLNDDirs(username string) error {
 	return nil
 }
 
-func writeLNDConfig(cfg *config.AppConfig, publicIPv4 string) error {
+// BuildLNDConfig generates lnd.conf content. Pure logic — no
+// side effects. LND binds by the literal loopback addresses
+// defined once in paths — the same constants every client
+// dials — so the two ends of each connection cannot disagree,
+// and the name localhost appears nowhere in the file (on this
+// node, which disables IPv6, that name can resolve to an
+// unusable IPv6 address).
+func BuildLNDConfig(cfg *config.AppConfig, publicIPv4, restOnion string) string {
 	net := cfg.NetworkConfig()
-	restOnion := strings.TrimSpace(readFileOrDefault(paths.TorLNDRESTHostname, ""))
 
-	listenLine := "listen=localhost:9735"
-	restListenLine := "restlisten=localhost:8080"
+	listenLine := "listen=" + paths.LNDP2PBind
+	restListenLine := "restlisten=" + paths.LNDRESTEndpoint
 	externalLine := ""
 	tlsExtraIP := ""
 	if cfg.P2PMode == "hybrid" && publicIPv4 != "" {
@@ -104,11 +110,11 @@ func writeLNDConfig(cfg *config.AppConfig, publicIPv4 string) error {
 
 	cookiePath := paths.LNDCookiePath(net.CookiePath)
 
-	content := fmt.Sprintf(`# Virtual Private Node — LND
+	return fmt.Sprintf(`# Virtual Private Node — LND
 [Application Options]
 lnddir=/var/lib/lnd
 %s
-rpclisten=localhost:10009
+rpclisten=%s
 %s
 debuglevel=info
 %s
@@ -181,10 +187,16 @@ db.bolt.auto-compact-min-age=168h
 healthcheck.diskspace.diskrequired=0.05
 healthcheck.diskspace.attempts=2
 healthcheck.diskspace.interval=12h
-`, listenLine, restListenLine, externalLine, tlsExtraDomain, tlsExtraIP,
+`, listenLine, paths.LNDGRPCEndpoint, restListenLine, externalLine,
+		tlsExtraDomain, tlsExtraIP,
 		net.LNDBitcoinFlag, cookiePath,
 		net.RPCPort, net.ZMQBlockPort, net.ZMQTxPort)
+}
 
+func writeLNDConfig(cfg *config.AppConfig, publicIPv4 string) error {
+	restOnion := strings.TrimSpace(
+		readFileOrDefault(paths.TorLNDRESTHostname, ""))
+	content := BuildLNDConfig(cfg, publicIPv4, restOnion)
 	if err := system.SudoWriteFile(paths.LNDConf, []byte(content), 0640); err != nil {
 		return err
 	}
@@ -353,7 +365,8 @@ func disableAutoUnlock() error {
 func waitForLND() error {
 	for i := 0; i < 60; i++ {
 		client := buildLNDClient()
-		resp, err := client.Get("https://localhost:8080/v1/state")
+		resp, err := client.Get(
+			"https://" + paths.LNDRESTEndpoint + "/v1/state")
 		if err == nil {
 			resp.Body.Close()
 			return nil

--- a/internal/installer/lnd_test.go
+++ b/internal/installer/lnd_test.go
@@ -6,8 +6,64 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/virtualprivatenode/vpn/internal/config"
 	"github.com/virtualprivatenode/vpn/internal/paths"
 )
+
+// The generated lnd.conf binds by the literal loopback
+// addresses defined once in paths — the same constants every
+// client dials — and carries no host name anywhere. On this
+// node, which disables IPv6, the name localhost can resolve to
+// an unusable IPv6 address, so it must never appear.
+func TestBuildLNDConfigBindsByAddress(t *testing.T) {
+	// Tor-only: every listener on the loopback constants.
+	cfg := config.Default()
+	torOnly := BuildLNDConfig(cfg, "", "")
+	for _, want := range []string{
+		"listen=" + paths.LNDP2PBind,
+		"restlisten=" + paths.LNDRESTEndpoint,
+		"rpclisten=" + paths.LNDGRPCEndpoint,
+	} {
+		if !strings.Contains(torOnly, want) {
+			t.Errorf("tor-only config missing %q", want)
+		}
+	}
+
+	// Hybrid: P2P and REST bind all interfaces as computed;
+	// gRPC stays on the loopback constant.
+	hybrid := config.Default()
+	hybrid.P2PMode = "hybrid"
+	hybridConf := BuildLNDConfig(hybrid, "203.0.113.7", "")
+	for _, want := range []string{
+		"listen=0.0.0.0:9735",
+		"restlisten=0.0.0.0:8080",
+		"rpclisten=" + paths.LNDGRPCEndpoint,
+		"externalhosts=203.0.113.7:9735",
+		"tlsextraip=203.0.113.7",
+	} {
+		if !strings.Contains(hybridConf, want) {
+			t.Errorf("hybrid config missing %q", want)
+		}
+	}
+
+	// No host name in either variant, with or without a REST
+	// onion for tlsextradomain.
+	withOnion := BuildLNDConfig(cfg, "",
+		"exampleonionaddress.onion")
+	for name, conf := range map[string]string{
+		"tor-only": torOnly,
+		"hybrid":   hybridConf,
+		"onion":    withOnion,
+	} {
+		if strings.Contains(conf, "localhost") {
+			t.Errorf("%s config contains the name localhost", name)
+		}
+	}
+	if !strings.Contains(withOnion,
+		"tlsextradomain=exampleonionaddress.onion") {
+		t.Error("onion config missing tlsextradomain")
+	}
+}
 
 // The LND unit template: one source for both variants, so they
 // can never drift apart in anything but the unlock flag.

--- a/internal/installer/setup.go
+++ b/internal/installer/setup.go
@@ -1005,13 +1005,14 @@ export -f bitcoin-cli
 		content += fmt.Sprintf(`
 lncli() {
     /usr/local/bin/lncli \
-        --rpcserver=localhost:10009 \%s
+        --rpcserver=%s \%s
         --macaroonpath=%s \
         --tlscertpath=%s \
         "$@"
 }
 export -f lncli
-`, lndNetFlag, paths.StateLNDMacaroon, paths.StateLNDTLSCert)
+`, paths.LNDGRPCEndpoint, lndNetFlag,
+			paths.StateLNDMacaroon, paths.StateLNDTLSCert)
 	}
 
 	if content == "" {

--- a/internal/lndrpc/client.go
+++ b/internal/lndrpc/client.go
@@ -8,9 +8,9 @@
 // holds the macaroon in memory for the duration of the process.
 // The macaroon is injected into every gRPC call as metadata.
 //
-// Connection uses TLS to localhost. The macaroon never crosses
-// the network. When the TUI process exits, the macaroon is gone
-// from memory.
+// Connection uses TLS to the loopback address. The macaroon
+// never crosses the network. When the TUI process exits, the
+// macaroon is gone from memory.
 //
 // This package only performs read operations. Fund-moving RPCs
 // (SendPayment, OpenChannel, etc.) are added in later changes
@@ -108,7 +108,11 @@ func (c *Client) dial(allowHeal bool) error {
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(50 * 1024 * 1024)),
 	}
 
-	conn, err := grpc.NewClient("localhost:10009", opts...)
+	// Dial by the shared loopback constant — the same value
+	// lnd.conf binds to. Never by the name localhost: with
+	// IPv6 disabled on the node, that name can resolve to an
+	// IPv6 address the connection cannot use.
+	conn, err := grpc.NewClient(paths.LNDGRPCEndpoint, opts...)
 	if err != nil {
 		return fmt.Errorf("grpc connect: %w", err)
 	}

--- a/internal/lndrpc/client_test.go
+++ b/internal/lndrpc/client_test.go
@@ -103,6 +103,15 @@ func TestIsCertificateError(t *testing.T) {
 	}
 	otherErrs := []string{
 		"rpc error: code = Unavailable desc = connection refused",
+		// Observed in production when the client dialed LND by
+		// the name localhost on a box with IPv6 disabled: the
+		// name resolved to ::1 and the kernel refused the
+		// address. An address-family failure, not a stale
+		// certificate — a re-stage must never fire on it.
+		"rpc error: code = Unavailable desc = connection error: " +
+			"desc = \"transport: Error while dialing: dial tcp " +
+			"[::1]:10009: connect: cannot assign requested " +
+			"address\"",
 		"rpc error: code = Unimplemented desc = unknown service " +
 			"lnrpc.Lightning",
 		"wallet locked, unlock it to enable full RPC access",

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -73,6 +73,37 @@ const (
 	SyncthingDir = "/etc/syncthing"
 )
 
+// ── Loopback endpoints ───────────────────────────────────
+
+// Each loopback endpoint is defined exactly once, and BOTH
+// ends of every connection use the same constant: lnd.conf
+// binds LND to these values, and every client dials them —
+// so the two ends cannot silently disagree.
+//
+// The values are literal IPv4 addresses, never the name
+// localhost. The installer disables IPv6 at the kernel, but
+// Debian's /etc/hosts still maps localhost to ::1, and that
+// file is not ours to correct (cloud provider tooling may
+// regenerate it). Reaching loopback by name can therefore
+// resolve to an IPv6 address the box cannot use; on a node
+// that disables IPv6, loopback is always dialed by address.
+const (
+	// LNDGRPCEndpoint is LND's gRPC server. Dialed by the
+	// console's gRPC client, the wallet-creation lncli
+	// invocation, and the shell's lncli wrapper.
+	LNDGRPCEndpoint = "127.0.0.1:10009"
+
+	// LNDRESTEndpoint is LND's REST server. Dialed by the
+	// installer's readiness probe; the Tor hidden service
+	// forwards the REST onion here.
+	LNDRESTEndpoint = "127.0.0.1:8080"
+
+	// LNDP2PBind is LND's peer listener in tor-only mode.
+	// Hybrid mode binds all interfaces instead, computed
+	// where the config is written.
+	LNDP2PBind = "127.0.0.1:9735"
+)
+
 // ── Data ─────────────────────────────────────────────────
 
 const (

--- a/internal/paths/paths_test.go
+++ b/internal/paths/paths_test.go
@@ -1,0 +1,40 @@
+// internal/paths/paths_test.go
+
+package paths
+
+import (
+	"net"
+	"testing"
+)
+
+// The loopback endpoints must be literal IPv4 addresses — never
+// a host name. The node disables IPv6 while /etc/hosts (a file
+// we do not own) still maps localhost to ::1, so an endpoint
+// that regressed to a name could resolve to an address the box
+// cannot use. Pinning the literal here keeps that regression
+// impossible for every consumer at once.
+func TestLoopbackEndpointsAreLiteralIPv4(t *testing.T) {
+	endpoints := map[string]string{
+		"LNDGRPCEndpoint": LNDGRPCEndpoint,
+		"LNDRESTEndpoint": LNDRESTEndpoint,
+		"LNDP2PBind":      LNDP2PBind,
+	}
+	for name, ep := range endpoints {
+		host, port, err := net.SplitHostPort(ep)
+		if err != nil {
+			t.Errorf("%s = %q: not host:port: %v", name, ep, err)
+			continue
+		}
+		if host != "127.0.0.1" {
+			t.Errorf("%s = %q: host is %q, want the literal "+
+				"IPv4 loopback address 127.0.0.1", name, ep, host)
+		}
+		if ip := net.ParseIP(host); ip == nil || ip.To4() == nil {
+			t.Errorf("%s = %q: host %q is not a literal IPv4 "+
+				"address", name, ep, host)
+		}
+		if port == "" {
+			t.Errorf("%s = %q: missing port", name, ep)
+		}
+	}
+}

--- a/internal/welcome/screen_system_wallet_create.go
+++ b/internal/welcome/screen_system_wallet_create.go
@@ -316,7 +316,7 @@ echo "  Your seed phrase will appear in this terminal."
 echo "  Make sure nobody is looking over your shoulder."
 echo
 /usr/local/bin/lncli ` +
-		`--rpcserver=localhost:10009 ` +
+		`--rpcserver=` + paths.LNDGRPCEndpoint + ` ` +
 		`--tlscertpath=` + paths.StateLNDTLSCert + ` ` +
 		`--network=` + net.LNCLINetwork + ` create && {
   trap '' INT


### PR DESCRIPTION
The console reached LND at the name localhost. These nodes disable IPv6 at the kernel while /etc/hosts still maps localhost to an IPv6 address, so a resolver that prefers IPv6 can hand the client an address the box cannot use and the connection fails before it starts. The two ends of each connection also named their endpoints independently, with lnd.conf binding by name while other callers dialed by address, so they agreed only by luck.

Every LND loopback endpoint is now defined once in the paths package as a literal IPv4 address, and both ends of every connection consume the same constant.

* lnd.conf binds rpclisten, restlisten and the peer listener in tor only mode by address; the name localhost no longer appears anywhere in the generated file

* the gRPC client, the installer readiness probe for the REST state endpoint, the wallet creation lncli invocation and the shell lncli wrapper all dial the shared constants

* the lnd.conf content builder is now a pure function, with unit tests asserting the bind lines and the absence of any host name in every variant

* new tests pin the endpoint constants to a literal IPv4 loopback address so they cannot regress to a name, and keep the observed IPv6 dial failure on the list of errors that the TLS certificate classifier must not match

* a comment at the bitcoin config writer now documents that the RPC credential pair is replaced together on every run but not atomically, and that a failure between the two writes leaves a divergence that is detected and reported rather than silent