### PR TITLE
fix: payments recover their outcome and coin control never widens

### DIFF
--- a/internal/lndrpc/client.go
+++ b/internal/lndrpc/client.go
@@ -12,9 +12,9 @@
 // never crosses the network. When the TUI process exits, the
 // macaroon is gone from memory.
 //
-// This package only performs read operations. Fund-moving RPCs
-// (SendPayment, OpenChannel, etc.) are added in later changes
-// with explicit confirmation flows.
+// Read queries and fund-moving RPCs share this one client;
+// every fund-moving call sits behind an explicit confirmation
+// flow in its caller.
 package lndrpc
 
 import (
@@ -27,6 +27,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
 
 	"github.com/lightningnetwork/lnd/lnrpc"
@@ -108,10 +109,19 @@ func (c *Client) dial(allowHeal bool) error {
 	}
 	c.macaroonHex = hex.EncodeToString(macBytes)
 
-	// Connect
+	// Connect. Keepalive bounds how long a silently dead TCP
+	// connection (LND restarted underneath the TUI, a network
+	// blip) can block calls and streams instead of blocking
+	// forever; LND disconnects clients that ping more often
+	// than every five seconds, and one minute stays far clear
+	// of that floor with pings only while calls are active.
 	opts := []grpc.DialOption{
 		grpc.WithTransportCredentials(tlsCreds),
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(50 * 1024 * 1024)),
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			Time:    time.Minute,
+			Timeout: 20 * time.Second,
+		}),
 	}
 
 	// Dial by the shared loopback constant — the same value
@@ -127,8 +137,13 @@ func (c *Client) dial(allowHeal bool) error {
 	c.lightning = lnrpc.NewLightningClient(conn)
 
 	// Test the connection with a longer timeout.
-	// During IBD, LND's GetInfo queries Bitcoin Core which can be slow.
-	ctx, cancel := context.WithTimeout(c.macaroonCtx(), 30*time.Second)
+	// During IBD, LND's GetInfo queries Bitcoin Core which can
+	// be slow. The probe context is built inline rather than
+	// through macaroonCtx: dial runs under the write lock and
+	// macaroonCtx takes the read lock.
+	md := metadata.New(map[string]string{"macaroon": c.macaroonHex})
+	probeCtx := metadata.NewOutgoingContext(context.Background(), md)
+	ctx, cancel := context.WithTimeout(probeCtx, 30*time.Second)
 	defer cancel()
 
 	_, err = c.lightning.GetInfo(ctx, &lnrpc.GetInfoRequest{})
@@ -227,10 +242,15 @@ func (c *Client) Close() {
 	}
 }
 
-// macaroonCtx returns a context with the macaroon injected as gRPC metadata.
+// macaroonCtx returns a context with the macaroon injected as
+// gRPC metadata. The field is read under the lock — Reconnect
+// rewrites it on another goroutine.
 func (c *Client) macaroonCtx() context.Context {
+	c.mu.RLock()
+	macHex := c.macaroonHex
+	c.mu.RUnlock()
 	md := metadata.New(map[string]string{
-		"macaroon": c.macaroonHex,
+		"macaroon": macHex,
 	})
 	return metadata.NewOutgoingContext(context.Background(), md)
 }

--- a/internal/lndrpc/client_test.go
+++ b/internal/lndrpc/client_test.go
@@ -3,6 +3,7 @@
 package lndrpc
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -81,6 +82,61 @@ func TestNilClientSafety(t *testing.T) {
 	}
 	if _, err := c.OpenChannel("a", 100000, false, false, nil, false, 0); err == nil {
 		t.Error("should error")
+	}
+	if _, err := c.SendPayment("lnbc1"); err == nil {
+		t.Error("should error")
+	}
+}
+
+// Both fund-moving coin-control call sites route through
+// parseOutpoint; anything that does not parse must be an error,
+// never a silently narrowed or retargeted selection.
+func TestParseOutpoint(t *testing.T) {
+	txid := strings.Repeat("ab", 32)
+	op, err := parseOutpoint(txid + ":7")
+	if err != nil || op.TxidStr != txid || op.OutputIndex != 7 {
+		t.Fatalf("valid outpoint: got (%v, %v)", op, err)
+	}
+	if _, err := parseOutpoint(txid + ":0"); err != nil {
+		t.Errorf("index 0 rejected: %v", err)
+	}
+	bad := []string{
+		"",
+		txid,
+		txid + ":",
+		txid + ":x",
+		txid + ":1x2",
+		txid + ":-1",
+		txid + ":4294967296",
+		"ab:0",
+		"nothex" + strings.Repeat("a", 58) + ":0",
+	}
+	for _, s := range bad {
+		if _, err := parseOutpoint(s); err == nil {
+			t.Errorf("accepted %q", s)
+		}
+	}
+}
+
+// The routing fee limit scales with the amount: half a percent
+// with a 30 sat floor, and a fixed cap when the amount is
+// unknown (zero-amount invoice).
+func TestPaymentFeeLimit(t *testing.T) {
+	tests := []struct{ amt, want int64 }{
+		{0, 1000},
+		{-5, 1000},
+		{1, 30},
+		{50, 30},
+		{6000, 30},
+		{6200, 31},
+		{200000, 1000},
+		{10000000, 50000},
+	}
+	for _, tt := range tests {
+		if got := paymentFeeLimitSat(tt.amt); got != tt.want {
+			t.Errorf("paymentFeeLimitSat(%d): got %d, want %d",
+				tt.amt, got, tt.want)
+		}
 	}
 }
 

--- a/internal/lndrpc/onchain.go
+++ b/internal/lndrpc/onchain.go
@@ -148,24 +148,16 @@ func (c *Client) SendCoins(
 		SpendUnconfirmed: true,
 	}
 
-	// Coin control: restrict inputs to selected UTXOs
+	// Coin control: restrict inputs to the selected UTXOs. A
+	// malformed outpoint aborts the whole operation — silently
+	// skipping one would widen coin selection past what the
+	// operator chose.
 	for _, op := range outpoints {
-		parts := strings.SplitN(op, ":", 2)
-		if len(parts) != 2 {
-			continue
+		outPoint, err := parseOutpoint(op)
+		if err != nil {
+			return nil, err
 		}
-		txid := parts[0]
-		var idx uint32
-		for _, c := range parts[1] {
-			if c >= '0' && c <= '9' {
-				idx = idx*10 + uint32(c-'0')
-			}
-		}
-		req.Outpoints = append(req.Outpoints,
-			&lnrpc.OutPoint{
-				TxidStr:     txid,
-				OutputIndex: idx,
-			})
+		req.Outpoints = append(req.Outpoints, outPoint)
 	}
 
 	resp, err := rpc.SendCoins(ctx, req)

--- a/internal/lndrpc/payments.go
+++ b/internal/lndrpc/payments.go
@@ -2,6 +2,7 @@ package lndrpc
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 	"time"
 
@@ -20,9 +21,36 @@ type SendPaymentResult struct {
 	Error    string
 }
 
+// paymentFeeLimitSat derives the routing fee limit from the
+// payment amount: half a percent, with a 30 sat floor so small
+// payments still route. A flat limit is wrong in both
+// directions — it authorizes an enormous relative fee on a tiny
+// payment and starves a large one of viable routes. Zero-amount
+// invoices (amount chosen by the sender at pay time is unknown
+// here) fall back to a fixed cap. The specific constants are a
+// first pass and may be tuned. Pure — unit-tested.
+func paymentFeeLimitSat(amountSats int64) int64 {
+	if amountSats <= 0 {
+		return 1000
+	}
+	limit := amountSats / 200
+	if limit < 30 {
+		limit = 30
+	}
+	return limit
+}
+
 // SendPayment sends a payment using SendPaymentV2 (streaming).
 // Blocks until the payment succeeds, fails, or times out.
 // Returns route hops on success for visualization.
+//
+// If the update stream drops before a terminal status, the
+// payment may still be running inside LND, and the one wrong
+// answer is reporting failure — an operator who retries a
+// payment that later settles has paid twice. The stream is
+// re-attached by payment hash instead, and if no terminal
+// status arrives before the deadline the result says IN_FLIGHT
+// with an instruction to check history before retrying.
 func (c *Client) SendPayment(payReq string) (*SendPaymentResult, error) {
 	if c.rpc() == nil {
 		return nil, errNotConnected
@@ -37,6 +65,18 @@ func (c *Client) SendPayment(payReq string) (*SendPaymentResult, error) {
 
 	routerClient := routerrpc.NewRouterClient(conn)
 
+	// Decode first: the amount drives the fee limit and the
+	// payment hash is the re-attach handle if the stream dies.
+	feeLimit := int64(1000)
+	var payHash []byte
+	if decoded, err := c.DecodePayReq(payReq); err == nil {
+		feeLimit = paymentFeeLimitSat(decoded.AmountSats)
+		if raw, err := hex.DecodeString(
+			decoded.PaymentHash); err == nil && len(raw) == 32 {
+			payHash = raw
+		}
+	}
+
 	ctx, cancel := context.WithTimeout(c.macaroonCtx(), 120*time.Second)
 	defer cancel()
 
@@ -44,7 +84,7 @@ func (c *Client) SendPayment(payReq string) (*SendPaymentResult, error) {
 		&routerrpc.SendPaymentRequest{
 			PaymentRequest:    payReq,
 			TimeoutSeconds:    60,
-			FeeLimitSat:       1000,
+			FeeLimitSat:       feeLimit,
 			MaxParts:          16,
 			NoInflightUpdates: true,
 		})
@@ -55,37 +95,12 @@ func (c *Client) SendPayment(payReq string) (*SendPaymentResult, error) {
 	for {
 		payment, err := stream.Recv()
 		if err != nil {
-			return nil, fmt.Errorf("payment stream: %w", err)
+			return c.recoverPaymentOutcome(ctx, payHash, err)
 		}
 
 		switch payment.GetStatus() {
 		case lnrpc.Payment_SUCCEEDED:
-			result := &SendPaymentResult{
-				Preimage: payment.GetPaymentPreimage(),
-				FeeSats:  payment.GetFeeSat(),
-				Status:   "SUCCEEDED",
-			}
-			for _, htlc := range payment.GetHtlcs() {
-				if htlc.GetStatus() == lnrpc.HTLCAttempt_SUCCEEDED &&
-					htlc.GetRoute() != nil {
-					for _, hop := range htlc.GetRoute().GetHops() {
-						result.Hops = append(result.Hops, RouteHop{
-							PubKey:   hop.GetPubKey(),
-							ChanID:   hop.GetChanId(),
-							FeeSats:  hop.GetFeeMsat() / 1000,
-							AmtToFwd: hop.GetAmtToForwardMsat() / 1000,
-						})
-					}
-					break
-				}
-			}
-			for i := range result.Hops {
-				result.Hops[i].Alias = c.getPeerAlias(
-					result.Hops[i].PubKey)
-			}
-			logger.TUI("Payment succeeded: fee=%d sats, hops=%d",
-				result.FeeSats, len(result.Hops))
-			return result, nil
+			return c.successResult(payment), nil
 
 		case lnrpc.Payment_FAILED:
 			reason := payment.GetFailureReason().String()
@@ -102,6 +117,97 @@ func (c *Client) SendPayment(payReq string) (*SendPaymentResult, error) {
 			continue
 		}
 	}
+}
+
+// successResult builds the success outcome, extracting the
+// route from the settled HTLC for visualization.
+func (c *Client) successResult(payment *lnrpc.Payment) *SendPaymentResult {
+	result := &SendPaymentResult{
+		Preimage: payment.GetPaymentPreimage(),
+		FeeSats:  payment.GetFeeSat(),
+		Status:   "SUCCEEDED",
+	}
+	for _, htlc := range payment.GetHtlcs() {
+		if htlc.GetStatus() == lnrpc.HTLCAttempt_SUCCEEDED &&
+			htlc.GetRoute() != nil {
+			for _, hop := range htlc.GetRoute().GetHops() {
+				result.Hops = append(result.Hops, RouteHop{
+					PubKey:   hop.GetPubKey(),
+					ChanID:   hop.GetChanId(),
+					FeeSats:  hop.GetFeeMsat() / 1000,
+					AmtToFwd: hop.GetAmtToForwardMsat() / 1000,
+				})
+			}
+			break
+		}
+	}
+	for i := range result.Hops {
+		result.Hops[i].Alias = c.getPeerAlias(
+			result.Hops[i].PubKey)
+	}
+	logger.TUI("Payment succeeded: fee=%d sats, hops=%d",
+		result.FeeSats, len(result.Hops))
+	return result
+}
+
+// recoverPaymentOutcome re-attaches to a payment whose update
+// stream died without a terminal status. It never invents an
+// outcome: it returns the tracked terminal status, or an
+// explicit IN_FLIGHT result when the deadline passes first.
+// Without a payment hash to track by (the decode failed), the
+// stream error is surfaced as-is.
+func (c *Client) recoverPaymentOutcome(
+	ctx context.Context, payHash []byte, streamErr error,
+) (*SendPaymentResult, error) {
+	if len(payHash) == 0 {
+		return nil, fmt.Errorf("payment stream: %w", streamErr)
+	}
+	logger.TUI("Payment stream dropped (%v) — tracking by hash",
+		streamErr)
+
+	for ctx.Err() == nil {
+		c.mu.RLock()
+		conn := c.conn
+		c.mu.RUnlock()
+		if conn == nil {
+			break
+		}
+		stream, err := routerrpc.NewRouterClient(conn).
+			TrackPaymentV2(ctx, &routerrpc.TrackPaymentRequest{
+				PaymentHash:       payHash,
+				NoInflightUpdates: true,
+			})
+		if err == nil {
+			for {
+				payment, err := stream.Recv()
+				if err != nil {
+					break
+				}
+				switch payment.GetStatus() {
+				case lnrpc.Payment_SUCCEEDED:
+					return c.successResult(payment), nil
+				case lnrpc.Payment_FAILED:
+					return &SendPaymentResult{
+						Status: "FAILED",
+						Error: payment.
+							GetFailureReason().String(),
+					}, nil
+				}
+			}
+		}
+		select {
+		case <-ctx.Done():
+		case <-time.After(2 * time.Second):
+		}
+	}
+
+	logger.TUI("Payment outcome unresolved before deadline — " +
+		"reported in flight")
+	return &SendPaymentResult{
+		Status: "IN_FLIGHT",
+		Error: "Payment still in flight. Check Payment History " +
+			"before retrying: sending again could pay twice.",
+	}, nil
 }
 
 // WaitForInvoiceSettlement polls an invoice until settled or expired.

--- a/internal/lndrpc/queries.go
+++ b/internal/lndrpc/queries.go
@@ -5,6 +5,7 @@ package lndrpc
 import (
 	"encoding/hex"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -470,24 +471,16 @@ func (c *Client) OpenChannel(pubkey string, localAmount int64, private bool, tap
 		req.SatPerVbyte = satPerVbyte
 	}
 
-	// Coin control: restrict inputs to selected UTXOs
+	// Coin control: restrict inputs to the selected UTXOs. A
+	// malformed outpoint aborts the whole operation — silently
+	// skipping one would widen coin selection past what the
+	// operator chose.
 	for _, op := range outpoints {
-		parts := strings.SplitN(op, ":", 2)
-		if len(parts) != 2 {
-			continue
+		outPoint, err := parseOutpoint(op)
+		if err != nil {
+			return nil, err
 		}
-		txid := parts[0]
-		var idx uint32
-		for _, c := range parts[1] {
-			if c >= '0' && c <= '9' {
-				idx = idx*10 + uint32(c-'0')
-			}
-		}
-		req.Outpoints = append(req.Outpoints,
-			&lnrpc.OutPoint{
-				TxidStr:     txid,
-				OutputIndex: idx,
-			})
+		req.Outpoints = append(req.Outpoints, outPoint)
 	}
 
 	resp, err := rpc.OpenChannelSync(ctx, req)
@@ -529,6 +522,30 @@ func (c *Client) getPeerAlias(pubkey string) string {
 		return resp.GetNode().GetAlias()
 	}
 	return ""
+}
+
+// parseOutpoint parses a txid:index outpoint string strictly.
+// Both fund-moving call sites (channel funding, on-chain send
+// with coin control) route through here: a value that does not
+// parse must abort the operation rather than silently narrow or
+// retarget the operator's coin selection. Pure — unit-tested.
+func parseOutpoint(op string) (*lnrpc.OutPoint, error) {
+	parts := strings.SplitN(op, ":", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid outpoint %q", op)
+	}
+	txidRaw, err := hex.DecodeString(parts[0])
+	if err != nil || len(txidRaw) != 32 {
+		return nil, fmt.Errorf("invalid outpoint txid in %q", op)
+	}
+	idx, err := strconv.ParseUint(parts[1], 10, 32)
+	if err != nil {
+		return nil, fmt.Errorf("invalid outpoint index in %q", op)
+	}
+	return &lnrpc.OutPoint{
+		TxidStr:     parts[0],
+		OutputIndex: uint32(idx),
+	}, nil
 }
 
 func (c *Client) handleError(err error) {


### PR DESCRIPTION
Five corrections to how this node talks to lnd, all against the current lnd 0.20.0. No version or dependency changes, no exported function changed shape, and the TUI needed no edits, so the change is contained to the lnd client package.

Lightning routing fees. Every payment carries a limit on what the node will spend routing it, and that limit was a flat one thousand sats no matter what the payment was worth. It now scales with the amount, half a percent, never below thirty sats. The limit is a ceiling rather than a charge, so payments do not cost more than before. It stops a large payment from failing to find a route that a flat thousand sats could never cover, and it stops a small payment from authorizing a fee many times its own value. The constants are a first pass and may be tuned.

Payments whose progress stream drops. If the connection carrying payment updates broke, the node reported the payment as failed while lnd was very likely still trying to send it, and an operator who retried could pay twice. The client now reattaches to the payment by its hash and reports what actually happened, or says the payment is still in flight and that history should be checked before retrying.

Coin control. When the operator chooses which coins to spend, an entry that did not parse was skipped or misread, which could quietly widen the selection beyond what was chosen. Any entry that does not parse now stops the operation instead.

Connection handling. The connection now carries keepalive probes so a silently dead link is noticed within a bounded time rather than blocking forever. Separately, the credential metadata attached to every call was read while a reconnect on another goroutine could be rewriting it; it is now read under the same lock the reconnect takes.