### PR TITLE
fix: staged node facts stay fresh or are read live

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -43,6 +43,39 @@ func main() {
 			fmt.Fprintf(os.Stderr, "vpn helperd: %v\n", err)
 			os.Exit(1)
 		}
+	case cmdStageLNDCert:
+		// Run by systemd's certificate watch (a path unit on
+		// LND's tls.cert) — never by hand. LND rewrites its
+		// certificate on its own (tlsautorefresh); this
+		// refreshes the TUI's staged copy to match. Its
+		// output lands in this oneshot unit's own journal
+		// (journalctl -u vpn-lnd-cert-stage.service), which is
+		// where watcher-driven restages are audited — the
+		// helper's journal only records operations that went
+		// through the helper's socket.
+		if os.Geteuid() != 0 {
+			fmt.Fprintln(os.Stderr,
+				"vpn stage-lnd-cert runs as root via its "+
+					"systemd unit — it is not meant to be "+
+					"started by hand")
+			os.Exit(1)
+		}
+		// Explicit dispatch, nothing inferred — but refuse
+		// fast and clearly on a box this command cannot apply
+		// to, instead of waiting out the stager's stability
+		// window against a file that will never appear.
+		if _, err := os.Stat(config.DefaultPath); err != nil {
+			fmt.Fprintf(os.Stderr,
+				"vpn stage-lnd-cert: no configuration at %s "+
+					"— this node is not installed\n",
+				config.DefaultPath)
+			os.Exit(1)
+		}
+		if err := installer.StageLNDTLSCert(); err != nil {
+			fmt.Fprintf(os.Stderr, "vpn stage-lnd-cert: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println("staged LND TLS certificate copy refreshed")
 	case cmdVersion:
 		fmt.Println(version)
 	case cmdHelp:
@@ -94,6 +127,7 @@ const (
 	cmdConsole command = iota
 	cmdInstall
 	cmdHelperd
+	cmdStageLNDCert
 	cmdVersion
 	cmdHelp
 )
@@ -131,6 +165,12 @@ func parseArgs(
 				"helperd takes no arguments")
 		}
 		return cmdHelperd, opts, nil
+	case "stage-lnd-cert":
+		if len(args) > 1 {
+			return 0, opts, fmt.Errorf(
+				"stage-lnd-cert takes no arguments")
+		}
+		return cmdStageLNDCert, opts, nil
 	case "version", "--version", "-v":
 		return cmdVersion, opts, nil
 	case "help", "--help", "-h":
@@ -156,6 +196,9 @@ Usage:
                      and password login disabled)
   vpn helperd        the node's root helper (started by systemd
                      through its socket, not by hand)
+  vpn stage-lnd-cert refresh the node's staged copy of the
+                     LND TLS certificate (run by systemd's
+                     certificate watch, not by hand)
   vpn version        print the version
 `
 }

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -58,4 +58,13 @@ func TestParseArgs(t *testing.T) {
 		[]string{"helperd", "--flag"}); err == nil {
 		t.Error("helperd with arguments accepted")
 	}
+
+	cmd, _, err = parseArgs([]string{"stage-lnd-cert"})
+	if err != nil || cmd != cmdStageLNDCert {
+		t.Errorf("stage-lnd-cert: got (%v,%v)", cmd, err)
+	}
+	if _, _, err := parseArgs(
+		[]string{"stage-lnd-cert", "--flag"}); err == nil {
+		t.Error("stage-lnd-cert with arguments accepted")
+	}
 }

--- a/internal/helper/wire.go
+++ b/internal/helper/wire.go
@@ -44,6 +44,16 @@ const (
 	VerbRebuildSSHConfig     = "rebuild-ssh-config"
 	VerbRebuildTorConfig     = "rebuild-tor-config"
 
+	// Read-only verbs: no parameters, no mutation, a typed
+	// result. They exist for display facts the TUI needs
+	// at human cadence (screen entry) whose truth lives in
+	// root-readable places and can change outside any
+	// operation of ours — keeping a copy of such a fact
+	// would risk rendering it confidently wrong, so no copy
+	// exists and the screens ask here instead.
+	VerbReadNodeAddresses = "read-node-addresses"
+	VerbReadSSHAuth       = "read-ssh-auth"
+
 	// Streaming verbs: step progress events precede the
 	// terminator, and feed the TUI's step renderer.
 	VerbPackageUpdate    = "package-update"
@@ -165,6 +175,30 @@ type SelfUpdateParams struct {
 // for the operator's config.
 type SyncthingInstallResult struct {
 	Password string `json:"password"`
+}
+
+// NodeAddressesResult is the read-node-addresses answer: the
+// node's Tor hidden-service hostnames and its Syncthing device
+// ID, read from their sources at the moment of the request. An
+// empty field means that service is not configured on this box
+// (its hostname file does not exist) — the screen renders the
+// feature unavailable rather than showing an address nobody
+// can reach.
+type NodeAddressesResult struct {
+	BitcoinP2POnion   string `json:"bitcoin_p2p_onion"`
+	LNDGRPCOnion      string `json:"lnd_grpc_onion"`
+	LNDRESTOnion      string `json:"lnd_rest_onion"`
+	SyncthingOnion    string `json:"syncthing_onion"`
+	SyncthingDeviceID string `json:"syncthing_device_id"`
+}
+
+// SSHAuthResult is the read-ssh-auth answer: whether sshd's
+// EFFECTIVE configuration permits password authentication for
+// the admin user, asked of sshd itself at request time. This
+// answer gates removing the last SSH key, so callers treat a
+// verb error as "unavailable" and refuse the risky action.
+type SSHAuthResult struct {
+	PasswordAuthEnabled bool `json:"password_auth_enabled"`
 }
 
 // ── Version gate (shared by both sides) ──────────────────

--- a/internal/helperd/matrix.go
+++ b/internal/helperd/matrix.go
@@ -21,60 +21,27 @@ import (
 // documentation that can drift from it.
 //
 // Reading the matrix: a verb not listed here invalidates no
-// staged fact (a package upgrade changes no onion address). One
-// entry is conditional: service-action invalidates the staged
-// LND TLS certificate only when the unit acted on is lnd — the
-// handler applies the entry under that condition, because the
-// verb-keyed table cannot see verb parameters. The unit tests
-// in matrix_test.go walk every cell: every listed fact has a
-// stager, every stager is reachable from a verb or the
-// installer's staging step, and the sets match this table
+// staged fact (a package upgrade changes no staged credential).
+// One entry is conditional: service-action invalidates the
+// staged LND TLS certificate only when the unit acted on is
+// lnd — the handler applies the entry under that condition,
+// because the verb-keyed table cannot see verb parameters. The
+// unit tests in matrix_test.go walk every cell: every listed
+// fact has a stager, every stager is reachable from a verb or
+// the installer's staging step, and the sets match this table
 // exactly.
 
 // stagers maps each board file to the function that refreshes
 // it from current reality. All run as root.
 var stagers = map[string]func() error{
-	paths.StateOnionBitcoinP2P: func() error {
-		return installer.StageOnionHostname(
-			paths.TorBitcoinP2P+"/hostname",
-			paths.StateOnionBitcoinP2P)
-	},
-	paths.StateOnionLNDGRPC: func() error {
-		return installer.StageOnionHostname(
-			paths.TorLNDGRPC+"/hostname",
-			paths.StateOnionLNDGRPC)
-	},
-	paths.StateOnionLNDREST: func() error {
-		return installer.StageOnionHostname(
-			paths.TorLNDRESTHostname,
-			paths.StateOnionLNDREST)
-	},
-	paths.StateOnionSyncthing: func() error {
-		return installer.StageOnionHostname(
-			paths.TorSyncthingHostname,
-			paths.StateOnionSyncthing)
-	},
 	paths.StateLNDTLSCert:      installer.StageLNDTLSCert,
 	paths.StateLNDMacaroon:     installer.StageLNDMacaroon,
 	paths.StateSyncthingAPIKey: installer.StageSyncthingAPIKey,
-	paths.StateSyncthingDevID:  installer.StageSyncthingDeviceID,
-	paths.StateSSHPasswordAuth: installer.StageSSHAuthFact,
 }
 
 // freshnessMatrix: verb → board facts the verb invalidates and
 // therefore re-stages on success.
 var freshnessMatrix = map[string][]string{
-	// Rebuilding torrc restarts Tor; hidden-service dirs are
-	// (re)created and hostnames may newly exist. Onion KEYS
-	// persist, so existing addresses do not change — but a
-	// toggled-on service's hostname appears here for the first
-	// time, and re-staging the unchanged ones is free.
-	helper.VerbRebuildTorConfig: {
-		paths.StateOnionBitcoinP2P,
-		paths.StateOnionLNDGRPC,
-		paths.StateOnionLNDREST,
-		paths.StateOnionSyncthing,
-	},
 	// Wallet creation mints fresh macaroons; the staging verb
 	// exists exactly for that moment (and re-copies the cert,
 	// which is free).
@@ -90,16 +57,9 @@ var freshnessMatrix = map[string][]string{
 		paths.StateLNDMacaroon,
 	},
 	// A fresh Syncthing install generates a new identity and
-	// API key, and its Tor rebuild creates the web-UI onion.
+	// API key.
 	helper.VerbSyncthingInstall: {
 		paths.StateSyncthingAPIKey,
-		paths.StateSyncthingDevID,
-		paths.StateOnionSyncthing,
-	},
-	// The SSH drop-in write changes effective password-auth
-	// state; the staged observation must follow it.
-	helper.VerbRebuildSSHConfig: {
-		paths.StateSSHPasswordAuth,
 	},
 	// An lnd start or restart can regenerate the TLS
 	// certificate (tlsautorefresh detects parameter changes and
@@ -110,6 +70,74 @@ var freshnessMatrix = map[string][]string{
 	helper.VerbServiceAction: {
 		paths.StateLNDTLSCert,
 	},
+}
+
+// ── Freshness declarations ───────────────────────────────
+//
+// Every fact the TUI consumes has exactly one declared
+// freshness story, and matrix_test.go fails on any board file
+// without one — a contributor adding a new fact is stopped by
+// a red test asking "how does this stay fresh?". The stories:
+//
+//   - watched: the fact's source can change autonomously (no
+//     operation of ours involved), and a systemd path unit on
+//     the source triggers a re-stage within seconds, before
+//     any human shows up to read a stale copy.
+//   - healed: the fact is a credential that fails CLOSED at
+//     the moment of use when stale (the cryptography rejects
+//     it, in front of the calling code), and the consumer
+//     repairs the failure by asking for a re-stage and
+//     retrying once, rate-limited process-wide.
+//   - live-read: no copy exists at all. The fact is a display
+//     or safety observation whose staleness would produce no
+//     failure to repair from, so screens read it through a
+//     read-only verb at human cadence (liveReadFacts below).
+//   - static-by-decision: the fact changes only through
+//     covered operations (install, a menu verb); foreign
+//     change is possible for root but is not promisable, and
+//     divergence surfaces as an honest, named error — never a
+//     silent false success.
+const (
+	freshWatched  = "watched"
+	freshHealed   = "healed"
+	freshLiveRead = "live-read"
+	freshStatic   = "static-by-decision"
+)
+
+// freshness declares the story for every BOARD file. These are
+// the machine-cadence facts (consumed per RPC call / per dial)
+// — the only ones that justify a cached copy at all.
+var freshness = map[string]string{
+	// Watched (the path unit), and additionally healed as the
+	// backstop: the connection self-heal in the TUI's LND
+	// client re-stages on persistent connection failure.
+	paths.StateLNDTLSCert: freshWatched,
+	// LND rejects a stale macaroon on every call
+	// (Unauthenticated); the client reconnects and the dial-
+	// time repair re-stages both LND credentials.
+	paths.StateLNDMacaroon: freshHealed,
+	// Regenerated only by a Syncthing (re)install, which the
+	// syncthing-install verb covers. The one foreign surface
+	// that can change it — the Syncthing web UI — produces an
+	// HTTP 403 that every REST wrapper now fails loudly on,
+	// so divergence is an immediate honest error.
+	paths.StateSyncthingAPIKey: freshStatic,
+	// Written by the installer, fresh pair per install; if
+	// root replaces the server-side half by hand, bitcoind
+	// answers 401 and the TUI's error names the
+	// divergence. That residue is accepted, not healed.
+	paths.StateBitcoindRPCPass: freshStatic,
+}
+
+// liveReadFacts pins the fourth story: facts with NO board
+// copy, served live by a read-only verb. The map value is the
+// verb that serves the fact; matrix_test.go asserts each is on
+// the menu, so retiring a verb without a replacement story is
+// a red test too.
+var liveReadFacts = map[string]string{
+	"onion-addresses":     helper.VerbReadNodeAddresses,
+	"syncthing-device-id": helper.VerbReadNodeAddresses,
+	"ssh-password-auth":   helper.VerbReadSSHAuth,
 }
 
 // restage refreshes every fact the given verb invalidates.

--- a/internal/helperd/matrix_test.go
+++ b/internal/helperd/matrix_test.go
@@ -21,12 +21,6 @@ import (
 // into agreement.
 
 var expectedMatrix = map[string][]string{
-	helper.VerbRebuildTorConfig: {
-		paths.StateOnionBitcoinP2P,
-		paths.StateOnionLNDGRPC,
-		paths.StateOnionLNDREST,
-		paths.StateOnionSyncthing,
-	},
 	helper.VerbStageLNDCredentials: {
 		paths.StateLNDTLSCert,
 		paths.StateLNDMacaroon,
@@ -37,11 +31,6 @@ var expectedMatrix = map[string][]string{
 	},
 	helper.VerbSyncthingInstall: {
 		paths.StateSyncthingAPIKey,
-		paths.StateSyncthingDevID,
-		paths.StateOnionSyncthing,
-	},
-	helper.VerbRebuildSSHConfig: {
-		paths.StateSSHPasswordAuth,
 	},
 	// Applied by the handler only for the lnd unit (start or
 	// restart): LND can regenerate its TLS certificate during
@@ -49,6 +38,10 @@ var expectedMatrix = map[string][]string{
 	helper.VerbServiceAction: {
 		paths.StateLNDTLSCert,
 	},
+	// Deliberately absent: rebuild-tor-config and
+	// rebuild-ssh-config no longer touch any board fact —
+	// onion addresses and the password-auth answer are
+	// live-read (no copy exists to go stale).
 }
 
 func TestFreshnessMatrixMatchesRuledTable(t *testing.T) {
@@ -75,22 +68,23 @@ func TestFreshnessMatrixMatchesRuledTable(t *testing.T) {
 	}
 }
 
+// expectedBoardFiles restates the complete board INDEPENDENTLY
+// of paths.go and matrix.go: the machine-cadence credential
+// facts, and nothing else. Display facts (onion addresses, the
+// Syncthing device ID, the SSH password-auth answer) are
+// deliberately NOT here — they are live-read, with no copy.
+var expectedBoardFiles = map[string]bool{
+	paths.StateBitcoindRPCPass: true,
+	paths.StateLNDTLSCert:      true,
+	paths.StateLNDMacaroon:     true,
+	paths.StateSyncthingAPIKey: true,
+}
+
 // Every fact in the matrix must have a stager, every verb in
 // the matrix must exist on the verb menu, and every stager key
 // must be a real board path.
 func TestFreshnessMatrixIsClosed(t *testing.T) {
-	boardFiles := map[string]bool{
-		paths.StateBitcoindRPCPass: true,
-		paths.StateLNDTLSCert:      true,
-		paths.StateLNDMacaroon:     true,
-		paths.StateOnionBitcoinP2P: true,
-		paths.StateOnionLNDGRPC:    true,
-		paths.StateOnionLNDREST:    true,
-		paths.StateOnionSyncthing:  true,
-		paths.StateSyncthingAPIKey: true,
-		paths.StateSyncthingDevID:  true,
-		paths.StateSSHPasswordAuth: true,
-	}
+	boardFiles := expectedBoardFiles
 	for verb, files := range freshnessMatrix {
 		if _, ok := verbs[verb]; !ok {
 			t.Errorf("matrix verb %s is not on the verb menu", verb)
@@ -116,6 +110,75 @@ func TestFreshnessMatrixIsClosed(t *testing.T) {
 func TestRestageUnknownVerbIsNoop(t *testing.T) {
 	if err := restage("no-such-verb"); err != nil {
 		t.Errorf("unknown verb should re-stage nothing: %v", err)
+	}
+}
+
+// ── Freshness-declaration tests ──────────────────────────
+//
+// The rule: every board fact declares exactly one freshness
+// story, and the live-read facts are pinned to menu verbs.
+// Adding board fact number five without deciding how it stays
+// fresh — or retiring a read verb without replacing the story
+// it serves — fails here.
+
+func TestEveryBoardFactDeclaresFreshness(t *testing.T) {
+	for f := range expectedBoardFiles {
+		story, ok := freshness[f]
+		if !ok {
+			t.Errorf("%s has no freshness declaration — how "+
+				"does this fact stay fresh? Declare watched, "+
+				"healed, live-read, or static-by-decision in "+
+				"matrix.go", f)
+			continue
+		}
+		switch story {
+		case freshWatched, freshHealed, freshStatic:
+		case freshLiveRead:
+			t.Errorf("%s declares live-read but has a board "+
+				"file — a live-read fact keeps no copy", f)
+		default:
+			t.Errorf("%s declares unknown story %q", f, story)
+		}
+	}
+	for f := range freshness {
+		if !expectedBoardFiles[f] {
+			t.Errorf("freshness declares %s, which is not a "+
+				"board file — update BOTH deliberately", f)
+		}
+	}
+	for f := range stagers {
+		if _, ok := freshness[f]; !ok {
+			t.Errorf("stager registered for %s without a "+
+				"freshness declaration", f)
+		}
+	}
+}
+
+// The watched and healed stories both depend on a stager
+// existing (the path unit and the self-heal each end in a
+// re-stage); a declaration without the mechanism is a lie.
+func TestFreshnessStoriesHaveTheirMechanism(t *testing.T) {
+	for f, story := range freshness {
+		if story == freshWatched || story == freshHealed {
+			if _, ok := stagers[f]; !ok {
+				t.Errorf("%s declares %s but has no stager",
+					f, story)
+			}
+		}
+	}
+}
+
+// Live-read facts are served by verbs that must exist on the
+// menu.
+func TestLiveReadFactsServedByMenuVerbs(t *testing.T) {
+	if len(liveReadFacts) == 0 {
+		t.Fatal("no live-read facts declared")
+	}
+	for fact, verb := range liveReadFacts {
+		if _, ok := verbs[verb]; !ok {
+			t.Errorf("live-read fact %q names verb %s, which "+
+				"is not on the menu", fact, verb)
+		}
 	}
 }
 

--- a/internal/helperd/verbs.go
+++ b/internal/helperd/verbs.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -54,6 +55,8 @@ var verbs = map[string]verbDef{
 	helper.VerbSelfUpdate:           {15 * time.Minute, verbSelfUpdate},
 	helper.VerbSetP2PMode:           {8 * time.Minute, verbSetP2PMode},
 	helper.VerbSyncthingInstall:     {30 * time.Minute, verbSyncthingInstall},
+	helper.VerbReadNodeAddresses:    {1 * time.Minute, verbReadNodeAddresses},
+	helper.VerbReadSSHAuth:          {1 * time.Minute, verbReadSSHAuth},
 }
 
 // decode unmarshals params strictly: unknown fields are an
@@ -237,6 +240,61 @@ func verbStageLNDCredentials(_ *verbCtx, _ json.RawMessage) (any, error) {
 	return nil, restage(helper.VerbStageLNDCredentials)
 }
 
+// ── Read-only verbs ──────────────────────────────────────
+//
+// Live reads for display facts the TUI needs at human
+// cadence (screen entry). These facts can change with no
+// operation of ours involved — a root login can destroy and
+// recreate hidden-service directories, an sshd drop-in can be
+// edited by hand or by provider tooling — and a fact with no
+// failure moment cannot be repaired at one. So no copy is
+// kept anywhere: the answer is read from its source at the
+// moment of the question, and what the screen shows is what
+// is true right now. Cost per read: one socket round-trip, a
+// handful of times per session. Both verbs take no parameters
+// and change nothing; they get the same peer-credential check
+// and journal record as every other verb.
+
+// readHostname reads a Tor hidden-service hostname file. A
+// missing or empty file means that service is not configured
+// on this box — reported as an empty field, which screens
+// render as unavailable.
+func readHostname(path string) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
+func verbReadNodeAddresses(_ *verbCtx, _ json.RawMessage) (any, error) {
+	return helper.NodeAddressesResult{
+		BitcoinP2POnion: readHostname(
+			paths.TorBitcoinP2P + "/hostname"),
+		LNDGRPCOnion: readHostname(
+			paths.TorLNDGRPC + "/hostname"),
+		LNDRESTOnion:   readHostname(paths.TorLNDRESTHostname),
+		SyncthingOnion: readHostname(paths.TorSyncthingHostname),
+		// Root-side read: parses Syncthing's own config, so it
+		// answers correctly even when the daemon is stopped.
+		SyncthingDeviceID: installer.GetSyncthingDeviceID(),
+	}, nil
+}
+
+func verbReadSSHAuth(_ *verbCtx, _ json.RawMessage) (any, error) {
+	// Root branch of EffectiveSSHPasswordAuth: sshd -T with a
+	// simulated connection for the admin user — the first-
+	// match-wins election across sshd_config and every
+	// drop-in, not any single file's vote. An error (broken
+	// sshd setup) fails the verb; callers refuse the risky
+	// action rather than guessing.
+	enabled, err := installer.EffectiveSSHPasswordAuth()
+	if err != nil {
+		return nil, err
+	}
+	return helper.SSHAuthResult{PasswordAuthEnabled: enabled}, nil
+}
+
 // ── Config writers (templates live on this side) ─────────
 
 func verbRebuildSSHConfig(_ *verbCtx, params json.RawMessage) (any, error) {
@@ -253,7 +311,10 @@ func verbRebuildSSHConfig(_ *verbCtx, params json.RawMessage) (any, error) {
 	if err := installer.RebuildSSHHardeningConfig(view); err != nil {
 		return nil, err
 	}
-	return nil, restage(helper.VerbRebuildSSHConfig)
+	// Nothing to re-stage: the effective password-auth answer
+	// is not copied anywhere — readers ask the read-ssh-auth
+	// verb, which queries sshd live.
+	return nil, nil
 }
 
 func verbRebuildTorConfig(_ *verbCtx, params json.RawMessage) (any, error) {
@@ -276,7 +337,12 @@ func verbRebuildTorConfig(_ *verbCtx, params json.RawMessage) (any, error) {
 	if err := installer.RestartTor(); err != nil {
 		return nil, err
 	}
-	return nil, restage(helper.VerbRebuildTorConfig)
+	// Nothing to re-stage: onion addresses are not copied
+	// anywhere — readers ask the read-node-addresses verb,
+	// which reads the hostname files live (and a hostname
+	// that newly exists after this rebuild is simply there on
+	// the next read).
+	return nil, nil
 }
 
 // ── Streaming verbs ──────────────────────────────────────

--- a/internal/helperd/verbs_test.go
+++ b/internal/helperd/verbs_test.go
@@ -49,6 +49,12 @@ func TestVerbMenuIsExactlyTheRuledSet(t *testing.T) {
 		helper.VerbSelfUpdate,
 		helper.VerbSetP2PMode,
 		helper.VerbSyncthingInstall,
+		// Read-only verbs: no parameters, no mutation. They
+		// serve the live-read display facts (onion addresses,
+		// the Syncthing device ID, the SSH password-auth
+		// answer), which keep no board copy.
+		helper.VerbReadNodeAddresses,
+		helper.VerbReadSSHAuth,
 	}
 	if len(verbs) != len(want) {
 		t.Errorf("verb menu has %d entries, want %d",

--- a/internal/installer/certwatch.go
+++ b/internal/installer/certwatch.go
@@ -1,0 +1,82 @@
+// internal/installer/certwatch.go
+
+package installer
+
+// The LND TLS certificate watch. lnd.conf sets tlsautorefresh,
+// which lets LND regenerate its own certificate at ANY startup
+// whose parameters changed or whose certificate nears expiry —
+// a crash restart, a reboot, a config change applied by a
+// reinstall. None of those moments is an operation the TUI
+// requested, so no operation can refresh the TUI's staged
+// copy of the certificate; without a watcher, the copy goes
+// stale the moment LND rewrites the file, and the TUI's
+// next connection fails until its self-heal notices. These two
+// units close that gap at the source: systemd watches the
+// certificate file itself and re-stages the copy within
+// seconds of a rewrite — hours before a human shows up to
+// read it. Same pattern as the channel-backup watcher
+// (lnd-backup-watch.path).
+
+import (
+	"fmt"
+
+	"github.com/virtualprivatenode/vpn/internal/logger"
+	"github.com/virtualprivatenode/vpn/internal/paths"
+	"github.com/virtualprivatenode/vpn/internal/system"
+)
+
+// lndCertWatchUnits renders the path unit and its oneshot
+// service. Pure — unit-tested.
+func lndCertWatchUnits() (pathUnit, serviceUnit string) {
+	pathUnit = fmt.Sprintf(`[Unit]
+Description=Watch the LND TLS certificate for the node console
+
+[Path]
+PathChanged=%s
+Unit=%s
+
+[Install]
+WantedBy=multi-user.target
+`, paths.LNDTLSCert, paths.LNDCertStageServiceName)
+
+	serviceUnit = fmt.Sprintf(`[Unit]
+Description=Refresh the staged copy of the LND TLS certificate
+
+[Service]
+Type=oneshot
+ExecStart=%s stage-lnd-cert
+SyslogIdentifier=vpn-cert-stage
+`, paths.BinaryPath)
+	return pathUnit, serviceUnit
+}
+
+// installLNDCertWatch writes both units, reloads systemd, and
+// enables and starts the path unit, verifying it is active.
+// Idempotent — a reinstall or migration pass rewrites the
+// current unit content and re-enables.
+func installLNDCertWatch() error {
+	pathUnit, serviceUnit := lndCertWatchUnits()
+	if err := system.SudoWriteFile(paths.LNDCertWatchPath,
+		[]byte(pathUnit), 0644); err != nil {
+		return err
+	}
+	if err := system.SudoWriteFile(paths.LNDCertStageService,
+		[]byte(serviceUnit), 0644); err != nil {
+		return err
+	}
+	if err := system.SudoRun("systemctl", "daemon-reload"); err != nil {
+		return err
+	}
+	if err := system.SudoRun("systemctl", "enable", "--now",
+		paths.LNDCertWatchPathName); err != nil {
+		return err
+	}
+	// Postcondition: the watch is really armed.
+	if !system.IsServiceActive(paths.LNDCertWatchPathName) {
+		return fmt.Errorf("%s is not active after enable",
+			paths.LNDCertWatchPathName)
+	}
+	logger.Install("LND TLS certificate watch enabled (%s)",
+		paths.LNDCertWatchPathName)
+	return nil
+}

--- a/internal/installer/certwatch_test.go
+++ b/internal/installer/certwatch_test.go
@@ -1,0 +1,47 @@
+// internal/installer/certwatch_test.go
+
+package installer
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/virtualprivatenode/vpn/internal/paths"
+)
+
+// The certificate watch is what keeps the staged TLS cert copy
+// current when LND regenerates the cert on its own
+// (tlsautorefresh at startup) — pin the units' load-bearing
+// lines.
+func TestLNDCertWatchUnits(t *testing.T) {
+	pathUnit, serviceUnit := lndCertWatchUnits()
+
+	// The path unit watches LND's OWN certificate file (the
+	// source), not the staged copy, and triggers the stage
+	// service.
+	for _, want := range []string{
+		"PathChanged=" + paths.LNDTLSCert,
+		"Unit=" + paths.LNDCertStageServiceName,
+		"WantedBy=multi-user.target",
+	} {
+		if !strings.Contains(pathUnit, want) {
+			t.Errorf("path unit missing %q:\n%s", want, pathUnit)
+		}
+	}
+
+	// The service is a oneshot running the installed binary's
+	// stage command as root (no User= line).
+	for _, want := range []string{
+		"Type=oneshot",
+		"ExecStart=" + paths.BinaryPath + " stage-lnd-cert",
+	} {
+		if !strings.Contains(serviceUnit, want) {
+			t.Errorf("service unit missing %q:\n%s",
+				want, serviceUnit)
+		}
+	}
+	if strings.Contains(serviceUnit, "User=") {
+		t.Error("stage service must run as root " +
+			"(it writes the root-owned board)")
+	}
+}

--- a/internal/installer/setup.go
+++ b/internal/installer/setup.go
@@ -646,6 +646,15 @@ func buildInstallSteps(
 				return restartTor()
 			}},
 		{Key: "lnd.start", Name: "Starting LND", Fn: startLND},
+		// LND owns its TLS certificate lifecycle
+		// (tlsautorefresh), so the cert can be rewritten by a
+		// startup no TUI operation requested. This watch
+		// re-stages the TUI's copy within seconds of any
+		// rewrite. After lnd.start so a migration pass arms it
+		// on the certificate LND is actually serving.
+		{Key: "lnd.certwatch",
+			Name: "Watching the LND TLS certificate",
+			Fn:   installLNDCertWatch},
 		// The initial drop-in write + stale-drop-in deletion,
 		// with the ruling-xv binding order inside (observe →
 		// write new → delete old → validate → restart). Late in

--- a/internal/installer/sshd.go
+++ b/internal/installer/sshd.go
@@ -134,17 +134,12 @@ func RebuildSSHHardeningConfig(cfg *config.AppConfig) error {
 			detail)
 	}
 
-	if err := restartSSHD(); err != nil {
-		return err
-	}
-
-	// Postcondition: record the now-effective password-auth
-	// answer on the staging board, where unprivileged readers
-	// (the key-removal guard, screen copy) consult it. A
-	// staging failure fails the whole operation — succeeding
-	// while leaving a stale staged answer would be the silent
-	// divergence the board's contract forbids.
-	return StageSSHAuthFact()
+	// No staged copy to refresh afterwards: the effective
+	// password-auth answer is read live (sshd -T through the
+	// helper's read-ssh-auth operation) by every unprivileged
+	// consumer, so the write cannot leave a stale copy behind
+	// — there is none.
+	return restartSSHD()
 }
 
 // restorePreviousDropIn puts the drop-in back to its
@@ -193,39 +188,34 @@ func SetSSHPasswordAuth(
 // configuration permits password authentication for the admin
 // user.
 //
-// Two sources, by privilege:
+// Both paths ask sshd itself, at the moment of the question:
 //
-//   - As root (installer, helper): sshd is asked directly —
-//     see queryEffectiveSSHPasswordAuth.
-//   - Unprivileged (the TUI): the answer comes from the
-//     staging board, where every SSH-config write records the
-//     observation it made right after restarting sshd (see
-//     StageSSHAuthFact). The staged answer is an observation
-//     of sshd's real state, not an echo of this app's config —
-//     it goes stale only if something outside this app edits
-//     sshd's config, and root-side edits are outside the
-//     model anyway.
+//   - As root (installer, helper): directly — see
+//     queryEffectiveSSHPasswordAuth.
+//   - Unprivileged (the TUI): through the helper's read-only
+//     read-ssh-auth operation, which runs the same query on
+//     the root side. No copy of the answer is kept anywhere:
+//     sshd's config can change outside this app (a hand edit,
+//     provider tooling), a stale recorded "yes" would permit
+//     removing the last SSH key on a box where password login
+//     is off — a lockout — and a fact with no failure moment
+//     cannot be repaired at one. Reading live removes the
+//     stale input entirely.
 //
 // Callers MUST treat an error as "password auth unavailable"
 // and refuse the risky action — never as unknown-so-proceed.
-// A missing staged fact therefore biases toward over-refusal,
+// An unreachable helper therefore biases toward over-refusal,
 // the safe direction.
 func EffectiveSSHPasswordAuth() (bool, error) {
 	if os.Geteuid() == 0 {
 		return queryEffectiveSSHPasswordAuth()
 	}
-	v, err := helper.ReadBoardString(paths.StateSSHPasswordAuth)
-	if err != nil {
+	var res helper.SSHAuthResult
+	if err := helper.Call(
+		helper.VerbReadSSHAuth, nil, &res); err != nil {
 		return false, err
 	}
-	switch v {
-	case "yes":
-		return true, nil
-	case "no":
-		return false, nil
-	}
-	return false, fmt.Errorf(
-		"staged password-auth fact is malformed (%q)", v)
+	return res.PasswordAuthEnabled, nil
 }
 
 // queryEffectiveSSHPasswordAuth asks sshd itself:

--- a/internal/installer/staging.go
+++ b/internal/installer/staging.go
@@ -25,31 +25,6 @@ import (
 	"github.com/virtualprivatenode/vpn/internal/system"
 )
 
-// StageOnionHostname copies a Tor hidden-service hostname file
-// to the board. Tor creates hostname files asynchronously after
-// a restart, so this waits briefly for the file to appear. A
-// hostname that never appears is treated as "this hidden
-// service is not configured": the board entry is removed, and a
-// screen that needs it reports unavailable rather than showing
-// a stale address.
-func StageOnionHostname(src, dst string) error {
-	deadline := time.Now().Add(20 * time.Second)
-	for {
-		data, err := os.ReadFile(src)
-		if err == nil && len(bytes.TrimSpace(data)) > 0 {
-			return helper.WriteBoard(dst,
-				append(bytes.TrimSpace(data), '\n'))
-		}
-		if time.Now().After(deadline) {
-			logger.System(
-				"staging: %s absent after 20s — removing the "+
-					"staged copy (service not configured?)", src)
-			return helper.RemoveBoard(dst)
-		}
-		time.Sleep(500 * time.Millisecond)
-	}
-}
-
 // StageLNDTLSCert copies LND's TLS certificate (the public
 // half only — tls.key never moves) to the board. LND rewrites
 // the cert during startup when its parameters change, so this
@@ -141,39 +116,21 @@ func StageSyncthingAPIKey() error {
 		paths.StateSyncthingAPIKey, []byte(key+"\n"))
 }
 
-// StageSyncthingDeviceID stages this node's Syncthing device
-// ID (shown during pairing; derived from Syncthing's TLS
-// identity, so it changes only when Syncthing is reinstalled).
-func StageSyncthingDeviceID() error {
-	id := GetSyncthingDeviceID()
-	if id == "" {
-		return fmt.Errorf("could not read the Syncthing device ID")
-	}
-	return helper.WriteBoard(
-		paths.StateSyncthingDevID, []byte(id+"\n"))
-}
-
-// StageSSHAuthFact records sshd's EFFECTIVE password-auth
-// answer for the admin user ("yes"/"no"), by asking sshd itself
-// (sshd -T with a simulated connection). Staged after every
-// SSH-config write, it is what unprivileged code consults where
-// it once ran the query via sudo. The staged answer is an
-// observation taken AFTER the write it follows — stronger than
-// trusting our own config, one step short of querying live
-// (which needs root). Consumers treat a missing or unreadable
-// fact as "unavailable" and refuse risky actions.
-func StageSSHAuthFact() error {
-	enabled, err := queryEffectiveSSHPasswordAuth()
-	if err != nil {
-		return fmt.Errorf(
-			"observe sshd password-auth state: %w", err)
-	}
-	v := "no"
-	if enabled {
-		v = "yes"
-	}
-	return helper.WriteBoard(
-		paths.StateSSHPasswordAuth, []byte(v+"\n"))
+// retiredBoardFiles are board files earlier releases staged
+// that no longer exist as facts: onion addresses, the
+// Syncthing device ID, and the SSH password-auth answer are
+// read LIVE through the helper's read-only verbs now, so a
+// copy on disk is only a chance to be stale. The install's
+// staging step deletes any that survive from an earlier
+// install (nothing reads them; removing them keeps the board
+// equal to the declared fact list).
+var retiredBoardFiles = []string{
+	paths.StateDir + "/onion-bitcoin-p2p",
+	paths.StateDir + "/onion-lnd-grpc",
+	paths.StateDir + "/onion-lnd-rest",
+	paths.StateDir + "/onion-syncthing",
+	paths.StateDir + "/syncthing-device-id",
+	paths.StateDir + "/ssh-password-auth",
 }
 
 // StageBoardAll builds the complete board at install time:
@@ -201,34 +158,18 @@ func StageBoardAll() error {
 	}
 
 	facts := []fact{
-		{"onion-bitcoin-p2p", func() error {
-			return StageOnionHostname(
-				paths.TorBitcoinP2P+"/hostname",
-				paths.StateOnionBitcoinP2P)
-		}, nil},
-		{"onion-lnd-grpc", func() error {
-			return StageOnionHostname(
-				paths.TorLNDGRPC+"/hostname",
-				paths.StateOnionLNDGRPC)
-		}, nil},
-		{"onion-lnd-rest", func() error {
-			return StageOnionHostname(
-				paths.TorLNDRESTHostname,
-				paths.StateOnionLNDREST)
-		}, nil},
-		{"onion-syncthing", func() error {
-			return StageOnionHostname(
-				paths.TorSyncthingHostname,
-				paths.StateOnionSyncthing)
-		}, func() bool { return !haveSyncthing }},
 		{"lnd-tls-cert", StageLNDTLSCert, nil},
 		{"lnd-admin-macaroon", StageLNDMacaroon,
 			func() bool { return !haveWallet }},
 		{"syncthing-api-key", StageSyncthingAPIKey,
 			func() bool { return !haveSyncthing }},
-		{"syncthing-device-id", StageSyncthingDeviceID,
-			func() bool { return !haveSyncthing }},
-		{"ssh-password-auth", StageSSHAuthFact, nil},
+	}
+	// Board hygiene on migrated boxes: drop files this release
+	// no longer stages (their facts are live-read now).
+	for _, f := range retiredBoardFiles {
+		if err := helper.RemoveBoard(f); err != nil {
+			return err
+		}
 	}
 	for _, f := range facts {
 		if f.skip != nil && f.skip() {

--- a/internal/installer/syncthing.go
+++ b/internal/installer/syncthing.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -375,17 +377,20 @@ func startSyncthing() error {
 	// Readiness probe. /rest/noauth/health is the documented
 	// unauthenticated endpoint; the previous probe hit
 	// /rest/system/status without an API key, got 403 on every
-	// try, and spun the full 30s. Fail-safe: if the daemon never
+	// try, and spun the full 30s. Same standard HTTP client as
+	// the REST transport below. Fail-safe: if the daemon never
 	// readies, stop it and fail the install.
 	ready := false
+	probe := &http.Client{Timeout: 3 * time.Second}
 	for i := 0; i < 30; i++ {
-		output, err := system.RunContext(3*time.Second,
-			"curl", "-s", "-o", "/dev/null",
-			"-w", "%{http_code}",
-			"http://127.0.0.1:8384/rest/noauth/health")
-		if err == nil && strings.TrimSpace(output) == "200" {
-			ready = true
-			break
+		resp, err := probe.Get(
+			syncthingGUIBase + "/rest/noauth/health")
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				ready = true
+				break
+			}
 		}
 		time.Sleep(1 * time.Second)
 	}
@@ -489,17 +494,22 @@ func registerBackupFolder() error {
 // GetSyncthingDeviceID returns this node's Syncthing device
 // ID. As root it parses Syncthing's config XML (works even
 // with the daemon stopped — the ID derives from the TLS cert);
-// unprivileged it reads the staged copy on the board, which
-// the install (and any reinstall) refreshes.
+// unprivileged it asks the helper's read-node-addresses
+// operation, which performs that same root-side read at the
+// moment of the question. No copy is kept: the ID changes when
+// Syncthing's identity is regenerated (a reinstall, a manual
+// key deletion), a stale copy would fail silently — the remote
+// device just never pairs — and screens need it only at human
+// cadence.
 func GetSyncthingDeviceID() string {
 	if os.Geteuid() != 0 {
-		id, err := helper.ReadBoardString(
-			paths.StateSyncthingDevID)
-		if err != nil {
+		var res helper.NodeAddressesResult
+		if err := helper.Call(
+			helper.VerbReadNodeAddresses, nil, &res); err != nil {
 			logger.Status("syncthing device ID: %v", err)
 			return ""
 		}
-		return id
+		return res.SyncthingDeviceID
 	}
 
 	output, err := os.ReadFile(paths.SyncthingConfigXML)
@@ -597,34 +607,92 @@ func getSyncthingAPIKey() (string, error) {
 	return cfg.GUI.APIKey, nil
 }
 
+// ── REST transport (fail-noisy) ──────────────────────────
+//
+// Every Syncthing REST call goes through syncthingAPI, which
+// FAILS on any HTTP error status. This is load-bearing: the
+// previous transport shelled out to curl -s, which exits 0 on
+// a 403, and these calls once reported success while the
+// daemon had rejected the request — a pairing "done" that had
+// paired nothing, which for the channel-backup folder means
+// the off-box copy the operator is counting on never starts
+// replicating. A silent false success here is forbidden.
+//
+// The transport is Go's standard HTTP client, not a curl
+// subprocess: the status code arrives as an integer with
+// nothing to parse out of shell output, and this path stops
+// depending on an image-supplied binary nothing of ours
+// installs. Same client choice as the LND readiness probe
+// (waitForLND).
+
+// syncthingGUIBase is the daemon's loopback GUI/REST address.
+// A variable so the transport tests can point it at a local
+// test server.
+var syncthingGUIBase = "http://127.0.0.1:8384"
+
+// syncthingAPI performs one REST call against the local
+// Syncthing daemon and returns the response body. Any non-2xx
+// answer is an error naming the refused call.
+func syncthingAPI(
+	method, apiKey, endpoint, body string,
+) (string, error) {
+	fail := func(err error) (string, error) {
+		return "", fmt.Errorf(
+			"syncthing API %s %s: %w", method, endpoint, err)
+	}
+	var reqBody io.Reader
+	if body != "" {
+		reqBody = strings.NewReader(body)
+	}
+	req, err := http.NewRequest(method,
+		syncthingGUIBase+endpoint, reqBody)
+	if err != nil {
+		return fail(err)
+	}
+	if apiKey != "" {
+		req.Header.Set("X-API-Key", apiKey)
+	}
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fail(err)
+	}
+	defer resp.Body.Close()
+	// The bound exists so a defect cannot balloon memory; real
+	// answers are far smaller.
+	data, err := io.ReadAll(io.LimitReader(resp.Body, 10<<20))
+	if err != nil {
+		return fail(fmt.Errorf("read response: %w", err))
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		hint := ""
+		if resp.StatusCode == http.StatusForbidden {
+			hint = " — the daemon rejected the API key this " +
+				"node staged; reinstalling Syncthing from " +
+				"the Add-On section refreshes it"
+		}
+		return "", fmt.Errorf(
+			"syncthing API %s %s failed: HTTP %d%s",
+			method, endpoint, resp.StatusCode, hint)
+	}
+	return string(data), nil
+}
+
 func syncthingAPIPost(apiKey, endpoint, body string) error {
-	_, err := system.RunContext(10*time.Second,
-		"curl", "-s",
-		"-X", "POST",
-		"-H", "X-API-Key: "+apiKey,
-		"-H", "Content-Type: application/json",
-		"-d", body,
-		"http://127.0.0.1:8384"+endpoint)
+	_, err := syncthingAPI("POST", apiKey, endpoint, body)
 	return err
 }
 
 func syncthingAPIPatch(apiKey, endpoint, body string) error {
-	_, err := system.RunContext(10*time.Second,
-		"curl", "-s",
-		"-X", "PATCH",
-		"-H", "X-API-Key: "+apiKey,
-		"-H", "Content-Type: application/json",
-		"-d", body,
-		"http://127.0.0.1:8384"+endpoint)
+	_, err := syncthingAPI("PATCH", apiKey, endpoint, body)
 	return err
 }
 
 func syncthingAPIDelete(apiKey, endpoint string) error {
-	_, err := system.RunContext(10*time.Second,
-		"curl", "-s",
-		"-X", "DELETE",
-		"-H", "X-API-Key: "+apiKey,
-		"http://127.0.0.1:8384"+endpoint)
+	_, err := syncthingAPI("DELETE", apiKey, endpoint, "")
 	return err
 }
 
@@ -648,10 +716,7 @@ func UnpairSyncthingDevice(deviceID string) error {
 }
 
 func syncthingAPIGet(apiKey, endpoint string) (string, error) {
-	return system.RunContext(10*time.Second,
-		"curl", "-s",
-		"-H", "X-API-Key: "+apiKey,
-		"http://127.0.0.1:8384"+endpoint)
+	return syncthingAPI("GET", apiKey, endpoint, "")
 }
 
 func addDeviceToBackupFolder(

--- a/internal/installer/syncthing_test.go
+++ b/internal/installer/syncthing_test.go
@@ -1,0 +1,103 @@
+// internal/installer/syncthing_test.go
+
+package installer
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// The Syncthing REST transport must fail on HTTP errors: the
+// old curl transport exited 0 on a 403, which once reported a
+// pairing as done when the daemon had rejected the API key.
+// These tests run the real transport against a local test
+// server and pin both directions: success passes the body
+// through, and every error status is a named error.
+func TestSyncthingAPI(t *testing.T) {
+	var gotMethod, gotKey, gotType, gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			gotMethod = r.Method
+			gotKey = r.Header.Get("X-API-Key")
+			gotType = r.Header.Get("Content-Type")
+			b, _ := io.ReadAll(r.Body)
+			gotBody = string(b)
+			switch r.URL.Path {
+			case "/ok":
+				w.Write([]byte(`{"ok":true}`))
+			case "/empty":
+				w.WriteHeader(http.StatusNoContent)
+			case "/forbidden":
+				w.WriteHeader(http.StatusForbidden)
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+	defer srv.Close()
+	old := syncthingGUIBase
+	syncthingGUIBase = srv.URL
+	defer func() { syncthingGUIBase = old }()
+
+	// Success: body through, headers set, request body sent.
+	body, err := syncthingAPI("POST", "key123", "/ok", `{"a":1}`)
+	if err != nil {
+		t.Fatalf("POST /ok: %v", err)
+	}
+	if body != `{"ok":true}` {
+		t.Errorf("POST /ok body: got %q", body)
+	}
+	if gotMethod != "POST" || gotKey != "key123" ||
+		gotType != "application/json" || gotBody != `{"a":1}` {
+		t.Errorf("request not as sent: method=%q key=%q type=%q body=%q",
+			gotMethod, gotKey, gotType, gotBody)
+	}
+
+	// A bodyless 2xx (some DELETE/POST answers) is success.
+	if _, err := syncthingAPI(
+		"DELETE", "key123", "/empty", ""); err != nil {
+		t.Errorf("DELETE /empty: %v", err)
+	}
+	if gotBody != "" || gotType != "" {
+		t.Errorf("empty-body request carried body=%q type=%q",
+			gotBody, gotType)
+	}
+
+	// The load-bearing case: an HTTP error IS an error, and a
+	// 403 names the API-key remedy.
+	_, err = syncthingAPI("GET", "stale-key", "/forbidden", "")
+	if err == nil {
+		t.Fatal("403 answer reported as success")
+	}
+	if !strings.Contains(err.Error(), "HTTP 403") ||
+		!strings.Contains(err.Error(), "API key") {
+		t.Errorf("403 error lacks status or hint: %v", err)
+	}
+
+	// Any other error status also fails, naming the call.
+	_, err = syncthingAPI("GET", "key123", "/missing", "")
+	if err == nil {
+		t.Fatal("404 answer reported as success")
+	}
+	if !strings.Contains(err.Error(), "HTTP 404") ||
+		!strings.Contains(err.Error(), "GET /missing") {
+		t.Errorf("404 error lacks status or call name: %v", err)
+	}
+}
+
+// A daemon that is not there is a transport error, not a
+// silent success.
+func TestSyncthingAPIDaemonDown(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {}))
+	srv.Close() // deliberately: the address now refuses
+	old := syncthingGUIBase
+	syncthingGUIBase = srv.URL
+	defer func() { syncthingGUIBase = old }()
+
+	if _, err := syncthingAPI("GET", "k", "/ok", ""); err == nil {
+		t.Error("unreachable daemon reported as success")
+	}
+}

--- a/internal/lndrpc/client.go
+++ b/internal/lndrpc/client.go
@@ -22,7 +22,6 @@ import (
 	"crypto/x509"
 	"encoding/hex"
 	"fmt"
-	"strings"
 	"sync"
 	"time"
 
@@ -70,15 +69,22 @@ func (c *Client) connect() error {
 
 // dial establishes the connection; the caller holds c.mu.
 //
-// allowHeal enables the staged-certificate self-heal: LND can
-// regenerate its TLS certificate OUTSIDE any helper operation —
-// an automatic restart after a crash, a reboot, a config change
-// applied by a reinstall — and the staged board copy then no
-// longer matches the certificate LND serves. That staleness
-// reliably surfaces exactly here, as a TLS verification failure
-// on the test call. On one, the client asks the helper to
-// re-stage the LND credentials (rate-limited process-wide) and
-// dials again once with the refreshed board copy.
+// allowHeal enables the staged-credential self-heal: LND can
+// regenerate its TLS certificate OUTSIDE any helper operation
+// (an automatic restart after a crash, a reboot, a config
+// change applied by a reinstall), and its macaroon can be
+// recreated the same way — and the staged board copies then no
+// longer match what LND accepts. That staleness reliably
+// surfaces exactly here, as a failed test call. The heal keys
+// on the ABSENCE OF SUCCESS, not on recognizing the failure's
+// text: enumerating the failure messages worth healing is a
+// whitelist, and a whitelist misses (a dial error this client
+// once produced was worded in a way no pattern anticipated).
+// On any test-call failure, the client asks the helper to
+// re-stage the LND credentials — rate-limited process-wide, so
+// failures with nothing to heal (LND down, wallet locked) cost
+// at most one re-stage per interval — and dials again ONCE
+// with the refreshed board copies.
 func (c *Client) dial(allowHeal bool) error {
 	// Read the staged TLS cert copy (fail-noisy: a missing
 	// staged fact names itself and points at the journal).
@@ -130,10 +136,10 @@ func (c *Client) dial(allowHeal bool) error {
 		logger.Status("LND gRPC connected and ready")
 		return nil
 	}
-	if allowHeal && isCertificateError(err) &&
-		requestCredentialRestage() {
-		logger.Status("LND gRPC: staged TLS certificate looks "+
-			"stale (%v) — re-staged, reconnecting", err)
+	if allowHeal && requestCredentialRestage() {
+		logger.Status("LND gRPC test call failed (%v) — staged "+
+			"credentials re-staged in case they were stale, "+
+			"reconnecting once", err)
 		c.conn.Close()
 		c.conn = nil
 		c.lightning = nil
@@ -143,43 +149,49 @@ func (c *Client) dial(allowHeal bool) error {
 	return nil
 }
 
-// isCertificateError reports whether a gRPC connect error looks
-// like a TLS certificate verification failure (as opposed to a
-// down service, a locked wallet, or a plain timeout). Matching
-// on the error text is unavoidable — grpc flattens the tls/x509
-// error chain into a string. Pure — unit-tested.
-func isCertificateError(err error) bool {
-	if err == nil {
-		return false
-	}
-	msg := err.Error()
-	return strings.Contains(msg, "x509") ||
-		strings.Contains(msg, "certificate")
-}
-
-// Certificate self-heal state: at most one re-stage request per
-// interval, process-wide — a wrong classification must not turn
-// every reconnect poll into helper traffic.
+// Credential self-heal state: at most one re-stage request per
+// interval, PROCESS-WIDE — with the heal keyed on any failed
+// test call, this limiter is what keeps a long LND outage from
+// turning every reconnect poll into helper traffic and journal
+// noise.
 var (
-	certRestageMu sync.Mutex
-	certRestageAt time.Time
+	credRestageMu sync.Mutex
+	credRestageAt time.Time
 )
 
-const certRestageInterval = 5 * time.Minute
+const credRestageInterval = 5 * time.Minute
+
+// restageDue reports whether enough time has passed since the
+// last re-stage request for another one. Pure — unit-tested.
+func restageDue(last, now time.Time) bool {
+	return last.IsZero() || now.Sub(last) >= credRestageInterval
+}
+
+// credRestageWorthwhile reports whether a re-stage request made
+// now would pass the limiter, WITHOUT consuming it. The
+// credential-rejection path in handleError checks this before
+// reconnecting: when no repair can happen, no reconnect can
+// help, and staying quiet caps a permanently rejected
+// credential at one reconnect-and-repair attempt (and one log
+// line) per limiter interval instead of one per failing call.
+func credRestageWorthwhile() bool {
+	credRestageMu.Lock()
+	defer credRestageMu.Unlock()
+	return restageDue(credRestageAt, time.Now())
+}
 
 // requestCredentialRestage asks the helper to refresh the staged
 // LND credentials from current reality. Reports whether a
 // re-stage actually happened (rate limit passed and the helper
-// succeeded), so the caller only re-dials when the board copy
+// succeeded), so the caller only re-dials when the board copies
 // could have changed.
 func requestCredentialRestage() bool {
-	certRestageMu.Lock()
-	defer certRestageMu.Unlock()
-	if !certRestageAt.IsZero() &&
-		time.Since(certRestageAt) < certRestageInterval {
+	credRestageMu.Lock()
+	defer credRestageMu.Unlock()
+	if !restageDue(credRestageAt, time.Now()) {
 		return false
 	}
-	certRestageAt = time.Now()
+	credRestageAt = time.Now()
 	if err := helper.Call(
 		helper.VerbStageLNDCredentials, nil, nil); err != nil {
 		logger.Status("stage-lnd-credentials: %v", err)

--- a/internal/lndrpc/client_test.go
+++ b/internal/lndrpc/client_test.go
@@ -3,8 +3,8 @@
 package lndrpc
 
 import (
-	"fmt"
 	"testing"
+	"time"
 )
 
 func TestNodeInfoFields(t *testing.T) {
@@ -84,50 +84,89 @@ func TestNilClientSafety(t *testing.T) {
 	}
 }
 
-// The staged-certificate self-heal keys off this classifier: a
-// TLS verification failure means the board copy may be stale; a
-// down service or a locked wallet must not trigger a re-stage.
-func TestIsCertificateError(t *testing.T) {
-	certErrs := []string{
+// The RPC error classifier routes failures: transport loss
+// reconnects, credential rejection reconnects under the
+// re-stage limiter's damping (both land at the dial-time
+// repair, which re-stages the LND credentials when they were
+// the problem); in-progress states and application answers
+// over a working connection do neither. The dial-time repair
+// itself deliberately has NO classifier — it keys on the
+// absence of a successful test call, because enumerating
+// heal-worthy failure texts is a whitelist and a whitelist
+// misses.
+func TestClassifyRPCError(t *testing.T) {
+	transport := []string{
+		"rpc error: code = Unavailable desc = connection refused",
+		// A TLS verification failure against a stale staged
+		// certificate surfaces with code Unavailable — the
+		// reconnect routes it to the dial-time repair.
 		"rpc error: code = Unavailable desc = connection error: " +
 			"desc = \"transport: authentication handshake failed: " +
 			"tls: failed to verify certificate: x509: " +
 			"certificate signed by unknown authority\"",
-		"x509: certificate is valid for 127.0.0.1, not ::1",
-		"tls: bad certificate",
-	}
-	for _, msg := range certErrs {
-		if !isCertificateError(errFromString(msg)) {
-			t.Errorf("not classified as certificate error: %q", msg)
-		}
-	}
-	otherErrs := []string{
-		"rpc error: code = Unavailable desc = connection refused",
-		// Observed in production when the client dialed LND by
-		// the name localhost on a box with IPv6 disabled: the
-		// name resolved to ::1 and the kernel refused the
-		// address. An address-family failure, not a stale
-		// certificate — a re-stage must never fire on it.
+		// Observed in production when an old build dialed LND by
+		// the name localhost on a box with IPv6 disabled. The
+		// client now dials by literal address so this shape
+		// should not recur, but if an address-family failure
+		// ever does, reconnecting is the right response to it.
 		"rpc error: code = Unavailable desc = connection error: " +
 			"desc = \"transport: Error while dialing: dial tcp " +
 			"[::1]:10009: connect: cannot assign requested " +
 			"address\"",
-		"rpc error: code = Unimplemented desc = unknown service " +
-			"lnrpc.Lightning",
-		"wallet locked, unlock it to enable full RPC access",
-		"context deadline exceeded",
 	}
-	for _, msg := range otherErrs {
-		if isCertificateError(errFromString(msg)) {
-			t.Errorf("wrongly classified as certificate error: %q",
-				msg)
+	for _, msg := range transport {
+		if classifyRPCError(msg) != rpcErrTransport {
+			t.Errorf("not classified transport: %q", msg)
 		}
 	}
-	if isCertificateError(nil) {
-		t.Error("nil classified as certificate error")
+	credential := []string{
+		// A stale staged macaroon fails closed HERE. This class
+		// was treated as terminal before, which made macaroon
+		// staleness permanent for the process's lifetime.
+		"rpc error: code = Unauthenticated desc = verification " +
+			"failed: signature mismatch after caveat verification",
+		"rpc error: code = PermissionDenied desc = permission " +
+			"denied",
+	}
+	for _, msg := range credential {
+		if classifyRPCError(msg) != rpcErrCredential {
+			t.Errorf("not classified credential: %q", msg)
+		}
+	}
+	other := []string{
+		// In-progress states: reconnecting cannot help and
+		// would churn the connection.
+		"context deadline exceeded",
+		"rpc error: code = DeadlineExceeded desc = deadline",
+		"the RPC server is still starting up",
+		"chain notifier RPC is still syncing, not yet ready",
+		// Application answers over a working connection.
+		"rpc error: code = InvalidArgument desc = invalid " +
+			"payment request",
+		"insufficient funds available to construct transaction",
+	}
+	for _, msg := range other {
+		if classifyRPCError(msg) != rpcErrOther {
+			t.Errorf("wrongly classified: %q", msg)
+		}
 	}
 }
 
-func errFromString(msg string) error {
-	return fmt.Errorf("%s", msg)
+// The re-stage limiter is process-wide and bounds the heal to
+// one request per interval — with the heal keyed on any failed
+// test call, this is what keeps a long outage cheap.
+func TestRestageDue(t *testing.T) {
+	now := time.Unix(1_800_000_000, 0)
+	if !restageDue(time.Time{}, now) {
+		t.Error("first request should be due")
+	}
+	if restageDue(now.Add(-credRestageInterval+time.Second), now) {
+		t.Error("due inside the interval")
+	}
+	if !restageDue(now.Add(-credRestageInterval), now) {
+		t.Error("not due at exactly the interval")
+	}
+	if !restageDue(now.Add(-time.Hour), now) {
+		t.Error("not due long after the interval")
+	}
 }

--- a/internal/lndrpc/queries.go
+++ b/internal/lndrpc/queries.go
@@ -532,17 +532,74 @@ func (c *Client) getPeerAlias(pubkey string) string {
 }
 
 func (c *Client) handleError(err error) {
-	errStr := err.Error()
-	if strings.Contains(errStr, "DeadlineExceeded") || strings.Contains(errStr, "context deadline") {
-		return
-	}
-	if strings.Contains(errStr, "starting up") || strings.Contains(errStr, "not yet ready") {
-		return
-	}
-	if strings.Contains(errStr, "Unavailable") || strings.Contains(errStr, "connection refused") {
-		logger.Status("LND connection lost, will reconnect: %v", err)
+	switch classifyRPCError(err.Error()) {
+	case rpcErrTransport:
+		logger.Status("LND connection lost, will reconnect: %v",
+			err)
 		go c.Reconnect()
+	case rpcErrCredential:
+		// Reconnecting is only useful when the dial-time
+		// repair could actually re-stage the credentials —
+		// otherwise the dial would rebuild the same connection
+		// from the same board copies and fail the same way. A
+		// credential LND rejects PERMANENTLY (not stale — e.g.
+		// a wallet recreated behind this process's back) would
+		// otherwise produce a reconnect and a log line for
+		// every failing call on every poll tick, forever. The
+		// re-stage limiter is the damper: one repair attempt
+		// per interval, quiet in between.
+		if credRestageWorthwhile() {
+			logger.Status("LND rejected the held credentials, "+
+				"will reconnect and repair: %v", err)
+			go c.Reconnect()
+		}
 	}
+}
+
+// RPC error classes, by what would help:
+//
+//   - transport: the connection itself is gone (Unavailable,
+//     connection refused) — LND restarted or is down; rebuild
+//     the connection and the next dial finds out.
+//   - credential: LND answered but rejected the caller
+//     (PermissionDenied, Unauthenticated) — the fail-closed
+//     moment of a stale staged macaroon. Treating this as
+//     terminal left that staleness permanent; routing it
+//     through Reconnect (damped, above) lands it at the
+//     dial-time repair, which re-stages both LND credentials
+//     and retries once.
+//   - other: in-progress states (deadline, starting up, not
+//     yet ready) and application answers over a working
+//     connection — nothing a reconnect can help.
+type rpcErrClass int
+
+const (
+	rpcErrOther rpcErrClass = iota
+	rpcErrTransport
+	rpcErrCredential
+)
+
+// classifyRPCError sorts an RPC error into the classes above.
+// Matching on error text is unavoidable — grpc flattens error
+// chains into strings. Pure — unit-tested.
+func classifyRPCError(errStr string) rpcErrClass {
+	if strings.Contains(errStr, "DeadlineExceeded") ||
+		strings.Contains(errStr, "context deadline") {
+		return rpcErrOther
+	}
+	if strings.Contains(errStr, "starting up") ||
+		strings.Contains(errStr, "not yet ready") {
+		return rpcErrOther
+	}
+	if strings.Contains(errStr, "Unavailable") ||
+		strings.Contains(errStr, "connection refused") {
+		return rpcErrTransport
+	}
+	if strings.Contains(errStr, "PermissionDenied") ||
+		strings.Contains(errStr, "Unauthenticated") {
+		return rpcErrCredential
+	}
+	return rpcErrOther
 }
 
 func satStr(sats int64) string {

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -35,14 +35,27 @@ const (
 	BitcoinDir  = "/etc/bitcoin"
 
 	// StateDir is the staging board: root-written files that
-	// carry privileged facts (onion hostnames, staged
-	// credentials) to the unprivileged admin user. The
-	// directory is root:vpn 0750; each file root:vpn 0640.
-	// Root (the installer and the helper) writes; the admin
-	// user reads. Every file is re-written by whatever
-	// operation changes the fact it carries — a reader that
-	// finds a file missing or unreadable reports the feature
-	// unavailable and logs why, never guesses.
+	// carry privileged facts (staged credentials) to the
+	// unprivileged admin user. The directory is root:vpn
+	// 0750; each file root:vpn 0640. Root (the installer and
+	// the helper) writes; the admin user reads. Every file is
+	// re-written by whatever operation changes the fact it
+	// carries — a reader that finds a file missing or
+	// unreadable reports the feature unavailable and logs
+	// why, never guesses.
+	//
+	// Only facts consumed at MACHINE cadence (per RPC call,
+	// per dial) live here — credentials, which fail closed at
+	// the moment of use when stale, so a stale copy cannot
+	// hide. Display facts consumed at HUMAN cadence (onion
+	// addresses, the Syncthing device ID, the SSH
+	// password-auth answer) have no copy at all: a stale copy
+	// of those would render confidently wrong with no failure
+	// to catch it, so the TUI reads them live through the
+	// helper's read-only verbs instead. Every board file
+	// declares how it stays fresh in the helper's freshness
+	// table (internal/helperd/matrix.go), and a unit test
+	// fails on any file without a declaration.
 	//
 	// The board lives under /var/lib/vpn — NOT under /etc/vpn
 	// — deliberately: /etc/vpn is owned by the admin user (the
@@ -59,13 +72,7 @@ const (
 	StateBitcoindRPCPass = StateDir + "/bitcoind-rpc.pass"
 	StateLNDTLSCert      = StateDir + "/lnd-tls.cert"
 	StateLNDMacaroon     = StateDir + "/lnd-admin.macaroon"
-	StateOnionBitcoinP2P = StateDir + "/onion-bitcoin-p2p"
-	StateOnionLNDGRPC    = StateDir + "/onion-lnd-grpc"
-	StateOnionLNDREST    = StateDir + "/onion-lnd-rest"
-	StateOnionSyncthing  = StateDir + "/onion-syncthing"
 	StateSyncthingAPIKey = StateDir + "/syncthing-api-key"
-	StateSyncthingDevID  = StateDir + "/syncthing-device-id"
-	StateSSHPasswordAuth = StateDir + "/ssh-password-auth"
 
 	LNDConf = "/etc/lnd/lnd.conf"
 	LNDDir  = "/etc/lnd"
@@ -157,6 +164,19 @@ const (
 	SyncthingService  = "/etc/systemd/system/syncthing.service"
 	BackupWatchPath   = "/etc/systemd/system/lnd-backup-watch.path"
 	BackupCopyService = "/etc/systemd/system/lnd-backup-copy.service"
+
+	// The LND TLS certificate watch. LND rewrites tls.cert on
+	// its own (tlsautorefresh in lnd.conf regenerates it at
+	// any startup whose parameters changed or whose cert
+	// nears expiry) — no TUI-requested operation is
+	// involved, so no operation can re-stage the TUI's
+	// copy. This path unit closes that gap at the source: a
+	// rewrite of the certificate triggers the stage service,
+	// which refreshes the staged copy within seconds.
+	LNDCertWatchPath        = "/etc/systemd/system/vpn-lnd-cert-watch.path"
+	LNDCertStageService     = "/etc/systemd/system/vpn-lnd-cert-stage.service"
+	LNDCertWatchPathName    = "vpn-lnd-cert-watch.path"
+	LNDCertStageServiceName = "vpn-lnd-cert-stage.service"
 
 	// The root helper's socket-activated units. The socket
 	// node's ownership and mode (root:vpn 0660, created by

--- a/internal/welcome/cmds.go
+++ b/internal/welcome/cmds.go
@@ -58,6 +58,27 @@ func fetchLatestVersionCmd() tea.Cmd {
 	}
 }
 
+// ── Live-read node facts ─────────────────────────────────
+
+// fetchNodeAddressesCmd asks the helper's read-node-addresses
+// operation for the node's onion hostnames and Syncthing
+// device ID, live. Screens that display these run this at
+// entry (Init, and again on tabActivatedMsg) and render the
+// answer from their own state — never from a stored copy that
+// could outlive the truth. tab routes the answer back to the
+// requesting screen.
+func fetchNodeAddressesCmd(tab tabKind) tea.Cmd {
+	return func() tea.Msg {
+		var res helper.NodeAddressesResult
+		err := helper.Call(
+			helper.VerbReadNodeAddresses, nil, &res)
+		if err != nil {
+			logger.Status("read node addresses: %v", err)
+		}
+		return nodeAddressesMsg{tab: tab, addrs: res, err: err}
+	}
+}
+
 // ── Syncthing actions ────────────────────────────────────
 
 func pairSyncthingDeviceCmd(

--- a/internal/welcome/helpers.go
+++ b/internal/welcome/helpers.go
@@ -17,32 +17,13 @@ import (
 	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
-// onionBoardFile maps a Tor hidden-service hostname path to
-// its staged copy on the board — the unprivileged read path
-// for onion addresses (the originals are readable only by
-// root and the tor user).
-var onionBoardFile = map[string]string{
-	paths.TorBitcoinP2P + "/hostname": paths.StateOnionBitcoinP2P,
-	paths.TorLNDGRPC + "/hostname":    paths.StateOnionLNDGRPC,
-	paths.TorLNDRESTHostname:          paths.StateOnionLNDREST,
-	paths.TorSyncthingHostname:        paths.StateOnionSyncthing,
-}
-
-func readOnion(path string) string {
-	board, ok := onionBoardFile[path]
-	if !ok {
-		logger.Status("readOnion: no staged copy mapped for %s", path)
-		return ""
-	}
-	v, err := helper.ReadBoardString(board)
-	if err != nil {
-		// Fail-noisy: the screen renders the address as
-		// unavailable; the log names the missing fact.
-		logger.Status("%v", err)
-		return ""
-	}
-	return v
-}
+// Onion addresses have NO unprivileged copy: screens that
+// display one fetch it live at entry with
+// fetchNodeAddressesCmd (cmds.go) and render from their own
+// state. The originals are readable only by root and the tor
+// user, and a staged copy could outlive a hidden service that
+// root destroyed and recreated — a dead address rendered
+// confidently, with no failure moment to catch it.
 
 func readMacaroonHex(cfg *config.AppConfig) string {
 	data, err := helper.ReadBoard(paths.StateLNDMacaroon)

--- a/internal/welcome/model.go
+++ b/internal/welcome/model.go
@@ -6,6 +6,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/virtualprivatenode/vpn/internal/config"
+	"github.com/virtualprivatenode/vpn/internal/helper"
 	"github.com/virtualprivatenode/vpn/internal/lndrpc"
 	"github.com/virtualprivatenode/vpn/internal/logger"
 	"github.com/virtualprivatenode/vpn/internal/theme"
@@ -105,6 +106,19 @@ type latestVersionMsg string
 // Used to refresh stale data without replacing the screen
 // or its in-progress state.
 type tabActivatedMsg struct{}
+
+// nodeAddressesMsg carries the live-read display facts (onion
+// hostnames, the Syncthing device ID) fetched at screen entry
+// through the helper's read-node-addresses operation. tab
+// names the screen that asked, so Update can route the answer
+// back to it. No screen caches these beyond its own lifetime —
+// the facts have no board copy, and re-entering a screen asks
+// again.
+type nodeAddressesMsg struct {
+	tab   tabKind
+	addrs helper.NodeAddressesResult
+	err   error
+}
 
 type syncthingPairedMsg struct {
 	deviceID string

--- a/internal/welcome/screen_addon_syncthing_pair.go
+++ b/internal/welcome/screen_addon_syncthing_pair.go
@@ -7,7 +7,6 @@ import (
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/virtualprivatenode/vpn/internal/installer"
 	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
@@ -37,6 +36,10 @@ type SyncthingPairScreen struct {
 	focusZone int // 0=input, 1=buttons
 	btnIdx    int
 	pairError string
+	// This node's Syncthing device ID, live-read at screen
+	// entry through the helper (no stored copy exists
+	// anywhere) and held only for this screen's lifetime.
+	nodeDeviceID string
 }
 
 func NewSyncthingPairScreen(
@@ -52,7 +55,7 @@ func NewSyncthingPairScreen(
 // ── Screen interface ────────────────────────────────────
 
 func (s *SyncthingPairScreen) Init() tea.Cmd {
-	return nil
+	return fetchNodeAddressesCmd(tabSyncthingPair)
 }
 
 func (s *SyncthingPairScreen) HandleKey(
@@ -80,6 +83,12 @@ func (s *SyncthingPairScreen) HandleMsg(
 			s.input, cmd = s.input.Update(msg)
 			return s, cmd
 		}
+	case tabActivatedMsg:
+		// Re-entering the tab re-asks: screen entry is the
+		// cadence at which live-read facts are read.
+		return s, fetchNodeAddressesCmd(tabSyncthingPair)
+	case nodeAddressesMsg:
+		s.nodeDeviceID = msg.addrs.SyncthingDeviceID
 	case syncthingPairedMsg:
 		if msg.err != nil {
 			s.pairError = msg.err.Error()
@@ -331,7 +340,7 @@ func (s *SyncthingPairScreen) handlePostPairKey(
 	case "enter":
 		switch s.btnIdx {
 		case 0: // Show QR
-			vpsDeviceID := installer.GetSyncthingDeviceID()
+			vpsDeviceID := s.nodeDeviceID
 			if vpsDeviceID == "" {
 				return s, nil
 			}
@@ -496,7 +505,7 @@ func (s *SyncthingPairScreen) viewPostPair(
 				"Complete Pairing"), w))
 	lines = append(lines, "")
 
-	vpsDeviceID := installer.GetSyncthingDeviceID()
+	vpsDeviceID := s.nodeDeviceID
 	if vpsDeviceID != "" {
 		lines = append(lines,
 			" "+theme.Dim.Render(

--- a/internal/welcome/screen_addon_syncthing_webui.go
+++ b/internal/welcome/screen_addon_syncthing_webui.go
@@ -4,7 +4,6 @@ import (
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/virtualprivatenode/vpn/internal/paths"
 	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
@@ -12,11 +11,18 @@ import (
 // Shows Syncthing Web UI connection info: URL, user,
 // password with show/hide toggle. Two buttons: Full URL
 // and Show/Hide Password.
+//
+// The web UI's onion address is live-read at screen entry
+// (no stored copy exists anywhere) and held only for this
+// screen's lifetime.
 
 type SyncthingWebUIScreen struct {
 	ctx         *ScreenContext
 	btnIdx      int // 0=Full URL, 1=Show/Hide Password
 	showSecrets bool
+	syncOnion   string
+	fetched     bool // the live read answered
+	fetchErr    bool // ...with an error (already logged)
 }
 
 func NewSyncthingWebUIScreen(
@@ -30,7 +36,7 @@ func NewSyncthingWebUIScreen(
 // ── Screen interface ────────────────────────────────────
 
 func (s *SyncthingWebUIScreen) Init() tea.Cmd {
-	return nil
+	return fetchNodeAddressesCmd(tabSyncthingWebUI)
 }
 
 func (s *SyncthingWebUIScreen) HandleKey(
@@ -70,8 +76,7 @@ func (s *SyncthingWebUIScreen) handleEnter() (
 ) {
 	switch s.btnIdx {
 	case 0: // Full URL
-		syncOnion := readOnion(
-			paths.TorSyncthingHostname)
+		syncOnion := s.syncOnion
 		if syncOnion != "" {
 			url := "http://" + syncOnion + ":8384"
 			return s, func() tea.Msg {
@@ -87,6 +92,16 @@ func (s *SyncthingWebUIScreen) handleEnter() (
 func (s *SyncthingWebUIScreen) HandleMsg(
 	msg tea.Msg,
 ) (Screen, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tabActivatedMsg:
+		// Re-entering the tab re-asks: screen entry is the
+		// cadence at which live-read facts are read.
+		return s, fetchNodeAddressesCmd(tabSyncthingWebUI)
+	case nodeAddressesMsg:
+		s.syncOnion = msg.addrs.SyncthingOnion
+		s.fetched = true
+		s.fetchErr = msg.err != nil
+	}
 	return s, nil
 }
 
@@ -96,9 +111,17 @@ func (s *SyncthingWebUIScreen) View(
 	p := newPane(w)
 	p.title(theme.Header, "↻ Syncthing Web UI")
 
-	syncOnion := readOnion(paths.TorSyncthingHostname)
+	syncOnion := s.syncOnion
 	if syncOnion == "" {
-		p.warn("Tor address not available yet.")
+		switch {
+		case !s.fetched:
+			p.dim("Reading the web UI's Tor address...")
+		case s.fetchErr:
+			p.warn("Cannot read the web UI's Tor address — " +
+				"check: journalctl -u vpn-helperd")
+		default:
+			p.warn("Tor address not available yet.")
+		}
 		return p.renderWithBottomButtons(
 			[]string{"Waiting..."}, 0, false, h)
 	}

--- a/internal/welcome/screen_offchain_pairing.go
+++ b/internal/welcome/screen_offchain_pairing.go
@@ -6,7 +6,6 @@ import (
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/virtualprivatenode/vpn/internal/paths"
 	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
@@ -14,10 +13,17 @@ import (
 // Zeus wallet pairing: shows LND REST connection info
 // with QR (Tor), Macaroon, and optional QR (Clearnet)
 // buttons.
+//
+// The REST onion address is live-read at screen entry (no
+// stored copy exists anywhere) and held only for this
+// screen's lifetime.
 
 type PairingScreen struct {
-	ctx    *ScreenContext
-	btnIdx int
+	ctx       *ScreenContext
+	btnIdx    int
+	restOnion string
+	fetched   bool // the live read answered
+	fetchErr  bool // ...with an error (already logged)
 }
 
 func NewPairingScreen(
@@ -31,7 +37,7 @@ func NewPairingScreen(
 // ── Screen interface ────────────────────────────────────
 
 func (s *PairingScreen) Init() tea.Cmd {
-	return nil
+	return fetchNodeAddressesCmd(tabPairing)
 }
 
 func (s *PairingScreen) maxBtn() int {
@@ -86,8 +92,7 @@ func (s *PairingScreen) handleEnter() (Screen, tea.Cmd) {
 	}
 	switch btns[s.btnIdx] {
 	case "Show QR (Tor)":
-		restOnion := readOnion(
-			paths.TorLNDRESTHostname)
+		restOnion := s.restOnion
 		mac := readMacaroonHex(s.ctx.Cfg)
 		if restOnion != "" && mac != "" {
 			url := fmt.Sprintf(
@@ -128,6 +133,16 @@ func (s *PairingScreen) handleEnter() (Screen, tea.Cmd) {
 func (s *PairingScreen) HandleMsg(
 	msg tea.Msg,
 ) (Screen, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tabActivatedMsg:
+		// Re-entering the tab re-asks: screen entry is the
+		// cadence at which live-read facts are read.
+		return s, fetchNodeAddressesCmd(tabPairing)
+	case nodeAddressesMsg:
+		s.restOnion = msg.addrs.LNDRESTOnion
+		s.fetched = true
+		s.fetchErr = msg.err != nil
+	}
 	return s, nil
 }
 
@@ -156,7 +171,7 @@ func (s *PairingScreen) View(
 	p := newPane(w)
 	p.title(theme.Lightning, "⚡ Zeus — LND REST")
 
-	restOnion := readOnion(paths.TorLNDRESTHostname)
+	restOnion := s.restOnion
 
 	if cfg.P2PMode == "hybrid" {
 		p.line(" " + theme.Header.Render(
@@ -173,7 +188,15 @@ func (s *PairingScreen) View(
 	}
 
 	if restOnion == "" {
-		p.warn("Tor not available")
+		switch {
+		case !s.fetched:
+			p.dim("Reading the node's Tor address...")
+		case s.fetchErr:
+			p.warn("Cannot read the node's Tor address — " +
+				"check: journalctl -u vpn-helperd")
+		default:
+			p.warn("Tor not available")
+		}
 	} else {
 		p.labelLine("Server:")
 		p.monoWrap(restOnion)

--- a/internal/welcome/update.go
+++ b/internal/welcome/update.go
@@ -305,6 +305,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.latestVersion = string(msg)
 		m.screenCtx.LatestVersion = string(msg)
 		return m, nil
+	case nodeAddressesMsg:
+		// Live-read answer — deliver to the screen that asked
+		// (it recorded which tab kind it lives on).
+		return m.dispatchToTab(msg.tab, msg)
 	case syncthingPairedMsg:
 		if msg.err == nil {
 			m.cfg.AddSyncthingDevice(msg.deviceID)


### PR DESCRIPTION
The TUI reads privileged facts through root staged copies under /var/lib/vpn/state. A copy can outlive the truth when the fact changes outside any operation the TUI requested, and the failure modes differ by fact: a stale credential fails closed at the moment of use, while a stale display fact renders confidently wrong with no failure at all. This change applies one rule across that surface: credentials stay cached and are repaired at their failure moment, display facts lose their copies entirely and are read live at screen entry.

* A systemd path unit now watches the certificate file LND itself rewrites (lnd regenerates it at any startup whose parameters changed or whose certificate nears expiry) and refreshes the staged copy within seconds through a new oneshot binary mode. The new mode refuses to run unprivileged or on a box that is not installed, and its runs are audited in its own systemd journal. The installer writes and enables the watch as a new install step, so migrated boxes arm it on their next install pass.

* The LND client connection heal no longer matches failure text. Enumerating heal worthy failure messages is a whitelist and a whitelist misses; the heal now keys on the absence of a successful test call, still bounded by the existing process wide five minute limiter and still retrying exactly once. Credential rejections from LND now trigger a reconnect instead of being treated as terminal, so a stale staged macaroon heals through the same path, and that reconnect is damped by the same limiter: a credential LND rejects permanently costs one repair attempt and one log line per interval, not one per failing call.

* Syncthing REST calls now go through the standard library HTTP client and fail on HTTP error statuses. The old transport shelled out to curl in silent mode, which exits zero on a 403 and could report a pairing as done when the daemon had rejected the request, leaving the operator believing channel backups replicate off the box when they do not. The status code is now a first class value, every call checks it, and an error naming the refused call surfaces in the TUI. The Syncthing readiness probe uses the same client, so this path no longer depends on an image supplied binary.

* Onion addresses, the Syncthing device id, and the effective ssh password auth answer are no longer copied to disk at all. Two new read only helper operations return them live, the screens fetch them at entry, and the install removes the retired files left by earlier releases. The password auth answer gates removing the last ssh key, so the stale yes that could strand a box with no way in can no longer exist as an input.

* Every remaining board file now declares how it stays fresh (watched, healed, read live, or static by decision) and a unit test fails on any fact without a declaration, so a future fact cannot be added without deciding its staleness story.

The bitcoind RPC password keeps its existing behavior deliberately: it changes only at install, and if the server side half is replaced by hand the TUI reports the divergence honestly.