### PR TITLE
fix: verify auto-unlock transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,11 @@ creation flow:
 
 The confirmation phrase is required — there is no skip. Once confirmed,
 the flow transitions into auto-unlock configuration so you don't have
-to manually unlock on every reboot.
+to manually unlock on every reboot. VPN restarts LND once to verify the
+password and reports success only after LND is fully ready and an
+authenticated `GetInfo` succeeds. If verification fails, LND is left
+stably locked instead of entering a restart loop, and the same form lets
+you retry.
 
 A note on cancellation: pressing `ctrl+c` during the password prompt is
 a legitimate escape hatch (no seed has been generated yet, nothing is
@@ -233,7 +237,7 @@ For the full setup guide, see
 - Secure temp file creation with O_EXCL (prevents symlink attacks)
 - Public IP detection uses kernel routing table (no external network calls)
 - Mandatory seed confirmation ("I SAVED MY SEED") during wallet creation
-- Auto-unlock (optional) uses a local password file with 0400 perms, never transmitted
+- Auto-unlock (optional) uses an `lnd:lnd` 0400 local password file, never sends the password over the network, and verifies a new LND invocation before publishing success
 
 ### Privacy — Network Traffic
 

--- a/internal/helper/wire.go
+++ b/internal/helper/wire.go
@@ -144,6 +144,31 @@ type StageWalletPasswordParams struct {
 	Password string `json:"password"`
 }
 
+// AutoUnlockOutcome is the classified end state of an auto-unlock change.
+// Helper transport success means the root side finished observing and
+// classifying the node; the outcome says whether the requested setting was
+// applied, safely rolled back, or needs operator repair. Keeping these states
+// structured prevents the TUI from parsing privileged error text.
+type AutoUnlockOutcome string
+
+const (
+	AutoUnlockEnabled              AutoUnlockOutcome = "enabled"
+	AutoUnlockDisabled             AutoUnlockOutcome = "disabled"
+	AutoUnlockVerificationFailed   AutoUnlockOutcome = "verification_failed"
+	AutoUnlockVerificationTimedOut AutoUnlockOutcome = "verification_timed_out"
+	AutoUnlockStillEnabled         AutoUnlockOutcome = "still_enabled"
+	AutoUnlockRepairRequired       AutoUnlockOutcome = "repair_required"
+)
+
+// AutoUnlockResult carries no credential material. FailedStep is a bounded,
+// operator-facing stage name for logs and the repair-required screen; Detail
+// is used only for a safely classified retry state.
+type AutoUnlockResult struct {
+	Outcome    AutoUnlockOutcome `json:"outcome"`
+	FailedStep string            `json:"failed_step,omitempty"`
+	Detail     string            `json:"detail,omitempty"`
+}
+
 // RebuildSSHConfigParams: rewrite the SSH hardening drop-in.
 // The template lives on the root side; the only caller-chosen
 // value is the password-auth flag.

--- a/internal/helper/wire_test.go
+++ b/internal/helper/wire_test.go
@@ -2,7 +2,32 @@
 
 package helper
 
-import "testing"
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestAutoUnlockResultWireCarriesClassificationButNoCredential(t *testing.T) {
+	result := AutoUnlockResult{
+		Outcome:    AutoUnlockRepairRequired,
+		FailedStep: "restore normal restart policy",
+	}
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "repair_required") ||
+		!strings.Contains(string(data), "restore normal restart policy") {
+		t.Fatalf("classification missing from wire result: %s", data)
+	}
+	for _, forbidden := range []string{"password", "credential", "secret"} {
+		if strings.Contains(strings.ToLower(string(data)), forbidden) {
+			t.Fatalf("wire result contains credential-shaped field %q: %s",
+				forbidden, data)
+		}
+	}
+}
 
 // The same-major gate is shared by the TUI's rendering and the
 // helper's refusal — one function, both sides. These tables pin

--- a/internal/helperd/verbs.go
+++ b/internal/helperd/verbs.go
@@ -43,12 +43,15 @@ type verbDef struct {
 }
 
 var verbs = map[string]verbDef{
-	helper.VerbServiceAction:        {14 * time.Minute, verbServiceAction},
-	helper.VerbReboot:               {1 * time.Minute, verbReboot},
-	helper.VerbDirSize:              {2 * time.Minute, verbDirSize},
-	helper.VerbSetUserPassword:      {1 * time.Minute, verbSetUserPassword},
-	helper.VerbStageWalletPassword:  {6 * time.Minute, verbStageWalletPassword},
-	helper.VerbRemoveWalletPassword: {6 * time.Minute, verbRemoveWalletPassword},
+	helper.VerbServiceAction:   {14 * time.Minute, verbServiceAction},
+	helper.VerbReboot:          {1 * time.Minute, verbReboot},
+	helper.VerbDirSize:         {2 * time.Minute, verbDirSize},
+	helper.VerbSetUserPassword: {1 * time.Minute, verbSetUserPassword},
+	// LND permits a graceful stop to take up to five minutes. A failed
+	// transition can require a second restart plus a second 120-second proof,
+	// so the helper connection must outlive that bounded recovery path.
+	helper.VerbStageWalletPassword:  {20 * time.Minute, verbStageWalletPassword},
+	helper.VerbRemoveWalletPassword: {20 * time.Minute, verbRemoveWalletPassword},
 	helper.VerbStageLNDCredentials:  {3 * time.Minute, verbStageLNDCredentials},
 	helper.VerbStageLNDMacaroon:     {1 * time.Minute, verbStageLNDMacaroon},
 	helper.VerbRebuildSSHConfig:     {3 * time.Minute, verbRebuildSSHConfig},
@@ -260,33 +263,11 @@ func verbStageWalletPassword(_ *verbCtx, params json.RawMessage) (any, error) {
 	if err := validateWalletPassword(p.Password); err != nil {
 		return nil, err
 	}
-	cfg, err := loadConfig()
-	if err != nil {
-		return nil, err
-	}
-	if err := setupAutoUnlock(p.Password); err != nil {
-		return nil, err
-	}
-	cfg.AutoUnlock = true
-	if err := saveSystemConfig(cfg); err != nil {
-		return nil, fmt.Errorf("publish auto-unlock setting: %w", err)
-	}
-	return nil, nil
+	return setupAutoUnlock(p.Password)
 }
 
 func verbRemoveWalletPassword(_ *verbCtx, _ json.RawMessage) (any, error) {
-	cfg, err := loadConfig()
-	if err != nil {
-		return nil, err
-	}
-	if err := disableAutoUnlock(); err != nil {
-		return nil, err
-	}
-	cfg.AutoUnlock = false
-	if err := saveSystemConfig(cfg); err != nil {
-		return nil, fmt.Errorf("publish auto-unlock setting: %w", err)
-	}
-	return nil, nil
+	return disableAutoUnlock()
 }
 
 // ── Credential staging ───────────────────────────────────

--- a/internal/helperd/verbs_test.go
+++ b/internal/helperd/verbs_test.go
@@ -109,34 +109,32 @@ func withConfigVerbTestDeps(t *testing.T) {
 	})
 }
 
-func TestAutoUnlockPersistenceFailuresAreOperationFailures(t *testing.T) {
+func TestAutoUnlockVerbsReturnStructuredTransitionResults(t *testing.T) {
 	withConfigVerbTestDeps(t)
-	wantErr := errors.New("injected config save failure")
-	var saved *config.AppConfig
-	loadSystemConfig = func() (*config.AppConfig, error) { return config.Default(), nil }
-	saveSystemConfig = func(cfg *config.AppConfig) error { saved = cfg; return wantErr }
-	setupAutoUnlock = func(string) error { return nil }
-	disableAutoUnlock = func() error { return nil }
+	wantEnable := installer.AutoUnlockResult{
+		Outcome: installer.AutoUnlockVerificationFailed,
+	}
+	setupAutoUnlock = func(password string) (installer.AutoUnlockResult, error) {
+		if password != "correct horse" {
+			t.Fatalf("password = %q", password)
+		}
+		return wantEnable, nil
+	}
+	wantDisable := installer.AutoUnlockResult{
+		Outcome: installer.AutoUnlockStillEnabled,
+	}
+	disableAutoUnlock = func() (installer.AutoUnlockResult, error) {
+		return wantDisable, nil
+	}
 
-	if _, err := verbStageWalletPassword(&verbCtx{}, raw(t,
-		helper.StageWalletPasswordParams{Password: "correct horse"})); !errors.Is(err, wantErr) {
-		t.Fatalf("enable error = %v, want injected save failure", err)
+	got, err := verbStageWalletPassword(&verbCtx{}, raw(t,
+		helper.StageWalletPasswordParams{Password: "correct horse"}))
+	if err != nil || got != wantEnable {
+		t.Fatalf("enable result = %#v, %v", got, err)
 	}
-	if saved == nil || !saved.AutoUnlock {
-		t.Fatalf("enable did not attempt desired-state publication: %+v", saved)
-	}
-
-	loadSystemConfig = func() (*config.AppConfig, error) {
-		cfg := config.Default()
-		cfg.AutoUnlock = true
-		return cfg, nil
-	}
-	saved = nil
-	if _, err := verbRemoveWalletPassword(&verbCtx{}, nil); !errors.Is(err, wantErr) {
-		t.Fatalf("disable error = %v, want injected save failure", err)
-	}
-	if saved == nil || saved.AutoUnlock {
-		t.Fatalf("disable did not attempt desired-state publication: %+v", saved)
+	got, err = verbRemoveWalletPassword(&verbCtx{}, nil)
+	if err != nil || got != wantDisable {
+		t.Fatalf("disable result = %#v, %v", got, err)
 	}
 }
 

--- a/internal/installer/lnd.go
+++ b/internal/installer/lnd.go
@@ -466,80 +466,6 @@ func startLND() error {
 	return system.SudoRun("systemctl", "restart", "lnd")
 }
 
-func setupAutoUnlock(password string) error {
-	// Write the password to a secure temp file, then move it
-	// into place with the service user's ownership (this runs
-	// as root). os.CreateTemp uses O_EXCL to prevent symlink
-	// attacks.
-	tmpFile, err := os.CreateTemp("", "vpn-wallet-pw-")
-	if err != nil {
-		return fmt.Errorf("create temp: %w", err)
-	}
-	tmpPw := tmpFile.Name()
-	if _, err := tmpFile.Write([]byte(password)); err != nil {
-		tmpFile.Close()
-		os.Remove(tmpPw)
-		return err
-	}
-	tmpFile.Close()
-	defer os.Remove(tmpPw)
-
-	passwordFile := paths.LNDWalletPassword
-	tmpDest := filepath.Join(filepath.Dir(passwordFile), ".wallet_password.tmp")
-	if err := system.SudoRun("install", "-m", "0400",
-		"-o", lndUser, "-g", lndUser, tmpPw, tmpDest); err != nil {
-		system.SudoRunSilent("rm", "-f", tmpDest)
-		logger.System("auto-unlock: install wallet password: %v", err)
-		return fmt.Errorf("install wallet password: %w", err)
-	}
-	if err := system.SudoRun("mv", tmpDest, passwordFile); err != nil {
-		system.SudoRunSilent("rm", "-f", tmpDest)
-		logger.System("auto-unlock: move wallet password: %v", err)
-		return fmt.Errorf("move wallet password: %w", err)
-	}
-
-	if err := writeLNDService(lndUser, true); err != nil {
-		return err
-	}
-	if err := system.SudoRun("systemctl", "daemon-reload"); err != nil {
-		return err
-	}
-	return system.SudoRun("systemctl", "restart", "lnd")
-}
-
-// disableAutoUnlock rewrites the LND systemd service back to
-// its initial (no auto-unlock) form, restarts LND, and only
-// THEN removes the wallet password file. After this returns
-// successfully, LND requires manual unlock (e.g. `lncli
-// unlock`) on next startup.
-//
-// The password file is removed LAST, deliberately. The old
-// order (remove first) meant a failure partway left the
-// security-relevant half already done while the operation
-// reported failure and the app still believed auto-unlock was
-// enabled — the state on disk, the service, and the config all
-// disagreed. With removal last, any failure leaves the file in
-// place and the operation honestly failed; a retry converges.
-func disableAutoUnlock() error {
-	if err := writeLNDService(lndUser, false); err != nil {
-		return fmt.Errorf("rewrite service: %w", err)
-	}
-	if err := system.SudoRun(
-		"systemctl", "daemon-reload"); err != nil {
-		return fmt.Errorf("daemon-reload: %w", err)
-	}
-	if err := system.SudoRun(
-		"systemctl", "restart", "lnd"); err != nil {
-		return fmt.Errorf("restart lnd: %w", err)
-	}
-	// SudoRunSilent because the file may not exist if called
-	// from an inconsistent state — that's fine, we just want
-	// it gone.
-	system.SudoRunSilent(
-		"rm", "-f", paths.LNDWalletPassword)
-	return nil
-}
-
 func waitForLND() error {
 	for i := 0; i < 60; i++ {
 		client := buildLNDClient()
@@ -566,29 +492,38 @@ func WaitForLND() error {
 	return waitForLND()
 }
 
-// SetupAutoUnlock enables wallet auto-unlock. As root
-// (installer, helper) it performs the operation directly; from
-// the unprivileged TUI it requests the helper's typed
-// stage-wallet-password operation — the password travels over
-// the local root-owned socket and is written root-side to a
-// file the admin user can never read.
-func SetupAutoUnlock(password string) error {
+// SetupAutoUnlock enables and synchronously proves wallet auto-unlock. As root
+// it runs the bounded transition directly; from the unprivileged TUI it asks
+// the typed helper operation. The password crosses only the root-owned local
+// socket and is written to a file the admin user cannot read.
+func SetupAutoUnlock(password string) (AutoUnlockResult, error) {
 	if os.Geteuid() == 0 {
-		return setupAutoUnlock(password)
+		ops, err := productionAutoUnlockOps()
+		if err != nil {
+			return repairRequired("initialize auto-unlock operation", err), nil
+		}
+		return enableAutoUnlock(password, ops), nil
 	}
-	return helper.Call(helper.VerbStageWalletPassword,
-		helper.StageWalletPasswordParams{Password: password}, nil)
+	var result AutoUnlockResult
+	err := helper.Call(helper.VerbStageWalletPassword,
+		helper.StageWalletPasswordParams{Password: password}, &result)
+	return result, err
 }
 
-// DisableAutoUnlock disables wallet auto-unlock (service
-// rewritten and restarted first; password file removed last —
-// see disableAutoUnlock). Root performs it directly; the TUI
-// requests the helper's typed operation.
-func DisableAutoUnlock() error {
+// DisableAutoUnlock starts and proves the plain locked LND invocation before
+// durably removing the password. Root performs the transition directly; the
+// TUI requests the helper's typed operation.
+func DisableAutoUnlock() (AutoUnlockResult, error) {
 	if os.Geteuid() == 0 {
-		return disableAutoUnlock()
+		ops, err := productionAutoUnlockOps()
+		if err != nil {
+			return repairRequired("initialize auto-unlock operation", err), nil
+		}
+		return disableAutoUnlockTransition(ops), nil
 	}
-	return helper.Call(helper.VerbRemoveWalletPassword, nil, nil)
+	var result AutoUnlockResult
+	err := helper.Call(helper.VerbRemoveWalletPassword, nil, &result)
+	return result, err
 }
 
 // lndTLSCertBytes returns LND's TLS certificate for client

--- a/internal/installer/lnd_auto_unlock.go
+++ b/internal/installer/lnd_auto_unlock.go
@@ -1,0 +1,1344 @@
+package installer
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/lightningnetwork/lnd/lnrpc"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/metadata"
+
+	"github.com/virtualprivatenode/vpn/internal/config"
+	"github.com/virtualprivatenode/vpn/internal/helper"
+	"github.com/virtualprivatenode/vpn/internal/logger"
+	"github.com/virtualprivatenode/vpn/internal/paths"
+	"github.com/virtualprivatenode/vpn/internal/system"
+)
+
+const (
+	autoUnlockVerificationTimeout = 120 * time.Second
+	autoUnlockPollInterval        = time.Second
+	autoUnlockRPCTimeout          = 5 * time.Second
+)
+
+const lndVerificationDropIn = `[Service]
+Restart=no
+`
+
+type autoUnlockUnit int
+
+const (
+	autoUnlockUnitUnknown autoUnlockUnit = iota
+	autoUnlockUnitPlain
+	autoUnlockUnitEnabled
+)
+
+type autoUnlockArtifacts struct {
+	unit          autoUnlockUnit
+	password      bool
+	passwordStage bool
+	verifyDrop    bool
+}
+
+type lndUnitStatus struct {
+	invocationID     string
+	mainPID          int
+	activeState      string
+	subState         string
+	result           string
+	execMainStatus   string
+	restart          string
+	fragmentPath     string
+	dropInPaths      []string
+	needDaemonReload string
+	execStart        string
+}
+
+type invocationResult int
+
+const (
+	invocationReady invocationResult = iota
+	invocationExited
+	invocationTimedOut
+)
+
+type autoUnlockOps struct {
+	loadConfig       func() (*config.AppConfig, error)
+	saveConfig       func(*config.AppConfig) error
+	artifacts        func() (autoUnlockArtifacts, error)
+	writeUnit        func(autoUnlockUnit) error
+	writePassword    func(string) error
+	removePassword   func() error
+	writeVerifyDrop  func() error
+	removeVerifyDrop func() error
+	validateUnit     func() error
+	daemonReload     func() error
+	restartLND       func() error
+	unitStatus       func() (lndUnitStatus, error)
+	processArgs      func(int) ([]string, error)
+	walletState      func() (lnrpc.WalletState, error)
+	getInfo          func(string) error
+	now              func() time.Time
+	sleep            func(time.Duration)
+}
+
+// AutoUnlockResult is the structured, credential-free result returned through
+// the privileged helper. Expected recovery outcomes are data, not error text.
+type AutoUnlockResult = helper.AutoUnlockResult
+type AutoUnlockOutcome = helper.AutoUnlockOutcome
+
+const (
+	AutoUnlockEnabled              = helper.AutoUnlockEnabled
+	AutoUnlockDisabled             = helper.AutoUnlockDisabled
+	AutoUnlockVerificationFailed   = helper.AutoUnlockVerificationFailed
+	AutoUnlockVerificationTimedOut = helper.AutoUnlockVerificationTimedOut
+	AutoUnlockStillEnabled         = helper.AutoUnlockStillEnabled
+	AutoUnlockRepairRequired       = helper.AutoUnlockRepairRequired
+)
+
+func repairRequired(stage string, cause ...error) AutoUnlockResult {
+	if len(cause) > 0 && cause[0] != nil {
+		logger.System("auto-unlock: %s: %v", stage, cause[0])
+	} else {
+		logger.System("auto-unlock: %s", stage)
+	}
+	return AutoUnlockResult{
+		Outcome:    AutoUnlockRepairRequired,
+		FailedStep: stage,
+	}
+}
+
+func enableAutoUnlock(password string, ops autoUnlockOps) AutoUnlockResult {
+	cfg, err := ops.loadConfig()
+	if err != nil {
+		return repairRequired("read node configuration", err)
+	}
+	if cfg.AutoUnlock {
+		return repairRequired("require disabled starting state")
+	}
+
+	artifacts, err := ops.artifacts()
+	if err != nil || artifacts.unit == autoUnlockUnitUnknown {
+		return repairRequired("inspect disabled starting state", err)
+	}
+
+	// Restart=no is installed before touching either the candidate credential
+	// or ExecStart. If this process or the host stops, the persistent drop-in
+	// prevents an unverified password from becoming a restart loop.
+	if err := ops.writeVerifyDrop(); err != nil {
+		return repairRequired("install one-attempt restart policy", err)
+	}
+	if err := normalizeDisabledDisk(ops); err != nil {
+		return repairRequired("restore disabled starting state", err)
+	}
+	if err := reloadAndVerifyUnit(ops, autoUnlockUnitPlain, "no", true); err != nil {
+		return repairRequired("load disabled starting state", err)
+	}
+
+	before, err := ops.unitStatus()
+	if err != nil {
+		return repairRequired("observe current LND invocation", err)
+	}
+	if before.mainPID == 0 || verifyProcessArgs(ops, before.mainPID, false) != nil {
+		// An interrupted older enable can leave an auto-unlock process alive
+		// while the still-false desired state has just been normalized on disk.
+		// Converge that recognizable shape to a plain locked invocation before
+		// testing the newly supplied password.
+		if err := ops.restartLND(); err != nil {
+			return repairRequired("restore disabled LND invocation", err)
+		}
+		outcome, err := waitForInvocation(
+			ops, before.invocationID, false, lnrpc.WalletState_LOCKED,
+			cfg.Network, autoUnlockVerificationTimeout,
+		)
+		if err != nil || outcome != invocationReady {
+			return repairRequired("prove disabled LND invocation", err)
+		}
+		before, err = ops.unitStatus()
+		if err != nil {
+			return repairRequired("observe restored LND invocation", err)
+		}
+	}
+
+	restarted := false
+	fail := func(
+		outcome AutoUnlockOutcome, stage, detail string, cause error,
+	) AutoUnlockResult {
+		if cause != nil {
+			logger.System("auto-unlock: %s: %v", stage, cause)
+		} else {
+			logger.System("auto-unlock: %s", stage)
+		}
+		if err := restoreDisabled(ops, cfg, before, restarted); err != nil {
+			return repairRequired(stage,
+				fmt.Errorf("recovery failed: %w", err))
+		}
+		return AutoUnlockResult{Outcome: outcome, Detail: detail}
+	}
+
+	if err := ops.writePassword(password); err != nil {
+		return fail(AutoUnlockVerificationFailed,
+			"write candidate wallet password",
+			"VPN could not store the password safely. The previous disabled setting was restored.", err)
+	}
+	if err := ops.writeUnit(autoUnlockUnitEnabled); err != nil {
+		return fail(AutoUnlockVerificationFailed,
+			"install auto-unlock unit",
+			"VPN could not install auto-unlock safely. The previous disabled setting was restored.", err)
+	}
+	if err := ops.validateUnit(); err != nil {
+		return fail(AutoUnlockVerificationFailed,
+			"validate auto-unlock unit",
+			"VPN could not validate the auto-unlock service. The previous disabled setting was restored.", err)
+	}
+	if err := reloadAndVerifyUnit(ops, autoUnlockUnitEnabled, "no", true); err != nil {
+		return fail(AutoUnlockVerificationFailed,
+			"load one-attempt auto-unlock unit",
+			"VPN could not load auto-unlock safely. The previous disabled setting was restored.", err)
+	}
+
+	restarted = true
+	restartErr := ops.restartLND()
+	invocation, verifyErr := waitForInvocation(
+		ops, before.invocationID, true, lnrpc.WalletState_SERVER_ACTIVE,
+		cfg.Network, autoUnlockVerificationTimeout,
+	)
+	if invocation == invocationExited {
+		return fail(AutoUnlockVerificationFailed,
+			"verify candidate wallet password", "", verifyErr)
+	}
+	if invocation == invocationTimedOut {
+		return fail(AutoUnlockVerificationTimedOut,
+			"wait for LND to become ready", "", verifyErr)
+	}
+	if restartErr != nil || verifyErr != nil {
+		cause := verifyErr
+		if restartErr != nil {
+			cause = restartErr
+		}
+		return fail(AutoUnlockVerificationFailed,
+			"verify restarted LND",
+			"VPN could not verify auto-unlock because a system operation failed. LND has been returned to the locked state.", cause)
+	}
+
+	// The password has now been proved. Removing the override and reloading
+	// changes only the policy PID 1 applies to a future failure; the verified
+	// LND invocation stays online and is checked again below.
+	if err := ops.removeVerifyDrop(); err != nil {
+		return fail(AutoUnlockVerificationFailed,
+			"remove one-attempt restart policy",
+			"VPN verified the password but could not finish auto-unlock safely. LND has been returned to the locked state.", err)
+	}
+	if err := reloadAndVerifyUnit(ops, autoUnlockUnitEnabled, "on-failure", false); err != nil {
+		return fail(AutoUnlockVerificationFailed,
+			"restore normal restart policy",
+			"VPN verified the password but could not finish auto-unlock safely. LND has been returned to the locked state.", err)
+	}
+	if err := verifySameReadyInvocation(ops, before.invocationID, cfg.Network); err != nil {
+		return fail(AutoUnlockVerificationFailed,
+			"recheck verified LND invocation",
+			"VPN could not prove that LND stayed ready. LND has been returned to the locked state.", err)
+	}
+
+	cfg.AutoUnlock = true
+	if err := ops.saveConfig(cfg); err != nil {
+		return fail(AutoUnlockVerificationFailed,
+			"publish enabled setting",
+			"VPN verified the password but could not publish auto-unlock safely. LND has been returned to the locked state.", err)
+	}
+	published, err := ops.loadConfig()
+	if err != nil || !published.AutoUnlock {
+		return fail(AutoUnlockVerificationFailed,
+			"confirm enabled setting",
+			"VPN could not confirm the auto-unlock setting. LND has been returned to the locked state.", err)
+	}
+	return AutoUnlockResult{Outcome: AutoUnlockEnabled}
+}
+
+func disableAutoUnlockTransition(ops autoUnlockOps) AutoUnlockResult {
+	cfg, err := ops.loadConfig()
+	if err != nil {
+		return repairRequired("read node configuration", err)
+	}
+	if !cfg.AutoUnlock {
+		return repairRequired("require enabled starting state")
+	}
+	artifacts, err := ops.artifacts()
+	if err != nil || artifacts.unit == autoUnlockUnitUnknown {
+		return repairRequired("inspect enabled starting state", err)
+	}
+	if !artifacts.password {
+		// Password deletion is the irreversible commit point. This exact shape
+		// is an interrupted disable after that point: finish publication rather
+		// than attempting to recreate a credential VPN no longer has.
+		if artifacts.unit != autoUnlockUnitPlain {
+			return repairRequired("classify interrupted disable")
+		}
+		if err := finishDisabledAfterPasswordRemoval(ops, cfg); err != nil {
+			return repairRequired("finish interrupted disable", err)
+		}
+		return AutoUnlockResult{Outcome: AutoUnlockDisabled}
+	}
+
+	if err := ops.writeVerifyDrop(); err != nil {
+		return repairRequired("install one-attempt restart policy", err)
+	}
+	if err := ops.writeUnit(autoUnlockUnitPlain); err != nil {
+		return restoreEnabledResult(ops, cfg, "install plain LND unit", err)
+	}
+	if err := ops.validateUnit(); err != nil {
+		return restoreEnabledResult(ops, cfg, "validate plain LND unit", err)
+	}
+	if err := reloadAndVerifyUnit(ops, autoUnlockUnitPlain, "no", true); err != nil {
+		return restoreEnabledResult(ops, cfg, "load plain LND unit", err)
+	}
+
+	before, err := ops.unitStatus()
+	if err != nil {
+		return restoreEnabledResult(ops, cfg, "observe current LND invocation", err)
+	}
+	restartErr := ops.restartLND()
+	invocation, verifyErr := waitForInvocation(
+		ops, before.invocationID, false, lnrpc.WalletState_LOCKED,
+		cfg.Network, autoUnlockVerificationTimeout,
+	)
+	if restartErr != nil || invocation != invocationReady || verifyErr != nil {
+		cause := verifyErr
+		if restartErr != nil {
+			cause = restartErr
+		}
+		return restoreEnabledResult(ops, cfg, "prove locked LND invocation", cause)
+	}
+
+	if err := ops.removeVerifyDrop(); err != nil {
+		return restoreEnabledResult(ops, cfg, "remove one-attempt restart policy", err)
+	}
+	if err := reloadAndVerifyUnit(ops, autoUnlockUnitPlain, "on-failure", false); err != nil {
+		return restoreEnabledResult(ops, cfg, "restore normal restart policy", err)
+	}
+	if err := verifySameLockedInvocation(ops, before.invocationID); err != nil {
+		return restoreEnabledResult(ops, cfg, "recheck locked LND invocation", err)
+	}
+
+	removeErr := ops.removePassword()
+	afterRemoval, inspectErr := ops.artifacts()
+	if inspectErr != nil {
+		return repairRequired("confirm wallet password removal", inspectErr)
+	}
+	if afterRemoval.password {
+		return restoreEnabledResult(ops, cfg, "remove wallet password", removeErr)
+	}
+	// An observed absence is past the irreversible commit point, but success
+	// still requires durability. Calling remove again when the name is absent
+	// retries the parent-directory sync without recreating credential data.
+	durabilityErr := removeErr
+	if removeErr != nil {
+		durabilityErr = ops.removePassword()
+	}
+	if err := finishDisabledAfterPasswordRemoval(ops, cfg); err != nil {
+		return repairRequired("publish disabled setting", err)
+	}
+	if durabilityErr != nil {
+		return repairRequired("confirm durable wallet password removal", durabilityErr)
+	}
+	return AutoUnlockResult{Outcome: AutoUnlockDisabled}
+}
+
+func normalizeDisabledDisk(ops autoUnlockOps) error {
+	if err := ops.writeUnit(autoUnlockUnitPlain); err != nil {
+		return err
+	}
+	if err := ops.validateUnit(); err != nil {
+		return err
+	}
+	if err := ops.removePassword(); err != nil {
+		return err
+	}
+	artifacts, err := ops.artifacts()
+	if err != nil {
+		return err
+	}
+	if artifacts.unit != autoUnlockUnitPlain || artifacts.password ||
+		artifacts.passwordStage || !artifacts.verifyDrop {
+		return errors.New("disabled disk state did not converge")
+	}
+	return nil
+}
+
+func restoreDisabled(
+	ops autoUnlockOps, cfg *config.AppConfig, before lndUnitStatus,
+	restarted bool,
+) error {
+	var lockedPreviousID string
+	if err := ops.writeVerifyDrop(); err != nil {
+		return err
+	}
+	if err := normalizeDisabledDisk(ops); err != nil {
+		return err
+	}
+	if err := reloadAndVerifyUnit(ops, autoUnlockUnitPlain, "no", true); err != nil {
+		return err
+	}
+	if restarted {
+		current, err := ops.unitStatus()
+		if err != nil {
+			return err
+		}
+		lockedPreviousID = current.invocationID
+		if err := ops.restartLND(); err != nil {
+			return err
+		}
+		outcome, err := waitForInvocation(
+			ops, current.invocationID, false, lnrpc.WalletState_LOCKED,
+			cfg.Network, autoUnlockVerificationTimeout,
+		)
+		if err != nil || outcome != invocationReady {
+			return errors.New("could not restore locked LND invocation")
+		}
+	} else if before.mainPID > 0 {
+		current, err := ops.unitStatus()
+		if err != nil || current.invocationID != before.invocationID {
+			return errors.New("original LND invocation changed")
+		}
+		if err := verifyProcessArgs(ops, current.mainPID, false); err != nil {
+			return err
+		}
+	}
+	if err := ops.removeVerifyDrop(); err != nil {
+		return err
+	}
+	if err := reloadAndVerifyUnit(ops, autoUnlockUnitPlain, "on-failure", false); err != nil {
+		return err
+	}
+	if restarted {
+		if err := verifySameLockedInvocation(ops, lockedPreviousID); err != nil {
+			return err
+		}
+	}
+	cfg.AutoUnlock = false
+	if err := ops.saveConfig(cfg); err != nil {
+		observed, loadErr := ops.loadConfig()
+		if loadErr != nil || observed.AutoUnlock {
+			return err
+		}
+	}
+	final, err := ops.artifacts()
+	if err != nil || final.unit != autoUnlockUnitPlain || final.password ||
+		final.passwordStage || final.verifyDrop {
+		return errors.New("disabled state did not pass final inspection")
+	}
+	return nil
+}
+
+func restoreEnabledResult(
+	ops autoUnlockOps, cfg *config.AppConfig, failedStage string, cause error,
+) AutoUnlockResult {
+	if cause != nil {
+		logger.System("auto-unlock: %s: %v", failedStage, cause)
+	} else {
+		logger.System("auto-unlock: %s", failedStage)
+	}
+	if err := restoreEnabled(ops, cfg); err != nil {
+		return repairRequired(failedStage,
+			fmt.Errorf("recovery failed: %w", err))
+	}
+	return AutoUnlockResult{Outcome: AutoUnlockStillEnabled}
+}
+
+func restoreEnabled(ops autoUnlockOps, cfg *config.AppConfig) error {
+	artifacts, err := ops.artifacts()
+	if err != nil || !artifacts.password {
+		return errors.New("stored wallet password is unavailable")
+	}
+	if err := ops.writeVerifyDrop(); err != nil {
+		return err
+	}
+	if err := ops.writeUnit(autoUnlockUnitEnabled); err != nil {
+		return err
+	}
+	if err := ops.validateUnit(); err != nil {
+		return err
+	}
+	if err := reloadAndVerifyUnit(ops, autoUnlockUnitEnabled, "no", true); err != nil {
+		return err
+	}
+	before, err := ops.unitStatus()
+	if err != nil {
+		return err
+	}
+	if err := ops.restartLND(); err != nil {
+		return err
+	}
+	outcome, err := waitForInvocation(
+		ops, before.invocationID, true, lnrpc.WalletState_SERVER_ACTIVE,
+		cfg.Network, autoUnlockVerificationTimeout,
+	)
+	if err != nil || outcome != invocationReady {
+		return errors.New("previous enabled state did not restart")
+	}
+	if err := ops.removeVerifyDrop(); err != nil {
+		return err
+	}
+	if err := reloadAndVerifyUnit(ops, autoUnlockUnitEnabled, "on-failure", false); err != nil {
+		return err
+	}
+	if err := verifySameReadyInvocation(ops, before.invocationID, cfg.Network); err != nil {
+		return err
+	}
+	cfg.AutoUnlock = true
+	if err := ops.saveConfig(cfg); err != nil {
+		observed, loadErr := ops.loadConfig()
+		if loadErr != nil || !observed.AutoUnlock {
+			return err
+		}
+	}
+	return nil
+}
+
+func finishDisabledAfterPasswordRemoval(
+	ops autoUnlockOps, cfg *config.AppConfig,
+) error {
+	if err := ops.writeVerifyDrop(); err != nil {
+		return err
+	}
+	if err := ops.writeUnit(autoUnlockUnitPlain); err != nil {
+		return err
+	}
+	if err := ops.validateUnit(); err != nil {
+		return err
+	}
+	if err := reloadAndVerifyUnit(ops, autoUnlockUnitPlain, "no", true); err != nil {
+		return err
+	}
+	if err := ensureLockedRuntime(ops, cfg.Network); err != nil {
+		return err
+	}
+	if err := ops.removeVerifyDrop(); err != nil {
+		return err
+	}
+	if err := reloadAndVerifyUnit(ops, autoUnlockUnitPlain, "on-failure", false); err != nil {
+		return err
+	}
+	if err := verifyCurrentLockedInvocation(ops); err != nil {
+		return err
+	}
+	cfg.AutoUnlock = false
+	if err := ops.saveConfig(cfg); err != nil {
+		observed, loadErr := ops.loadConfig()
+		if loadErr != nil || observed.AutoUnlock {
+			return err
+		}
+	}
+	final, err := ops.artifacts()
+	if err != nil {
+		return err
+	}
+	if final.unit != autoUnlockUnitPlain || final.password ||
+		final.passwordStage || final.verifyDrop {
+		return errors.New("disabled state did not pass final inspection")
+	}
+	return nil
+}
+
+func ensureLockedRuntime(ops autoUnlockOps, network string) error {
+	status, err := ops.unitStatus()
+	if err != nil {
+		return err
+	}
+	if status.mainPID > 0 {
+		if err := verifyProcessArgs(ops, status.mainPID, false); err == nil {
+			state, stateErr := ops.walletState()
+			if stateErr == nil && state == lnrpc.WalletState_LOCKED {
+				return nil
+			}
+		}
+	}
+	if err := ops.restartLND(); err != nil {
+		return err
+	}
+	outcome, err := waitForInvocation(
+		ops, status.invocationID, false, lnrpc.WalletState_LOCKED,
+		network, autoUnlockVerificationTimeout,
+	)
+	if err != nil || outcome != invocationReady {
+		return errors.New("could not prove a locked LND invocation")
+	}
+	return nil
+}
+
+func reloadAndVerifyUnit(
+	ops autoUnlockOps, unit autoUnlockUnit, restart string, drop bool,
+) error {
+	if err := ops.daemonReload(); err != nil {
+		return err
+	}
+	status, err := ops.unitStatus()
+	if err != nil {
+		return err
+	}
+	return verifyLoadedUnit(status, unit, restart, drop)
+}
+
+func verifyLoadedUnit(
+	status lndUnitStatus, unit autoUnlockUnit, restart string, drop bool,
+) error {
+	if status.fragmentPath != paths.LNDService {
+		return fmt.Errorf("loaded fragment is %q", status.fragmentPath)
+	}
+	if status.needDaemonReload != "no" {
+		return fmt.Errorf("systemd still requires daemon-reload")
+	}
+	if status.restart != restart {
+		return fmt.Errorf("loaded Restart=%s, want %s", status.restart, restart)
+	}
+	wantDrops := []string(nil)
+	if drop {
+		wantDrops = []string{paths.LNDVerificationDropIn}
+	}
+	if !equalStrings(status.dropInPaths, wantDrops) {
+		return fmt.Errorf("loaded drop-ins are %q", status.dropInPaths)
+	}
+	if !loadedExecMatches(status.execStart, unit == autoUnlockUnitEnabled) {
+		return errors.New("loaded ExecStart is not the exact VPN LND command")
+	}
+	return nil
+}
+
+func waitForInvocation(
+	ops autoUnlockOps, previousID string, withUnlock bool,
+	wantState lnrpc.WalletState, network string, timeout time.Duration,
+) (invocationResult, error) {
+	deadline := ops.now().Add(timeout)
+	var lastErr error
+	for {
+		status, statusErr := ops.unitStatus()
+		if statusErr != nil {
+			lastErr = statusErr
+		}
+		if statusErr == nil && status.invocationID != "" &&
+			status.invocationID != previousID {
+			if status.mainPID == 0 {
+				if status.activeState == "failed" ||
+					status.activeState == "inactive" {
+					return invocationExited, fmt.Errorf(
+						"new LND invocation exited: active=%s sub=%s result=%s status=%s",
+						status.activeState, status.subState,
+						status.result, status.execMainStatus)
+				}
+			} else {
+				if err := verifyProcessArgs(ops, status.mainPID, withUnlock); err != nil {
+					return invocationReady, err
+				}
+				state, err := ops.walletState()
+				if err != nil {
+					lastErr = err
+				}
+				if err == nil && state == wantState {
+					if wantState == lnrpc.WalletState_SERVER_ACTIVE {
+						if err := ops.getInfo(network); err != nil {
+							lastErr = err
+							// SERVER_ACTIVE and authenticated GetInfo are one
+							// postcondition. A transient RPC failure keeps polling.
+						} else {
+							return invocationReady, nil
+						}
+					} else {
+						return invocationReady, nil
+					}
+				}
+			}
+		}
+		if !ops.now().Before(deadline) {
+			return invocationTimedOut, lastErr
+		}
+		ops.sleep(autoUnlockPollInterval)
+	}
+}
+
+func verifySameReadyInvocation(
+	ops autoUnlockOps, previousID, network string,
+) error {
+	status, err := ops.unitStatus()
+	if err != nil {
+		return err
+	}
+	if status.invocationID == "" || status.invocationID == previousID || status.mainPID == 0 {
+		return errors.New("verified LND invocation is not running")
+	}
+	if err := verifyProcessArgs(ops, status.mainPID, true); err != nil {
+		return err
+	}
+	state, err := ops.walletState()
+	if err != nil || state != lnrpc.WalletState_SERVER_ACTIVE {
+		return errors.New("verified LND invocation is not SERVER_ACTIVE")
+	}
+	return ops.getInfo(network)
+}
+
+func verifySameLockedInvocation(ops autoUnlockOps, previousID string) error {
+	status, err := ops.unitStatus()
+	if err != nil {
+		return err
+	}
+	if status.invocationID == "" || status.invocationID == previousID || status.mainPID == 0 {
+		return errors.New("locked LND invocation is not running")
+	}
+	return verifyLockedStatus(ops, status)
+}
+
+func verifyCurrentLockedInvocation(ops autoUnlockOps) error {
+	status, err := ops.unitStatus()
+	if err != nil {
+		return err
+	}
+	if status.invocationID == "" || status.mainPID == 0 {
+		return errors.New("locked LND invocation is not running")
+	}
+	return verifyLockedStatus(ops, status)
+}
+
+func verifyLockedStatus(ops autoUnlockOps, status lndUnitStatus) error {
+	if err := verifyProcessArgs(ops, status.mainPID, false); err != nil {
+		return err
+	}
+	state, err := ops.walletState()
+	if err != nil || state != lnrpc.WalletState_LOCKED {
+		return errors.New("LND did not remain LOCKED")
+	}
+	return nil
+}
+
+func verifyProcessArgs(ops autoUnlockOps, pid int, withUnlock bool) error {
+	args, err := ops.processArgs(pid)
+	if err != nil {
+		return err
+	}
+	want := expectedLNDArgs(withUnlock)
+	if !equalStrings(args, want) {
+		return fmt.Errorf("LND process arguments do not match the loaded unit")
+	}
+	return nil
+}
+
+func expectedLNDArgs(withUnlock bool) []string {
+	args := []string{"/usr/local/bin/lnd", "--configfile=/etc/lnd/lnd.conf"}
+	if withUnlock {
+		args = append(args, "--wallet-unlock-password-file="+paths.LNDWalletPassword)
+	}
+	return args
+}
+
+func loadedExecMatches(raw string, withUnlock bool) bool {
+	const prefix = "argv[]="
+	start := strings.Index(raw, prefix)
+	if start < 0 {
+		return false
+	}
+	argv := raw[start+len(prefix):]
+	if end := strings.Index(argv, " ;"); end >= 0 {
+		argv = argv[:end]
+	} else if end := strings.IndexByte(argv, '}'); end >= 0 {
+		argv = strings.TrimSpace(argv[:end])
+	}
+	return argv == strings.Join(expectedLNDArgs(withUnlock), " ")
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// ── Production operations ────────────────────────────────────────────────
+
+type autoUnlockFS struct {
+	lndUID int
+	lndGID int
+}
+
+func productionAutoUnlockOps() (autoUnlockOps, error) {
+	identity, err := user.Lookup(lndUser)
+	if err != nil {
+		return autoUnlockOps{}, fmt.Errorf("resolve lnd user: %w", err)
+	}
+	uid, err := strconv.Atoi(identity.Uid)
+	if err != nil {
+		return autoUnlockOps{}, fmt.Errorf("parse lnd uid: %w", err)
+	}
+	gid, err := strconv.Atoi(identity.Gid)
+	if err != nil {
+		return autoUnlockOps{}, fmt.Errorf("parse lnd gid: %w", err)
+	}
+	fs := &autoUnlockFS{lndUID: uid, lndGID: gid}
+	return autoUnlockOps{
+		loadConfig:       config.Load,
+		saveConfig:       config.Save,
+		artifacts:        fs.inspectArtifacts,
+		writeUnit:        fs.writeUnit,
+		writePassword:    fs.writePassword,
+		removePassword:   fs.removePassword,
+		writeVerifyDrop:  fs.writeVerifyDrop,
+		removeVerifyDrop: fs.removeVerifyDrop,
+		validateUnit:     validateInstalledLNDUnit,
+		daemonReload: func() error {
+			return system.SudoRun("systemctl", "daemon-reload")
+		},
+		restartLND: func() error {
+			return system.SudoRun("systemctl", "restart", "lnd.service")
+		},
+		unitStatus:  readLNDUnitStatus,
+		processArgs: readProcessArgs,
+		walletState: readLNDWalletState,
+		getInfo:     authenticatedLNDGetInfo,
+		now:         time.Now,
+		sleep:       time.Sleep,
+	}, nil
+}
+
+func (fs *autoUnlockFS) inspectArtifacts() (autoUnlockArtifacts, error) {
+	var out autoUnlockArtifacts
+	unit, exists, err := readExactFile(paths.LNDService, 0o644, 0, 0)
+	if err != nil {
+		return out, fmt.Errorf("inspect LND unit: %w", err)
+	}
+	if !exists {
+		return out, errors.New("LND unit is missing")
+	}
+	switch string(unit) {
+	case lndServiceUnit(lndUser, false):
+		out.unit = autoUnlockUnitPlain
+	case lndServiceUnit(lndUser, true):
+		out.unit = autoUnlockUnitEnabled
+	default:
+		out.unit = autoUnlockUnitUnknown
+	}
+	out.password, err = exactFileExists(
+		paths.LNDWalletPassword, 0o400, fs.lndUID, fs.lndGID)
+	if err != nil {
+		return out, fmt.Errorf("inspect wallet password: %w", err)
+	}
+	out.passwordStage, err = passwordStageExists(fs.lndUID, fs.lndGID)
+	if err != nil {
+		return out, fmt.Errorf("inspect staged wallet password: %w", err)
+	}
+
+	if err := validateOptionalDropInDir(); err != nil {
+		return out, err
+	}
+	drop, exists, err := readExactFile(
+		paths.LNDVerificationDropIn, 0o644, 0, 0)
+	if err != nil {
+		return out, fmt.Errorf("inspect verification drop-in: %w", err)
+	}
+	if exists {
+		if string(drop) != lndVerificationDropIn {
+			return out, errors.New("verification drop-in has unexpected content")
+		}
+		out.verifyDrop = true
+	}
+	return out, nil
+}
+
+func (fs *autoUnlockFS) writeUnit(unit autoUnlockUnit) error {
+	var content string
+	switch unit {
+	case autoUnlockUnitPlain:
+		content = lndServiceUnit(lndUser, false)
+	case autoUnlockUnitEnabled:
+		content = lndServiceUnit(lndUser, true)
+	default:
+		return errors.New("refusing to write unknown LND unit variant")
+	}
+	if err := validateExactDir(filepath.Dir(paths.LNDService), 0o755, 0, 0); err != nil {
+		return err
+	}
+	return replaceExactFile(paths.LNDService, []byte(content), 0o644, 0, 0)
+}
+
+func (fs *autoUnlockFS) writePassword(password string) error {
+	if password == "" || strings.ContainsAny(password, "\r\n") {
+		return errors.New("wallet password has an invalid shape")
+	}
+	if err := validateExactDir(
+		filepath.Dir(paths.LNDWalletPassword), 0o750,
+		fs.lndUID, fs.lndGID,
+	); err != nil {
+		return err
+	}
+	return publishWalletPassword([]byte(password), fs.lndUID, fs.lndGID)
+}
+
+func (fs *autoUnlockFS) removePassword() error {
+	canonicalErr := removeExactFile(
+		paths.LNDWalletPassword, 0o400, fs.lndUID, fs.lndGID)
+	stageErr := removeWalletPasswordStage(fs.lndUID, fs.lndGID)
+	if canonicalErr != nil {
+		return canonicalErr
+	}
+	return stageErr
+}
+
+func publishWalletPassword(data []byte, uid, gid int) error {
+	return publishWalletPasswordAt(
+		paths.LNDWalletPassword, paths.LNDWalletPasswordStage,
+		data, uid, gid,
+	)
+}
+
+func publishWalletPasswordAt(
+	canonical, stage string, data []byte, uid, gid int,
+) error {
+	if exists, err := passwordStageExistsAt(stage, uid, gid); err != nil {
+		return err
+	} else if exists {
+		return errors.New("staged wallet password already exists")
+	}
+	if info, err := os.Lstat(canonical); err == nil {
+		if err := validateFileInfo(
+			canonical, info, false, 0o400, uid, gid,
+		); err != nil {
+			return err
+		}
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+
+	f, err := os.OpenFile(stage, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return fmt.Errorf("create staged wallet password: %w", err)
+	}
+	cleanup := func() {
+		f.Close()
+		if os.Remove(stage) == nil {
+			_ = syncDir(filepath.Dir(stage))
+		}
+	}
+	failed := true
+	defer func() {
+		if failed {
+			cleanup()
+		}
+	}()
+	if _, err := f.Write(data); err != nil {
+		return fmt.Errorf("write staged wallet password: %w", err)
+	}
+	if err := f.Chmod(0o400); err != nil {
+		return fmt.Errorf("protect staged wallet password: %w", err)
+	}
+	if err := f.Chown(uid, gid); err != nil {
+		return fmt.Errorf("own staged wallet password: %w", err)
+	}
+	if err := f.Sync(); err != nil {
+		return fmt.Errorf("sync staged wallet password: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("close staged wallet password: %w", err)
+	}
+	if err := os.Rename(stage, canonical); err != nil {
+		return fmt.Errorf("publish wallet password: %w", err)
+	}
+	if err := syncDir(filepath.Dir(canonical)); err != nil {
+		return err
+	}
+	failed = false
+	return nil
+}
+
+func passwordStageExists(uid, gid int) (bool, error) {
+	return passwordStageExistsAt(paths.LNDWalletPasswordStage, uid, gid)
+}
+
+func passwordStageExistsAt(path string, uid, gid int) (bool, error) {
+	info, err := os.Lstat(path)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return false, errors.New("wallet-password stage is not a regular file")
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return false, errors.New("wallet-password stage ownership is unavailable")
+	}
+	mode := info.Mode().Perm()
+	rootPhase := int(stat.Uid) == 0 && int(stat.Gid) == 0 &&
+		(mode == 0o600 || mode == 0o400)
+	lndPhase := int(stat.Uid) == uid && int(stat.Gid) == gid && mode == 0o400
+	if !rootPhase && !lndPhase {
+		return false, fmt.Errorf(
+			"wallet-password stage metadata is %d:%d %04o",
+			stat.Uid, stat.Gid, mode)
+	}
+	return true, nil
+}
+
+func removeWalletPasswordStage(uid, gid int) error {
+	return removeWalletPasswordStageAt(paths.LNDWalletPasswordStage, uid, gid)
+}
+
+func removeWalletPasswordStageAt(path string, uid, gid int) error {
+	exists, err := passwordStageExistsAt(path, uid, gid)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return syncDir(filepath.Dir(path))
+	}
+	if err := os.Remove(path); err != nil {
+		return err
+	}
+	return syncDir(filepath.Dir(path))
+}
+
+func (fs *autoUnlockFS) writeVerifyDrop() error {
+	parent := filepath.Dir(paths.LNDServiceDropInDir)
+	if err := validateExactDir(parent, 0o755, 0, 0); err != nil {
+		return err
+	}
+	if _, err := os.Lstat(paths.LNDServiceDropInDir); os.IsNotExist(err) {
+		if err := os.Mkdir(paths.LNDServiceDropInDir, 0o755); err != nil {
+			return fmt.Errorf("create LND drop-in directory: %w", err)
+		}
+		if err := os.Chmod(paths.LNDServiceDropInDir, 0o755); err != nil {
+			return fmt.Errorf("set LND drop-in directory mode: %w", err)
+		}
+		if err := os.Chown(paths.LNDServiceDropInDir, 0, 0); err != nil {
+			return fmt.Errorf("own LND drop-in directory: %w", err)
+		}
+	} else if err != nil {
+		return fmt.Errorf("inspect LND drop-in directory: %w", err)
+	}
+	if err := validateExactDir(paths.LNDServiceDropInDir, 0o755, 0, 0); err != nil {
+		return err
+	}
+	if err := syncDir(parent); err != nil {
+		return err
+	}
+	return replaceExactFile(
+		paths.LNDVerificationDropIn, []byte(lndVerificationDropIn),
+		0o644, 0, 0,
+	)
+}
+
+func (fs *autoUnlockFS) removeVerifyDrop() error {
+	if err := validateOptionalDropInDir(); err != nil {
+		return err
+	}
+	if err := removeExactFile(paths.LNDVerificationDropIn, 0o644, 0, 0); err != nil {
+		return err
+	}
+	if _, err := os.Lstat(paths.LNDServiceDropInDir); os.IsNotExist(err) {
+		return nil
+	} else if err != nil {
+		return err
+	}
+	if err := os.Remove(paths.LNDServiceDropInDir); err != nil {
+		return fmt.Errorf("remove LND drop-in directory: %w", err)
+	}
+	return syncDir(filepath.Dir(paths.LNDServiceDropInDir))
+}
+
+func validateOptionalDropInDir() error {
+	info, err := os.Lstat(paths.LNDServiceDropInDir)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("inspect LND drop-in directory: %w", err)
+	}
+	if err := validateFileInfo(paths.LNDServiceDropInDir, info, true, 0o755, 0, 0); err != nil {
+		return err
+	}
+	entries, err := os.ReadDir(paths.LNDServiceDropInDir)
+	if err != nil {
+		return fmt.Errorf("read LND drop-in directory: %w", err)
+	}
+	for _, entry := range entries {
+		if entry.Name() != filepath.Base(paths.LNDVerificationDropIn) {
+			return fmt.Errorf("unexpected LND service drop-in %q", entry.Name())
+		}
+	}
+	return nil
+}
+
+func validateInstalledLNDUnit() error {
+	out, err := system.SudoRunCombinedOutput(
+		"systemd-analyze", "verify", paths.LNDService)
+	if err != nil {
+		return fmt.Errorf("systemd rejected LND unit: %s: %w",
+			strings.TrimSpace(out), err)
+	}
+	return nil
+}
+
+func readLNDUnitStatus() (lndUnitStatus, error) {
+	properties := []string{
+		"InvocationID", "MainPID", "ActiveState", "SubState", "Result",
+		"ExecMainStatus", "Restart", "FragmentPath", "DropInPaths",
+		"NeedDaemonReload", "ExecStart",
+	}
+	args := []string{"show", "lnd.service", "--no-pager"}
+	for _, property := range properties {
+		args = append(args, "--property="+property)
+	}
+	out, err := system.SudoRunOutput("systemctl", args...)
+	if err != nil {
+		return lndUnitStatus{}, err
+	}
+	values := make(map[string]string, len(properties))
+	for _, line := range strings.Split(out, "\n") {
+		key, value, found := strings.Cut(line, "=")
+		if found {
+			values[key] = value
+		}
+	}
+	pid, err := strconv.Atoi(values["MainPID"])
+	if err != nil {
+		return lndUnitStatus{}, fmt.Errorf("parse LND MainPID %q: %w", values["MainPID"], err)
+	}
+	drops := []string(nil)
+	if values["DropInPaths"] != "" {
+		drops = strings.Fields(values["DropInPaths"])
+	}
+	return lndUnitStatus{
+		invocationID: values["InvocationID"], mainPID: pid,
+		activeState: values["ActiveState"], subState: values["SubState"],
+		result: values["Result"], execMainStatus: values["ExecMainStatus"],
+		restart: values["Restart"], fragmentPath: values["FragmentPath"],
+		dropInPaths: drops, needDaemonReload: values["NeedDaemonReload"],
+		execStart: values["ExecStart"],
+	}, nil
+}
+
+func readProcessArgs(pid int) ([]string, error) {
+	if pid <= 0 {
+		return nil, errors.New("LND has no main process")
+	}
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid))
+	if err != nil {
+		return nil, fmt.Errorf("read LND process arguments: %w", err)
+	}
+	parts := strings.Split(string(data), "\x00")
+	if len(parts) > 0 && parts[len(parts)-1] == "" {
+		parts = parts[:len(parts)-1]
+	}
+	return parts, nil
+}
+
+func readLNDWalletState() (lnrpc.WalletState, error) {
+	conn, err := directLNDConn()
+	if err != nil {
+		return lnrpc.WalletState_WAITING_TO_START, err
+	}
+	defer conn.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), autoUnlockRPCTimeout)
+	defer cancel()
+	resp, err := lnrpc.NewStateClient(conn).GetState(ctx, &lnrpc.GetStateRequest{})
+	if err != nil {
+		return lnrpc.WalletState_WAITING_TO_START, err
+	}
+	return resp.GetState(), nil
+}
+
+func authenticatedLNDGetInfo(network string) error {
+	conn, err := directLNDConn()
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	macaroon, err := os.ReadFile(paths.LNDMacaroon(network))
+	if err != nil {
+		return fmt.Errorf("read LND admin macaroon: %w", err)
+	}
+	md := metadata.New(map[string]string{"macaroon": hex.EncodeToString(macaroon)})
+	ctx := metadata.NewOutgoingContext(context.Background(), md)
+	ctx, cancel := context.WithTimeout(ctx, autoUnlockRPCTimeout)
+	defer cancel()
+	_, err = lnrpc.NewLightningClient(conn).GetInfo(ctx, &lnrpc.GetInfoRequest{})
+	return err
+}
+
+func directLNDConn() (*grpc.ClientConn, error) {
+	certData, err := os.ReadFile(paths.LNDTLSCert)
+	if err != nil {
+		return nil, fmt.Errorf("read LND TLS certificate: %w", err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(certData) {
+		return nil, errors.New("parse LND TLS certificate")
+	}
+	return grpc.NewClient(paths.LNDGRPCEndpoint,
+		grpc.WithTransportCredentials(credentials.NewClientTLSFromCert(pool, "")))
+}
+
+func readExactFile(
+	path string, mode os.FileMode, uid, gid int,
+) ([]byte, bool, error) {
+	info, err := os.Lstat(path)
+	if os.IsNotExist(err) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	if err := validateFileInfo(path, info, false, mode, uid, gid); err != nil {
+		return nil, false, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, false, err
+	}
+	return data, true, nil
+}
+
+func exactFileExists(path string, mode os.FileMode, uid, gid int) (bool, error) {
+	info, err := os.Lstat(path)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if err := validateFileInfo(path, info, false, mode, uid, gid); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func validateExactDir(path string, mode os.FileMode, uid, gid int) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return fmt.Errorf("inspect directory %s: %w", path, err)
+	}
+	return validateFileInfo(path, info, true, mode, uid, gid)
+}
+
+func validateFileInfo(
+	path string, info os.FileInfo, wantDir bool,
+	mode os.FileMode, uid, gid int,
+) error {
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("%s is a symlink", path)
+	}
+	if wantDir && !info.IsDir() {
+		return fmt.Errorf("%s is not a directory", path)
+	}
+	if !wantDir && !info.Mode().IsRegular() {
+		return fmt.Errorf("%s is not a regular file", path)
+	}
+	if info.Mode().Perm() != mode {
+		return fmt.Errorf("%s mode is %04o, want %04o", path, info.Mode().Perm(), mode)
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return fmt.Errorf("%s ownership is unavailable", path)
+	}
+	if int(stat.Uid) != uid || int(stat.Gid) != gid {
+		return fmt.Errorf("%s owner is %d:%d, want %d:%d",
+			path, stat.Uid, stat.Gid, uid, gid)
+	}
+	return nil
+}
+
+func replaceExactFile(
+	path string, data []byte, mode os.FileMode, uid, gid int,
+) error {
+	if info, err := os.Lstat(path); err == nil {
+		if err := validateFileInfo(path, info, false, mode, uid, gid); err != nil {
+			return err
+		}
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(path)+"-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temporary %s: %w", path, err)
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	fail := func(stage string, stageErr error) error {
+		tmp.Close()
+		return fmt.Errorf("%s %s: %w", stage, path, stageErr)
+	}
+	if _, err := tmp.Write(data); err != nil {
+		return fail("write", err)
+	}
+	if err := tmp.Chmod(mode); err != nil {
+		return fail("chmod", err)
+	}
+	if err := tmp.Chown(uid, gid); err != nil {
+		return fail("chown", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		return fail("sync", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temporary %s: %w", path, err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("publish %s: %w", path, err)
+	}
+	return syncDir(dir)
+}
+
+func removeExactFile(path string, mode os.FileMode, uid, gid int) error {
+	info, err := os.Lstat(path)
+	if os.IsNotExist(err) {
+		// Absence is only a durable fact after the containing directory has
+		// been synchronized. This also lets a caller retry a sync that failed
+		// after an earlier successful unlink without recreating the file.
+		return syncDir(filepath.Dir(path))
+	}
+	if err != nil {
+		return err
+	}
+	if err := validateFileInfo(path, info, false, mode, uid, gid); err != nil {
+		return err
+	}
+	if err := os.Remove(path); err != nil {
+		return err
+	}
+	if err := syncDir(filepath.Dir(path)); err != nil {
+		return err
+	}
+	if _, err := os.Lstat(path); !os.IsNotExist(err) {
+		if err == nil {
+			return fmt.Errorf("%s still exists after removal", path)
+		}
+		return err
+	}
+	return nil
+}
+
+func syncDir(path string) error {
+	dir, err := os.Open(filepath.Clean(path))
+	if err != nil {
+		return fmt.Errorf("open directory %s for sync: %w", path, err)
+	}
+	defer dir.Close()
+	if err := dir.Sync(); err != nil {
+		return fmt.Errorf("sync directory %s: %w", path, err)
+	}
+	return nil
+}

--- a/internal/installer/lnd_auto_unlock_root_test.go
+++ b/internal/installer/lnd_auto_unlock_root_test.go
@@ -1,0 +1,129 @@
+package installer
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+func TestRootAutoUnlockProtectedFileReplacementAndRemoval(t *testing.T) {
+	requireRootTestEnvironment(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "wallet_password")
+	// The repository's sandboxed root runner can map only UID/GID 0. The
+	// disposable Debian gate exercises the same primitive with the real lnd
+	// identity and proves lnd:lnd ownership on the canonical path.
+	const uid, gid = 0, 0
+	if err := replaceExactFile(path, []byte("secret"), 0o400, uid, gid); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stat := info.Sys().(*syscall.Stat_t)
+	if info.Mode().Perm() != 0o400 || stat.Uid != uid || stat.Gid != gid {
+		t.Fatalf("metadata mode=%04o owner=%d:%d",
+			info.Mode().Perm(), stat.Uid, stat.Gid)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil || string(data) != "secret" {
+		t.Fatalf("content=%q err=%v", data, err)
+	}
+	if err := removeExactFile(path, 0o400, uid, gid); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Lstat(path); !os.IsNotExist(err) {
+		t.Fatalf("protected file still exists: %v", err)
+	}
+}
+
+func TestRootAutoUnlockPasswordPublicationLeavesNoStage(t *testing.T) {
+	requireRootTestEnvironment(t)
+	dir := t.TempDir()
+	canonical := filepath.Join(dir, "wallet_password")
+	stage := filepath.Join(dir, ".vpn-wallet-password.stage")
+	if err := publishWalletPasswordAt(
+		canonical, stage, []byte("first secret"), 0, 0,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Lstat(stage); !os.IsNotExist(err) {
+		t.Fatalf("stage remains after publication: %v", err)
+	}
+	if err := publishWalletPasswordAt(
+		canonical, stage, []byte("replacement"), 0, 0,
+	); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(canonical)
+	if err != nil || string(data) != "replacement" {
+		t.Fatalf("canonical content=%q err=%v", data, err)
+	}
+	info, err := os.Lstat(canonical)
+	if err != nil || info.Mode().Perm() != 0o400 {
+		t.Fatalf("canonical metadata=%v err=%v", info, err)
+	}
+}
+
+func TestRootAutoUnlockStageClassificationAndCleanup(t *testing.T) {
+	requireRootTestEnvironment(t)
+	dir := t.TempDir()
+	stage := filepath.Join(dir, ".vpn-wallet-password.stage")
+	if err := os.WriteFile(stage, []byte("interrupted"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	exists, err := passwordStageExistsAt(stage, 0, 0)
+	if err != nil || !exists {
+		t.Fatalf("root write phase not recognized: exists=%v err=%v", exists, err)
+	}
+	if err := removeWalletPasswordStageAt(stage, 0, 0); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Lstat(stage); !os.IsNotExist(err) {
+		t.Fatalf("interrupted stage remains: %v", err)
+	}
+	if err := os.Symlink("target", stage); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := passwordStageExistsAt(stage, 0, 0); err == nil {
+		t.Fatal("symlink stage was accepted")
+	}
+}
+
+func TestRootAutoUnlockRefusesSymlinkDirectoryBoundary(t *testing.T) {
+	requireRootTestEnvironment(t)
+	root := t.TempDir()
+	realDir := filepath.Join(root, "real")
+	if err := os.Mkdir(realDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	linkDir := filepath.Join(root, "link")
+	if err := os.Symlink(realDir, linkDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateExactDir(linkDir, 0o755, 0, 0); err == nil {
+		t.Fatal("symlink directory boundary was accepted")
+	}
+}
+
+func TestRootAutoUnlockProtectedFileRefusesUnsafeDestination(t *testing.T) {
+	requireRootTestEnvironment(t)
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target")
+	if err := os.WriteFile(target, []byte("do not replace"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "wallet_password")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	if err := replaceExactFile(link, []byte("secret"), 0o400, 0, 0); err == nil {
+		t.Fatal("symlink destination was accepted")
+	}
+	data, err := os.ReadFile(target)
+	if err != nil || string(data) != "do not replace" {
+		t.Fatalf("symlink target changed: %q, %v", data, err)
+	}
+}

--- a/internal/installer/lnd_auto_unlock_test.go
+++ b/internal/installer/lnd_auto_unlock_test.go
@@ -1,0 +1,552 @@
+package installer
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lightningnetwork/lnd/lnrpc"
+
+	"github.com/virtualprivatenode/vpn/internal/config"
+	"github.com/virtualprivatenode/vpn/internal/paths"
+)
+
+type autoUnlockFixture struct {
+	cfg        config.AppConfig
+	art        autoUnlockArtifacts
+	loaded     autoUnlockUnit
+	restart    string
+	loadedDrop bool
+
+	invocation string
+	pid        int
+	args       []string
+	wallet     lnrpc.WalletState
+	password   string
+
+	now          time.Time
+	restartCount int
+	getInfoCount int
+	holdEnabled  bool
+
+	calls  map[string]int
+	failOn map[string]int
+	after  map[string]bool
+	always map[string]bool
+}
+
+func newAutoUnlockFixture(enabled bool) *autoUnlockFixture {
+	f := &autoUnlockFixture{
+		now:        time.Unix(1_700_000_000, 0),
+		pid:        100,
+		invocation: "invocation-1",
+		calls:      map[string]int{},
+		failOn:     map[string]int{},
+		after:      map[string]bool{},
+		always:     map[string]bool{},
+	}
+	f.cfg = *config.Default()
+	if enabled {
+		f.cfg.AutoUnlock = true
+		f.art = autoUnlockArtifacts{unit: autoUnlockUnitEnabled, password: true}
+		f.loaded = autoUnlockUnitEnabled
+		f.args = expectedLNDArgs(true)
+		f.wallet = lnrpc.WalletState_SERVER_ACTIVE
+		f.password = "correct"
+	} else {
+		f.art = autoUnlockArtifacts{unit: autoUnlockUnitPlain}
+		f.loaded = autoUnlockUnitPlain
+		f.args = expectedLNDArgs(false)
+		f.wallet = lnrpc.WalletState_SERVER_ACTIVE
+	}
+	f.restart = "on-failure"
+	return f
+}
+
+func (f *autoUnlockFixture) fail(name string) error {
+	f.calls[name]++
+	if f.always[name] {
+		return fmt.Errorf("injected persistent %s failure", name)
+	}
+	if f.failOn[name] == f.calls[name] {
+		return fmt.Errorf("injected %s failure", name)
+	}
+	return nil
+}
+
+func (f *autoUnlockFixture) ops() autoUnlockOps {
+	return autoUnlockOps{
+		loadConfig: func() (*config.AppConfig, error) {
+			if err := f.fail("load-config"); err != nil {
+				return nil, err
+			}
+			cfg := f.cfg
+			return &cfg, nil
+		},
+		saveConfig: func(cfg *config.AppConfig) error {
+			name := "save-disabled"
+			if cfg.AutoUnlock {
+				name = "save-enabled"
+			}
+			if f.after[name] {
+				f.cfg = *cfg
+				return fmt.Errorf("injected %s post-publication failure", name)
+			}
+			if err := f.fail(name); err != nil {
+				return err
+			}
+			f.cfg = *cfg
+			return nil
+		},
+		artifacts: func() (autoUnlockArtifacts, error) {
+			if err := f.fail("inspect"); err != nil {
+				return autoUnlockArtifacts{}, err
+			}
+			return f.art, nil
+		},
+		writeUnit: func(unit autoUnlockUnit) error {
+			name := "write-unit-plain"
+			if unit == autoUnlockUnitEnabled {
+				name = "write-unit-enabled"
+			}
+			if err := f.fail(name); err != nil {
+				return err
+			}
+			f.art.unit = unit
+			return nil
+		},
+		writePassword: func(password string) error {
+			if err := f.fail("write-password"); err != nil {
+				return err
+			}
+			f.password = password
+			f.art.password = true
+			f.art.passwordStage = false
+			return nil
+		},
+		removePassword: func() error {
+			if f.after["remove-password"] {
+				f.after["remove-password"] = false
+				f.art.password = false
+				f.art.passwordStage = false
+				f.password = ""
+				return errors.New("injected remove-password post-unlink failure")
+			}
+			if err := f.fail("remove-password"); err != nil {
+				return err
+			}
+			f.art.password = false
+			f.art.passwordStage = false
+			f.password = ""
+			return nil
+		},
+		writeVerifyDrop: func() error {
+			if err := f.fail("write-drop"); err != nil {
+				return err
+			}
+			f.art.verifyDrop = true
+			return nil
+		},
+		removeVerifyDrop: func() error {
+			if err := f.fail("remove-drop"); err != nil {
+				return err
+			}
+			f.art.verifyDrop = false
+			return nil
+		},
+		validateUnit: func() error { return f.fail("validate") },
+		daemonReload: func() error {
+			if err := f.fail("daemon-reload"); err != nil {
+				return err
+			}
+			f.loaded = f.art.unit
+			f.loadedDrop = f.art.verifyDrop
+			if f.loadedDrop {
+				f.restart = "no"
+			} else {
+				f.restart = "on-failure"
+			}
+			return nil
+		},
+		restartLND: func() error {
+			f.restartCount++
+			f.invocation = fmt.Sprintf("invocation-%d", f.restartCount+1)
+			if err := f.fail("restart-lnd"); err != nil {
+				return err
+			}
+			if f.loaded == autoUnlockUnitEnabled && f.password != "correct" {
+				f.pid = 0
+				f.args = nil
+				f.wallet = lnrpc.WalletState_WAITING_TO_START
+				return nil
+			}
+			f.pid = 100 + f.restartCount
+			f.args = expectedLNDArgs(f.loaded == autoUnlockUnitEnabled)
+			if f.loaded == autoUnlockUnitEnabled {
+				if f.holdEnabled {
+					f.wallet = lnrpc.WalletState_UNLOCKED
+				} else {
+					f.wallet = lnrpc.WalletState_SERVER_ACTIVE
+				}
+			} else {
+				f.wallet = lnrpc.WalletState_LOCKED
+			}
+			return nil
+		},
+		unitStatus: func() (lndUnitStatus, error) {
+			if err := f.fail("unit-status"); err != nil {
+				return lndUnitStatus{}, err
+			}
+			active := "active"
+			sub := "running"
+			if f.pid == 0 {
+				active = "failed"
+				sub = "failed"
+			}
+			drops := []string(nil)
+			if f.loadedDrop {
+				drops = []string{paths.LNDVerificationDropIn}
+			}
+			return lndUnitStatus{
+				invocationID:     f.invocation,
+				mainPID:          f.pid,
+				activeState:      active,
+				subState:         sub,
+				restart:          f.restart,
+				fragmentPath:     paths.LNDService,
+				dropInPaths:      drops,
+				needDaemonReload: "no",
+				execStart: "{ path=/usr/local/bin/lnd ; argv[]=" +
+					strings.Join(expectedLNDArgs(f.loaded == autoUnlockUnitEnabled), " ") +
+					" ; ignore_errors=no ; }",
+			}, nil
+		},
+		processArgs: func(pid int) ([]string, error) {
+			if err := f.fail("process-args"); err != nil {
+				return nil, err
+			}
+			if pid != f.pid || pid == 0 {
+				return nil, errors.New("process does not exist")
+			}
+			return append([]string(nil), f.args...), nil
+		},
+		walletState: func() (lnrpc.WalletState, error) {
+			if err := f.fail("wallet-state"); err != nil {
+				return lnrpc.WalletState_WAITING_TO_START, err
+			}
+			return f.wallet, nil
+		},
+		getInfo: func(string) error {
+			f.getInfoCount++
+			if err := f.fail("get-info"); err != nil {
+				return err
+			}
+			if f.wallet != lnrpc.WalletState_SERVER_ACTIVE {
+				return errors.New("LND is not ready")
+			}
+			return nil
+		},
+		now: func() time.Time { return f.now },
+		sleep: func(d time.Duration) {
+			f.now = f.now.Add(d)
+		},
+	}
+}
+
+func assertDisabled(t *testing.T, f *autoUnlockFixture) {
+	t.Helper()
+	if f.cfg.AutoUnlock || f.art.unit != autoUnlockUnitPlain ||
+		f.art.password || f.art.passwordStage || f.art.verifyDrop ||
+		f.restart != "on-failure" ||
+		f.wallet != lnrpc.WalletState_LOCKED {
+		t.Fatalf("not safely disabled: cfg=%+v art=%+v restart=%s wallet=%s",
+			f.cfg, f.art, f.restart, f.wallet)
+	}
+}
+
+func assertDisabledDisk(t *testing.T, f *autoUnlockFixture) {
+	t.Helper()
+	if f.cfg.AutoUnlock || f.art.unit != autoUnlockUnitPlain ||
+		f.art.password || f.art.passwordStage || f.art.verifyDrop ||
+		f.restart != "on-failure" {
+		t.Fatalf("disabled disk state did not converge: cfg=%+v art=%+v restart=%s",
+			f.cfg, f.art, f.restart)
+	}
+}
+
+func assertEnabled(t *testing.T, f *autoUnlockFixture) {
+	t.Helper()
+	if !f.cfg.AutoUnlock || f.art.unit != autoUnlockUnitEnabled ||
+		!f.art.password || f.art.verifyDrop || f.restart != "on-failure" ||
+		f.wallet != lnrpc.WalletState_SERVER_ACTIVE {
+		t.Fatalf("not safely enabled: cfg=%+v art=%+v restart=%s wallet=%s",
+			f.cfg, f.art, f.restart, f.wallet)
+	}
+}
+
+func TestEnableAutoUnlockProvesAndPublishes(t *testing.T) {
+	f := newAutoUnlockFixture(false)
+	result := enableAutoUnlock("correct", f.ops())
+	if result.Outcome != AutoUnlockEnabled {
+		t.Fatalf("outcome = %+v", result)
+	}
+	assertEnabled(t, f)
+	if f.restartCount != 1 || f.getInfoCount < 2 {
+		t.Fatalf("restart=%d GetInfo=%d", f.restartCount, f.getInfoCount)
+	}
+}
+
+func TestEnableWrongPasswordReturnsToLockedRetryState(t *testing.T) {
+	f := newAutoUnlockFixture(false)
+	result := enableAutoUnlock("wrong", f.ops())
+	if result.Outcome != AutoUnlockVerificationFailed || result.Detail != "" {
+		t.Fatalf("outcome = %+v", result)
+	}
+	assertDisabled(t, f)
+	if f.restartCount != 2 {
+		t.Fatalf("restarts = %d, want candidate plus locked rollback", f.restartCount)
+	}
+}
+
+func TestEnableTimeoutIsInconclusiveAndLocked(t *testing.T) {
+	f := newAutoUnlockFixture(false)
+	f.holdEnabled = true
+	result := enableAutoUnlock("correct", f.ops())
+	if result.Outcome != AutoUnlockVerificationTimedOut {
+		t.Fatalf("outcome = %+v", result)
+	}
+	assertDisabled(t, f)
+	if elapsed := f.now.Sub(time.Unix(1_700_000_000, 0)); elapsed < 120*time.Second {
+		t.Fatalf("timeout elapsed only %s", elapsed)
+	}
+}
+
+func TestEnablePublicationFailureRollsBackDisabled(t *testing.T) {
+	f := newAutoUnlockFixture(false)
+	f.failOn["save-enabled"] = 1
+	result := enableAutoUnlock("correct", f.ops())
+	if result.Outcome != AutoUnlockVerificationFailed || result.Detail == "" {
+		t.Fatalf("outcome = %+v", result)
+	}
+	assertDisabled(t, f)
+}
+
+func TestEnableRecoversRecognizableInterruptedAttemptWithoutMarker(t *testing.T) {
+	f := newAutoUnlockFixture(false)
+	f.art = autoUnlockArtifacts{
+		unit:          autoUnlockUnitEnabled,
+		password:      true,
+		passwordStage: true,
+		verifyDrop:    true,
+	}
+	f.loaded = autoUnlockUnitEnabled
+	f.loadedDrop = true
+	f.restart = "no"
+	f.args = expectedLNDArgs(true)
+	f.password = "correct"
+	result := enableAutoUnlock("correct", f.ops())
+	if result.Outcome != AutoUnlockEnabled {
+		t.Fatalf("outcome = %+v", result)
+	}
+	assertEnabled(t, f)
+	if f.restartCount != 2 {
+		t.Fatalf("restarts = %d, want recovery plus candidate", f.restartCount)
+	}
+}
+
+func TestEnableRollbackFailureRequiresRepair(t *testing.T) {
+	f := newAutoUnlockFixture(false)
+	f.failOn["write-unit-plain"] = 2
+	result := enableAutoUnlock("wrong", f.ops())
+	if result.Outcome != AutoUnlockRepairRequired || result.FailedStep == "" {
+		t.Fatalf("outcome = %+v", result)
+	}
+}
+
+func TestEnableFailureInjectionConvergesToDisabledState(t *testing.T) {
+	tests := []struct {
+		name        string
+		inject      func(*autoUnlockFixture)
+		wantOutcome AutoUnlockOutcome
+	}{
+		{"write password", func(f *autoUnlockFixture) { f.failOn["write-password"] = 1 }, AutoUnlockVerificationFailed},
+		{"write unit", func(f *autoUnlockFixture) { f.failOn["write-unit-enabled"] = 1 }, AutoUnlockVerificationFailed},
+		{"validate candidate", func(f *autoUnlockFixture) { f.failOn["validate"] = 2 }, AutoUnlockVerificationFailed},
+		{"reload candidate", func(f *autoUnlockFixture) { f.failOn["daemon-reload"] = 2 }, AutoUnlockVerificationFailed},
+		{"restart candidate", func(f *autoUnlockFixture) { f.failOn["restart-lnd"] = 1 }, AutoUnlockVerificationFailed},
+		{"read candidate process", func(f *autoUnlockFixture) { f.failOn["process-args"] = 2 }, AutoUnlockVerificationFailed},
+		{"authenticated GetInfo unavailable", func(f *autoUnlockFixture) { f.always["get-info"] = true }, AutoUnlockVerificationTimedOut},
+		{"remove verification drop-in", func(f *autoUnlockFixture) { f.failOn["remove-drop"] = 1 }, AutoUnlockVerificationFailed},
+		{"reload final policy", func(f *autoUnlockFixture) { f.failOn["daemon-reload"] = 3 }, AutoUnlockVerificationFailed},
+		{"recheck process", func(f *autoUnlockFixture) { f.failOn["process-args"] = 3 }, AutoUnlockVerificationFailed},
+		{"recheck state", func(f *autoUnlockFixture) { f.failOn["wallet-state"] = 2 }, AutoUnlockVerificationFailed},
+		{"recheck GetInfo", func(f *autoUnlockFixture) { f.failOn["get-info"] = 2 }, AutoUnlockVerificationFailed},
+		{"publish enabled config", func(f *autoUnlockFixture) { f.failOn["save-enabled"] = 1 }, AutoUnlockVerificationFailed},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			f := newAutoUnlockFixture(false)
+			test.inject(f)
+			result := enableAutoUnlock("correct", f.ops())
+			if result.Outcome != test.wantOutcome {
+				t.Fatalf("outcome = %+v, want %s", result, test.wantOutcome)
+			}
+			assertDisabledDisk(t, f)
+		})
+	}
+}
+
+func TestDisableAutoUnlockDeletesPasswordAndPublishes(t *testing.T) {
+	f := newAutoUnlockFixture(true)
+	result := disableAutoUnlockTransition(f.ops())
+	if result.Outcome != AutoUnlockDisabled {
+		t.Fatalf("outcome = %+v", result)
+	}
+	assertDisabled(t, f)
+	if f.restartCount != 1 {
+		t.Fatalf("restarts = %d, want one", f.restartCount)
+	}
+}
+
+func TestDisableFailureBeforeDeletionRestoresEnabledState(t *testing.T) {
+	f := newAutoUnlockFixture(true)
+	f.failOn["validate"] = 1
+	result := disableAutoUnlockTransition(f.ops())
+	if result.Outcome != AutoUnlockStillEnabled {
+		t.Fatalf("outcome = %+v", result)
+	}
+	assertEnabled(t, f)
+}
+
+func TestDisableRemovalFailureWithPasswordPresentRestoresEnabled(t *testing.T) {
+	f := newAutoUnlockFixture(true)
+	f.failOn["remove-password"] = 1
+	result := disableAutoUnlockTransition(f.ops())
+	if result.Outcome != AutoUnlockStillEnabled {
+		t.Fatalf("outcome = %+v", result)
+	}
+	assertEnabled(t, f)
+}
+
+func TestDisableRemovalErrorAfterUnlinkFinishesDisabled(t *testing.T) {
+	f := newAutoUnlockFixture(true)
+	f.after["remove-password"] = true
+	result := disableAutoUnlockTransition(f.ops())
+	if result.Outcome != AutoUnlockDisabled {
+		t.Fatalf("outcome = %+v", result)
+	}
+	assertDisabled(t, f)
+}
+
+func TestDisableRollbackFailureRequiresRepair(t *testing.T) {
+	f := newAutoUnlockFixture(true)
+	f.password = "wrong"
+	f.failOn["validate"] = 1
+	result := disableAutoUnlockTransition(f.ops())
+	if result.Outcome != AutoUnlockRepairRequired {
+		t.Fatalf("outcome = %+v", result)
+	}
+}
+
+func TestDisableResumesAfterPasswordCommitPoint(t *testing.T) {
+	f := newAutoUnlockFixture(true)
+	f.art = autoUnlockArtifacts{unit: autoUnlockUnitPlain}
+	f.loaded = autoUnlockUnitPlain
+	f.args = expectedLNDArgs(false)
+	f.wallet = lnrpc.WalletState_LOCKED
+	result := disableAutoUnlockTransition(f.ops())
+	if result.Outcome != AutoUnlockDisabled {
+		t.Fatalf("outcome = %+v", result)
+	}
+	assertDisabled(t, f)
+}
+
+func TestDisablePublicationFailureAfterDeletionRequiresRepair(t *testing.T) {
+	f := newAutoUnlockFixture(true)
+	f.failOn["save-disabled"] = 1
+	result := disableAutoUnlockTransition(f.ops())
+	if result.Outcome != AutoUnlockRepairRequired {
+		t.Fatalf("outcome = %+v", result)
+	}
+	if f.art.password {
+		t.Fatal("password was recreated after the irreversible deletion point")
+	}
+}
+
+func TestDisableFailureInjectionBeforeDeletionRestoresEnabled(t *testing.T) {
+	tests := []struct {
+		name   string
+		inject func(*autoUnlockFixture)
+	}{
+		{"write plain unit", func(f *autoUnlockFixture) { f.failOn["write-unit-plain"] = 1 }},
+		{"validate plain unit", func(f *autoUnlockFixture) { f.failOn["validate"] = 1 }},
+		{"reload plain unit", func(f *autoUnlockFixture) { f.failOn["daemon-reload"] = 1 }},
+		{"inspect loaded plain unit", func(f *autoUnlockFixture) { f.failOn["unit-status"] = 1 }},
+		{"restart plain LND", func(f *autoUnlockFixture) { f.failOn["restart-lnd"] = 1 }},
+		{"inspect plain process", func(f *autoUnlockFixture) { f.failOn["process-args"] = 1 }},
+		{"remove verification drop-in", func(f *autoUnlockFixture) { f.failOn["remove-drop"] = 1 }},
+		{"reload final policy", func(f *autoUnlockFixture) { f.failOn["daemon-reload"] = 2 }},
+		{"recheck locked process", func(f *autoUnlockFixture) { f.failOn["process-args"] = 2 }},
+		{"recheck locked state", func(f *autoUnlockFixture) { f.failOn["wallet-state"] = 2 }},
+		{"remove password before unlink", func(f *autoUnlockFixture) { f.failOn["remove-password"] = 1 }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			f := newAutoUnlockFixture(true)
+			test.inject(f)
+			result := disableAutoUnlockTransition(f.ops())
+			if result.Outcome != AutoUnlockStillEnabled {
+				t.Fatalf("outcome = %+v", result)
+			}
+			assertEnabled(t, f)
+		})
+	}
+}
+
+func TestDisableFailureInjectionAfterDeletionNeverRecreatesPassword(t *testing.T) {
+	tests := []struct {
+		name   string
+		inject func(*autoUnlockFixture)
+	}{
+		{"synchronize committed deletion", func(f *autoUnlockFixture) {
+			f.after["remove-password"] = true
+			f.failOn["remove-password"] = 1
+		}},
+		{"inspect committed deletion", func(f *autoUnlockFixture) { f.failOn["inspect"] = 2 }},
+		{"validate final plain unit", func(f *autoUnlockFixture) { f.failOn["validate"] = 2 }},
+		{"reload final plain unit", func(f *autoUnlockFixture) { f.failOn["daemon-reload"] = 3 }},
+		{"publish disabled config", func(f *autoUnlockFixture) { f.failOn["save-disabled"] = 1 }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			f := newAutoUnlockFixture(true)
+			test.inject(f)
+			result := disableAutoUnlockTransition(f.ops())
+			if result.Outcome != AutoUnlockRepairRequired {
+				t.Fatalf("outcome = %+v", result)
+			}
+			if f.art.password {
+				t.Fatal("password was recreated after the deletion commit point")
+			}
+		})
+	}
+}
+
+func TestLoadedExecMatchesOnlyExactCommand(t *testing.T) {
+	good := "{ path=/usr/local/bin/lnd ; argv[]=" +
+		strings.Join(expectedLNDArgs(true), " ") + " ; ignore_errors=no ; }"
+	if !loadedExecMatches(good, true) {
+		t.Fatal("exact auto-unlock command was rejected")
+	}
+	for _, bad := range []string{
+		strings.Replace(good, paths.LNDWalletPassword, "/tmp/password", 1),
+		strings.Replace(good, " ; ignore_errors", " --extra ; ignore_errors", 1),
+		strings.Replace(good, "argv[]=", "command[]=", 1),
+	} {
+		if loadedExecMatches(bad, true) {
+			t.Fatalf("non-exact command accepted: %s", bad)
+		}
+	}
+}

--- a/internal/lndrpc/client.go
+++ b/internal/lndrpc/client.go
@@ -41,6 +41,7 @@ import (
 type Client struct {
 	conn        *grpc.ClientConn
 	lightning   lnrpc.LightningClient
+	state       lnrpc.StateClient
 	macaroonHex string
 	network     string
 	mu          sync.RWMutex
@@ -135,6 +136,7 @@ func (c *Client) dial(allowHeal bool) error {
 
 	c.conn = conn
 	c.lightning = lnrpc.NewLightningClient(conn)
+	c.state = lnrpc.NewStateClient(conn)
 
 	// Test the connection with a longer timeout.
 	// During IBD, LND's GetInfo queries Bitcoin Core which can
@@ -158,6 +160,7 @@ func (c *Client) dial(allowHeal bool) error {
 		c.conn.Close()
 		c.conn = nil
 		c.lightning = nil
+		c.state = nil
 		return c.dial(false)
 	}
 	logger.Status("LND gRPC connected, waiting for RPC ready: %v", err)
@@ -224,6 +227,7 @@ func (c *Client) Reconnect() {
 	}
 	c.conn = nil
 	c.lightning = nil
+	c.state = nil
 	c.mu.Unlock()
 
 	if err := c.connect(); err != nil {
@@ -239,6 +243,7 @@ func (c *Client) Close() {
 		c.conn.Close()
 		c.conn = nil
 		c.lightning = nil
+		c.state = nil
 	}
 }
 
@@ -265,4 +270,10 @@ func (c *Client) rpc() lnrpc.LightningClient {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.lightning
+}
+
+func (c *Client) stateRPC() lnrpc.StateClient {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.state
 }

--- a/internal/lndrpc/client_test.go
+++ b/internal/lndrpc/client_test.go
@@ -9,8 +9,21 @@ import (
 	"testing"
 	"time"
 
+	"github.com/lightningnetwork/lnd/lnrpc"
 	"google.golang.org/grpc/metadata"
 )
+
+func TestWalletStateNames(t *testing.T) {
+	for state, want := range map[lnrpc.WalletState]WalletState{
+		lnrpc.WalletState_LOCKED:        WalletStateLocked,
+		lnrpc.WalletState_SERVER_ACTIVE: WalletStateActive,
+		lnrpc.WalletState_UNLOCKED:      "UNLOCKED",
+	} {
+		if got := walletStateName(state); got != want {
+			t.Errorf("walletStateName(%s) = %s, want %s", state, got, want)
+		}
+	}
+}
 
 func TestNodeInfoFields(t *testing.T) {
 	info := &NodeInfo{
@@ -63,6 +76,9 @@ func TestSatStr(t *testing.T) {
 
 func TestNilClientSafety(t *testing.T) {
 	c := &Client{}
+	if _, err := c.GetState(); err == nil {
+		t.Error("should error")
+	}
 	if _, err := c.GetInfo(); err == nil {
 		t.Error("should error")
 	}

--- a/internal/lndrpc/queries.go
+++ b/internal/lndrpc/queries.go
@@ -3,6 +3,7 @@
 package lndrpc
 
 import (
+	"context"
 	"encoding/hex"
 	"fmt"
 	"strconv"
@@ -103,6 +104,16 @@ type OnChainAddress struct {
 	Address string
 }
 
+// WalletState is LND's live readiness state, exposed without leaking the
+// generated protobuf type into the TUI.
+type WalletState string
+
+const (
+	WalletStateUnknown WalletState = "UNKNOWN"
+	WalletStateLocked  WalletState = "LOCKED"
+	WalletStateActive  WalletState = "SERVER_ACTIVE"
+)
+
 type ChannelOpenResult struct {
 	FundingTxID string
 }
@@ -141,6 +152,34 @@ func (c *Client) GetInfo() (*NodeInfo, error) {
 		Version:     resp.GetVersion(),
 		URIs:        resp.GetUris(),
 	}, nil
+}
+
+// GetState uses LND's state service, which remains available while the wallet
+// is locked. This lets status distinguish an intentionally running-but-locked
+// daemon from a stopped daemon or a generic RPC outage.
+func (c *Client) GetState() (WalletState, error) {
+	rpc := c.stateRPC()
+	if rpc == nil {
+		return WalletStateUnknown, errNotConnected
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+	resp, err := rpc.GetState(ctx, &lnrpc.GetStateRequest{})
+	if err != nil {
+		return WalletStateUnknown, err
+	}
+	return walletStateName(resp.GetState()), nil
+}
+
+func walletStateName(state lnrpc.WalletState) WalletState {
+	switch state {
+	case lnrpc.WalletState_LOCKED:
+		return WalletStateLocked
+	case lnrpc.WalletState_SERVER_ACTIVE:
+		return WalletStateActive
+	default:
+		return WalletState(state.String())
+	}
 }
 
 func (c *Client) GetWalletBalance() (*WalletBalance, error) {

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -164,6 +164,11 @@ const (
 	LNDTLSCert        = "/var/lib/lnd/tls.cert"
 	LNDTLSKey         = "/var/lib/lnd/tls.key"
 	LNDWalletPassword = "/var/lib/lnd/wallet_password"
+	// LNDWalletPasswordStage is the one recognizable same-filesystem staging
+	// name used while publishing the canonical password. An interrupted write
+	// can be cleaned deterministically without scanning or guessing at files in
+	// LND's private directory.
+	LNDWalletPasswordStage = "/var/lib/lnd/.vpn-wallet-password.stage"
 )
 
 // LNDMacaroon returns the path to the admin macaroon for a given network.
@@ -199,6 +204,14 @@ const (
 const (
 	BitcoindService     = "/etc/systemd/system/bitcoind.service"
 	LNDService          = "/etc/systemd/system/lnd.service"
+	LNDServiceDropInDir = "/etc/systemd/system/lnd.service.d"
+	// LNDVerificationDropIn disables automatic restart only while VPN is
+	// proving one candidate wallet password. It is persistent (rather than
+	// under /run) so a host reboot cannot reintroduce a password-failure loop
+	// halfway through the operation, and is removed before success is
+	// published.
+	LNDVerificationDropIn = LNDServiceDropInDir +
+		"/90-vpn-auto-unlock-verification.conf"
 	SyncthingService    = "/etc/systemd/system/syncthing.service"
 	BackupWatchPath     = "/etc/systemd/system/lnd-backup-watch.path"
 	BackupExportService = "/etc/systemd/system/lnd-backup-export.service"

--- a/internal/welcome/model.go
+++ b/internal/welcome/model.go
@@ -272,6 +272,7 @@ type statusMsg struct {
 	lndSyncedChain               bool
 	lndSyncedGraph               bool
 	lndResponding                bool
+	lndWalletState               lndrpc.WalletState
 	publicIP                     string
 	channels                     []channelInfo
 	pendingOpen                  int

--- a/internal/welcome/screen_system_auto_unlock.go
+++ b/internal/welcome/screen_system_auto_unlock.go
@@ -9,6 +9,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/virtualprivatenode/vpn/internal/installer"
+	"github.com/virtualprivatenode/vpn/internal/logger"
 	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
@@ -60,8 +61,14 @@ const (
 // Messages emitted by the auto-unlock command runners.
 // Both unique to this screen so they don't collide with
 // any other async flow.
-type autoUnlockSetupDoneMsg struct{ err error }
-type autoUnlockDisableDoneMsg struct{ err error }
+type autoUnlockSetupDoneMsg struct {
+	result installer.AutoUnlockResult
+	err    error
+}
+type autoUnlockDisableDoneMsg struct {
+	result installer.AutoUnlockResult
+	err    error
+}
 
 type AutoUnlockScreen struct {
 	ctx  *ScreenContext
@@ -79,8 +86,8 @@ type AutoUnlockScreen struct {
 	// Inline error string (e.g. "Passwords do not match")
 	errMsg string
 
-	// Final result of installer call (after running)
-	resultErr error
+	// Final classified result of installer call (after running).
+	result installer.AutoUnlockResult
 }
 
 func NewAutoUnlockScreen(
@@ -148,6 +155,37 @@ func (s *AutoUnlockScreen) HandleKey(
 	// Done states
 	if s.state == auState_doneOK ||
 		s.state == auState_doneErr {
+		if s.state == auState_doneOK &&
+			s.result.Outcome == installer.AutoUnlockDisabled {
+			switch keyStr {
+			case "ctrl+c":
+				return s, tea.Quit
+			case "left":
+				if s.btnIdx > 0 {
+					s.btnIdx--
+					return s, nil
+				}
+				return s, emitFocusSidebar
+			case "right":
+				if s.btnIdx < 1 {
+					s.btnIdx++
+				}
+				return s, nil
+			case "enter":
+				if s.btnIdx == 1 {
+					s.resetToEnableForm()
+					return s, s.pw1.Focus()
+				}
+				return s, emitCloseTab
+			case "up", "shift+tab":
+				if s.ctx.HasTabs {
+					return s, emitFocusTabBar
+				}
+			case "backspace":
+				return s, emitFocusParent
+			}
+			return s, nil
+		}
 		switch keyStr {
 		case "ctrl+c":
 			return s, tea.Quit
@@ -367,12 +405,25 @@ func (s *AutoUnlockScreen) tryConfirm() (
 	}
 
 	s.state = auState_running
+	s.errMsg = ""
 	return s, setupAutoUnlockCmd(pw1)
 }
 
 func (s *AutoUnlockScreen) refocusFirstInput() {
 	s.focusZone = auZoneInput1
 	s.pw2.Blur()
+	s.pw1.Focus()
+}
+
+func (s *AutoUnlockScreen) resetToEnableForm() {
+	s.mode = autoUnlockEnable
+	s.state = auState_form
+	s.result = installer.AutoUnlockResult{}
+	s.errMsg = ""
+	s.pw1 = newAutoUnlockPwInput()
+	s.pw2 = newAutoUnlockPwInput()
+	s.focusZone = auZoneInput1
+	s.btnIdx = 1
 	s.pw1.Focus()
 }
 
@@ -384,30 +435,67 @@ func (s *AutoUnlockScreen) HandleMsg(
 	switch m := msg.(type) {
 	case autoUnlockSetupDoneMsg:
 		if m.err != nil {
+			logger.TUI("configure auto-unlock helper: %v", m.err)
 			s.state = auState_doneErr
-			s.resultErr = m.err
+			s.result = installer.AutoUnlockResult{
+				Outcome:    installer.AutoUnlockRepairRequired,
+				FailedStep: "complete privileged operation",
+			}
 			return s, nil
 		}
-		if err := reloadSystemConfig(s.ctx.Cfg); err != nil {
+		s.result = m.result
+		switch m.result.Outcome {
+		case installer.AutoUnlockEnabled:
+			s.ctx.Cfg.AutoUnlock = true
+			s.state = auState_doneOK
+			return s, func() tea.Msg { return refreshStatusMsg{} }
+		case installer.AutoUnlockVerificationFailed:
+			s.state = auState_form
+			s.pw1.SetValue("")
+			s.pw2.SetValue("")
+			s.refocusFirstInput()
+			if m.result.Detail != "" {
+				s.errMsg = m.result.Detail
+			} else {
+				s.errMsg = "VPN could not verify that password. LND is locked. Check the password and try again."
+			}
+			return s, nil
+		case installer.AutoUnlockVerificationTimedOut:
+			s.state = auState_form
+			s.pw1.SetValue("")
+			s.pw2.SetValue("")
+			s.refocusFirstInput()
+			s.errMsg = "LND did not become ready within 120 seconds. VPN could not determine whether the password was correct. LND has been returned to the locked state."
+			return s, nil
+		default:
 			s.state = auState_doneErr
-			s.resultErr = err
 			return s, nil
 		}
-		s.state = auState_doneOK
-		return s, func() tea.Msg { return refreshStatusMsg{} }
 	case autoUnlockDisableDoneMsg:
 		if m.err != nil {
+			logger.TUI("disable auto-unlock helper: %v", m.err)
 			s.state = auState_doneErr
-			s.resultErr = m.err
+			s.result = installer.AutoUnlockResult{
+				Outcome:    installer.AutoUnlockRepairRequired,
+				FailedStep: "complete privileged operation",
+			}
 			return s, nil
 		}
-		if err := reloadSystemConfig(s.ctx.Cfg); err != nil {
+		s.result = m.result
+		switch m.result.Outcome {
+		case installer.AutoUnlockDisabled:
+			s.ctx.Cfg.AutoUnlock = false
+			s.state = auState_doneOK
+			s.btnIdx = 0
+			return s, func() tea.Msg { return refreshStatusMsg{} }
+		case installer.AutoUnlockStillEnabled:
+			s.ctx.Cfg.AutoUnlock = true
+			s.state = auState_doneOK
+			return s, func() tea.Msg { return refreshStatusMsg{} }
+		default:
 			s.state = auState_doneErr
-			s.resultErr = err
 			return s, nil
 		}
-		s.state = auState_doneOK
-		return s, func() tea.Msg { return refreshStatusMsg{} }
 	case tea.PasteMsg:
 		if s.mode != autoUnlockEnable ||
 			s.state != auState_form {
@@ -430,15 +518,15 @@ func (s *AutoUnlockScreen) HandleMsg(
 
 func setupAutoUnlockCmd(password string) tea.Cmd {
 	return func() tea.Msg {
-		err := installer.SetupAutoUnlock(password)
-		return autoUnlockSetupDoneMsg{err: err}
+		result, err := installer.SetupAutoUnlock(password)
+		return autoUnlockSetupDoneMsg{result: result, err: err}
 	}
 }
 
 func disableAutoUnlockCmd() tea.Cmd {
 	return func() tea.Msg {
-		err := installer.DisableAutoUnlock()
-		return autoUnlockDisableDoneMsg{err: err}
+		result, err := installer.DisableAutoUnlock()
+		return autoUnlockDisableDoneMsg{result: result, err: err}
 	}
 }
 
@@ -564,13 +652,12 @@ func (s *AutoUnlockScreen) viewRunning(
 		p.title(theme.Header,
 			"Disabling Auto-Unlock")
 		p.blank()
-		p.dim("Restarting LND...")
+		p.dim("Restarting LND and proving it is locked...")
 	} else {
 		p.title(theme.Header,
 			"Configuring Auto-Unlock")
 		p.blank()
-		p.dim("Writing password file and " +
-			"restarting LND...")
+		p.dim("Restarting LND and verifying the password...")
 	}
 	return p.render()
 }
@@ -581,7 +668,16 @@ func (s *AutoUnlockScreen) viewDone(
 	isFocused := s.ctx.ContentFocused
 	p := newPane(w)
 
-	if s.mode == autoUnlockDisable {
+	if s.result.Outcome == installer.AutoUnlockStillEnabled {
+		p.title(theme.Header,
+			"Auto-Unlock Still Enabled")
+		p.line(" " + theme.Warning.Render(
+			"Disabling auto-unlock failed."))
+		p.line(" " + theme.Good.Render(
+			"The previous enabled state was restored,"))
+		p.line(" " + theme.Good.Render(
+			"and LND is online."))
+	} else if s.mode == autoUnlockDisable {
 		p.title(theme.Header,
 			"Auto-Unlock Disabled")
 		p.line(" " + theme.Good.Render(
@@ -606,8 +702,12 @@ func (s *AutoUnlockScreen) viewDone(
 			"automatically on every reboot."))
 	}
 
+	buttons := []string{"Done"}
+	if s.result.Outcome == installer.AutoUnlockDisabled {
+		buttons = []string{"Done", "Re-enable"}
+	}
 	return p.renderWithBottomButtons(
-		[]string{"Done"}, 0, isFocused, h)
+		buttons, s.btnIdx, isFocused, h)
 }
 
 func (s *AutoUnlockScreen) viewError(
@@ -616,16 +716,12 @@ func (s *AutoUnlockScreen) viewError(
 	isFocused := s.ctx.ContentFocused
 	p := newPane(w)
 
-	if s.mode == autoUnlockDisable {
-		p.title(theme.Header,
-			"Failed to Disable Auto-Unlock")
-	} else {
-		p.title(theme.Header,
-			"Failed to Configure Auto-Unlock")
-	}
+	p.title(theme.Header, "Repair Required")
 	p.blank()
-	if s.resultErr != nil {
-		p.warnWrap(s.resultErr.Error())
+	p.warnWrap("VPN could not prove the auto-unlock state due to a system failure. Do not assume LND is online or that auto-unlock is correctly configured.")
+	if s.result.FailedStep != "" {
+		p.blank()
+		p.warnWrap("Failed step: " + s.result.FailedStep)
 	}
 
 	return p.renderWithBottomButtons(
@@ -640,6 +736,10 @@ func (s *AutoUnlockScreen) HelpBindings() []key.Binding {
 	}
 	if s.state == auState_doneOK ||
 		s.state == auState_doneErr {
+		if s.state == auState_doneOK &&
+			s.result.Outcome == installer.AutoUnlockDisabled {
+			return actionButtonBindings(s.btnIdx, s.ctx.HasTabs)
+		}
 		return resultBindings(s.ctx.HasTabs)
 	}
 

--- a/internal/welcome/screen_system_auto_unlock_test.go
+++ b/internal/welcome/screen_system_auto_unlock_test.go
@@ -1,0 +1,158 @@
+package welcome
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/virtualprivatenode/vpn/internal/config"
+	"github.com/virtualprivatenode/vpn/internal/installer"
+	"github.com/virtualprivatenode/vpn/internal/lndrpc"
+)
+
+func autoUnlockTestContext(enabled bool) *ScreenContext {
+	cfg := config.Default()
+	cfg.AutoUnlock = enabled
+	return &ScreenContext{
+		Cfg:            cfg,
+		State:          &RuntimeState{WalletKnown: true, WalletExists: true},
+		ContentFocused: true,
+	}
+}
+
+func TestAutoUnlockVerificationFailureReturnsToExistingForm(t *testing.T) {
+	s := NewAutoUnlockScreen(autoUnlockTestContext(false))
+	s.pw1.SetValue("not retained")
+	s.pw2.SetValue("not retained")
+	_, _ = s.HandleMsg(autoUnlockSetupDoneMsg{result: installer.AutoUnlockResult{
+		Outcome: installer.AutoUnlockVerificationFailed,
+	}})
+	if s.state != auState_form || s.pw1.Value() != "" || s.pw2.Value() != "" {
+		t.Fatalf("retry form state=%v pw1=%q pw2=%q", s.state, s.pw1.Value(), s.pw2.Value())
+	}
+	view := s.View(82, 34)
+	for _, want := range []string{
+		"Configure Auto-Unlock", "VPN could not verify that password.",
+		"LND is locked.", "Skip", "Confirm",
+	} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("retry view missing %q:\n%s", want, view)
+		}
+	}
+	if strings.Contains(view, "Try Again") || strings.Contains(view, "Leave LND Locked") {
+		t.Fatal("retry flow introduced unapproved replacement buttons")
+	}
+}
+
+func TestAutoUnlockTimeoutCopyIsExplicitAndInconclusive(t *testing.T) {
+	s := NewAutoUnlockScreen(autoUnlockTestContext(false))
+	_, _ = s.HandleMsg(autoUnlockSetupDoneMsg{result: installer.AutoUnlockResult{
+		Outcome: installer.AutoUnlockVerificationTimedOut,
+	}})
+	view := s.View(82, 34)
+	for _, want := range []string{
+		"did not become ready within 120 seconds",
+		"could not determine whether the",
+		"password was correct",
+		"returned to the locked state",
+	} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("timeout view missing %q:\n%s", want, view)
+		}
+	}
+	if strings.Contains(view, "password was accepted") {
+		t.Fatal("timeout copy makes an unproved password claim")
+	}
+}
+
+func TestAutoUnlockRepairRequiredUsesApprovedMessage(t *testing.T) {
+	s := NewAutoUnlockScreen(autoUnlockTestContext(false))
+	_, _ = s.HandleMsg(autoUnlockSetupDoneMsg{result: installer.AutoUnlockResult{
+		Outcome:    installer.AutoUnlockRepairRequired,
+		FailedStep: "restore normal restart policy",
+	}})
+	view := s.View(82, 34)
+	for _, want := range []string{
+		"Repair Required",
+		"VPN could not prove the auto-unlock state due to a system failure.",
+		"Do not assume",
+		"LND is online or that auto-unlock is correctly configured.",
+		"Failed step: restore normal restart policy",
+		"Done",
+	} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("repair view missing %q:\n%s", want, view)
+		}
+	}
+}
+
+func TestAutoUnlockHelperResponseFailureRequiresRepairWithoutRawError(t *testing.T) {
+	s := NewAutoUnlockScreen(autoUnlockTestContext(false))
+	_, _ = s.HandleMsg(autoUnlockSetupDoneMsg{
+		err: errors.New("injected socket detail"),
+	})
+	view := s.View(82, 34)
+	for _, want := range []string{"Repair Required", "Failed step: complete privileged operation"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("helper failure view missing %q:\n%s", want, view)
+		}
+	}
+	if strings.Contains(view, "injected socket detail") {
+		t.Fatal("raw helper error leaked into the user-facing repair message")
+	}
+}
+
+func TestDisableRollbackReportsStillEnabled(t *testing.T) {
+	ctx := autoUnlockTestContext(true)
+	s := NewAutoUnlockScreen(ctx)
+	_, _ = s.HandleMsg(autoUnlockDisableDoneMsg{result: installer.AutoUnlockResult{
+		Outcome: installer.AutoUnlockStillEnabled,
+	}})
+	if !ctx.Cfg.AutoUnlock || s.state != auState_doneOK {
+		t.Fatalf("rollback state cfg=%v screen=%v", ctx.Cfg.AutoUnlock, s.state)
+	}
+	view := s.View(82, 34)
+	for _, want := range []string{
+		"Auto-Unlock Still Enabled", "previous enabled state was restored",
+		"LND is online", "Done",
+	} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("rollback view missing %q:\n%s", want, view)
+		}
+	}
+}
+
+func TestSuccessfulDisableOffersReenableOnSameScreen(t *testing.T) {
+	ctx := autoUnlockTestContext(true)
+	s := NewAutoUnlockScreen(ctx)
+	_, _ = s.HandleMsg(autoUnlockDisableDoneMsg{result: installer.AutoUnlockResult{
+		Outcome: installer.AutoUnlockDisabled,
+	}})
+	view := s.View(82, 34)
+	for _, want := range []string{"Auto-Unlock Disabled", "Done", "Re-enable"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("disabled view missing %q:\n%s", want, view)
+		}
+	}
+	_, _ = s.HandleKey("right", tea.KeyPressMsg{})
+	_, _ = s.HandleKey("enter", tea.KeyPressMsg{})
+	if s.mode != autoUnlockEnable || s.state != auState_form ||
+		s.focusZone != auZoneInput1 {
+		t.Fatalf("re-enable did not return to enable form: mode=%v state=%v focus=%v",
+			s.mode, s.state, s.focusZone)
+	}
+}
+
+func TestSystemServiceRowShowsLockedLND(t *testing.T) {
+	ctx := autoUnlockTestContext(false)
+	ctx.Status = &statusMsg{
+		services:       map[string]bool{"lnd": true},
+		lndWalletState: lndrpc.WalletStateLocked,
+	}
+	view := NewSystemHomeScreen(ctx).View(82, 34)
+	if !strings.Contains(view, "lnd") || !strings.Contains(view, "locked") {
+		t.Fatalf("LND service row does not expose locked state:\n%s", view)
+	}
+}

--- a/internal/welcome/screen_system_home.go
+++ b/internal/welcome/screen_system_home.go
@@ -12,6 +12,7 @@ import (
 	"github.com/virtualprivatenode/vpn/internal/bitcoin"
 	"github.com/virtualprivatenode/vpn/internal/helper"
 	"github.com/virtualprivatenode/vpn/internal/installer"
+	"github.com/virtualprivatenode/vpn/internal/lndrpc"
 	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
@@ -412,6 +413,10 @@ func (s *SystemHomeScreen) View(
 
 		svcLine := prefix + " " + dot + " " +
 			style.Render(name)
+		if name == "lnd" && status != nil &&
+			status.lndWalletState == lndrpc.WalletStateLocked {
+			svcLine += "  " + theme.Warning.Render("locked")
+		}
 
 		if isSelected && s.svcPending != "" {
 			svcLine += "  " +

--- a/internal/welcome/status.go
+++ b/internal/welcome/status.go
@@ -89,6 +89,17 @@ func fetchStatus(
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
+				walletState, err := lndClient.GetState()
+				if err == nil {
+					mu.Lock()
+					s.lndWalletState = walletState
+					mu.Unlock()
+				}
+			}()
+
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
 				lndInfo, err := lndClient.GetInfo()
 				mu.Lock()
 				if err == nil {


### PR DESCRIPTION
## Summary

- Verify the supplied wallet password through a controlled LND restart before enabling auto-unlock.
- Prevent wrong-password restart loops using a temporary `Restart=no` systemd drop-in.
- Require a new LND invocation, the exact password-file process flag, `SERVER_ACTIVE`, and authenticated `GetInfo`.
- Return wrong-password failures to a stable locked state without publishing auto-unlock as enabled.
- Support verified disable and re-enable transitions.
- Destroy and verify removal of the stored password when disabling.
- Surface locked LND state and classified failure results in the TUI.

## Why

The previous flow confirmed only that both password fields matched. It could install an incorrect password, restart LND into a failure loop, and publish auto-unlock as enabled without proving the wallet was usable.

This change reports success only after the restarted wallet is fully active and authenticated RPC succeeds.

## Security and recovery behavior

- The canonical password remains `/var/lib/lnd/wallet_password` as `lnd:lnd 0400`.
- Passwords are not exposed through command arguments, logs, helper results, or test evidence.
- Wrong-password attempts leave LND stably locked with no restart loop.
- Readiness timeouts are reported as inconclusive rather than incorrectly labeled as wrong passwords.
- Ambiguous or failed recovery produces an explicit Repair Required result.
- Successful disablement requires confirmed password-file removal.
- No generic transaction framework or permanent transition marker was added.

## Validation

Passed on the exact committed candidate:

- `go mod verify`
- `go mod tidy -diff`
- `go test -count=1 ./...`
- `go test -race -count=1 ./...`
- `go vet ./...`
- formatting, build, and diff checks
- required-root installer tests on Debian 13 amd64 with none skipped
- clean unattended 29-step `testnet4` installation
- real TUI wallet creation
- wrong-password rollback with `NRestarts=0`
- correct-password enablement
- ordinary LND restart
- disable with verified password destruction
- same-screen re-enable
- full host reboot and automatic wallet unlock
- post-reboot `SERVER_ACTIVE` and authenticated `GetInfo`
- daemon-permission validation before wallet creation and after reboot

## Scope

This PR is limited to LND auto-unlock correctness and its directly coupled tests, root-helper interface, status handling, and documentation.