### PR TITLE
fix: channel close rejects malformed channel points

### DIFF
--- a/internal/lndrpc/client_test.go
+++ b/internal/lndrpc/client_test.go
@@ -3,9 +3,13 @@
 package lndrpc
 
 import (
+	"fmt"
 	"strings"
+	"sync"
 	"testing"
 	"time"
+
+	"google.golang.org/grpc/metadata"
 )
 
 func TestNodeInfoFields(t *testing.T) {
@@ -86,6 +90,55 @@ func TestNilClientSafety(t *testing.T) {
 	if _, err := c.SendPayment("lnbc1"); err == nil {
 		t.Error("should error")
 	}
+	if _, err := c.CloseChannel(
+		strings.Repeat("ab", 32)+":0", false, 0); err == nil {
+		t.Error("should error")
+	}
+}
+
+// macaroonCtx attaches the credential metadata to every call
+// while Reconnect can rewrite the credential field on another
+// goroutine. This test runs both sides at once so the race
+// detector, not code review, arbitrates the lock discipline:
+// readers hammer macaroonCtx while a writer rewrites the field
+// under the same write lock the redial path holds. Run under
+// go test -race; without the detector it still verifies that
+// every context carries exactly one non-empty macaroon value.
+func TestMacaroonCtxConcurrentRewrite(t *testing.T) {
+	c := &Client{macaroonHex: "00"}
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				md, ok := metadata.FromOutgoingContext(
+					c.macaroonCtx())
+				if !ok {
+					t.Error("context carries no metadata")
+					return
+				}
+				vals := md.Get("macaroon")
+				if len(vals) != 1 || vals[0] == "" {
+					t.Errorf("macaroon metadata: %q", vals)
+					return
+				}
+			}
+		}()
+	}
+	for i := 0; i < 500; i++ {
+		c.mu.Lock()
+		c.macaroonHex = fmt.Sprintf("%04x", i+1)
+		c.mu.Unlock()
+	}
+	close(stop)
+	wg.Wait()
 }
 
 // Both fund-moving coin-control call sites route through

--- a/internal/lndrpc/close.go
+++ b/internal/lndrpc/close.go
@@ -1,9 +1,7 @@
 package lndrpc
 
 import (
-	"encoding/hex"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/lightningnetwork/lnd/lnrpc"
@@ -29,45 +27,24 @@ func (c *Client) CloseChannel(
 		return nil, errNotConnected
 	}
 
-	// Parse "txid:index" into components
-	parts := strings.SplitN(channelPoint, ":", 2)
-	if len(parts) != 2 {
-		return nil, fmt.Errorf(
-			"invalid channel point: %s",
-			channelPoint)
-	}
-	txidHex := parts[0]
-	var outputIndex uint32
-	for _, c := range parts[1] {
-		if c < '0' || c > '9' {
-			return nil, fmt.Errorf(
-				"invalid output index: %s",
-				parts[1])
-		}
-		outputIndex = outputIndex*10 +
-			uint32(c-'0')
-	}
-
-	// Convert txid hex to reversed bytes
-	// (LND expects internal byte order)
-	txidBytes, err := hex.DecodeString(txidHex)
+	// The channel point goes through the same strict parser
+	// as every other fund-moving call site: a close must
+	// target exactly the output the operator chose, so a
+	// value that does not parse aborts the request instead
+	// of being reinterpreted. LND accepts the txid in its
+	// display form here, so no byte order handling is
+	// needed.
+	op, err := parseOutpoint(channelPoint)
 	if err != nil {
-		return nil, fmt.Errorf(
-			"invalid txid hex: %w", err)
-	}
-	if len(txidBytes) == 32 {
-		for i, j := 0, 31; i < j; i, j = i+1, j-1 {
-			txidBytes[i], txidBytes[j] =
-				txidBytes[j], txidBytes[i]
-		}
+		return nil, err
 	}
 
 	req := &lnrpc.CloseChannelRequest{
 		ChannelPoint: &lnrpc.ChannelPoint{
-			FundingTxid: &lnrpc.ChannelPoint_FundingTxidBytes{
-				FundingTxidBytes: txidBytes,
+			FundingTxid: &lnrpc.ChannelPoint_FundingTxidStr{
+				FundingTxidStr: op.TxidStr,
 			},
-			OutputIndex: outputIndex,
+			OutputIndex: op.OutputIndex,
 		},
 		Force: force,
 	}

--- a/internal/lndrpc/queries.go
+++ b/internal/lndrpc/queries.go
@@ -525,10 +525,11 @@ func (c *Client) getPeerAlias(pubkey string) string {
 }
 
 // parseOutpoint parses a txid:index outpoint string strictly.
-// Both fund-moving call sites (channel funding, on-chain send
-// with coin control) route through here: a value that does not
-// parse must abort the operation rather than silently narrow or
-// retarget the operator's coin selection. Pure — unit-tested.
+// Every fund-moving call site that names an outpoint (channel
+// funding, on-chain send with coin control, channel close)
+// routes through here: a value that does not parse must abort
+// the operation rather than silently narrow or retarget what
+// the operator chose. Pure — unit-tested.
 func parseOutpoint(op string) (*lnrpc.OutPoint, error) {
 	parts := strings.SplitN(op, ":", 2)
 	if len(parts) != 2 {


### PR DESCRIPTION
A channel close names its target with a channel point, the funding transaction id plus an output index, written as txid:index. The close request parsed that string with its own hand written digit loop, while the other fund moving calls had already moved to one shared strict parser. The homemade loop had three holes. An output index too large for 32 bits silently wrapped around to a different small number. An empty index was read as index zero. A transaction id of the wrong length passed through unchecked. Any of these could turn a malformed channel point into a close aimed at a different output than the one chosen, instead of an error. The close now goes through the same shared parser as channel funding and coin controlled sends, so a channel point that does not parse stops the request with a clear error. The parser change also lets the request send the transaction id in its ordinary display form, which lnd accepts directly, so a hand maintained byte order conversion is deleted rather than carried.

Separately, every call to lnd carries an authentication credential attached as request metadata. The field holding that credential must be read under a lock, because a reconnect running on another goroutine rewrites it. That rule was previously only enforced by code review. This change adds a regression test that runs both sides at once, several readers building call contexts while a writer rewrites the credential, so the test suite run with the race detector now fails automatically if the lock is ever dropped.